### PR TITLE
6 standardize id types to number

### DIFF
--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/children-profiles/[childId]/edit/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/children-profiles/[childId]/edit/page.tsx
@@ -5,8 +5,14 @@ import { AuthContext } from "@/app/admins/(authenticated)/authContext";
 import EditChildProfile from "@/app/components/customers-dashboard/children-profiles/EditChildProfile";
 
 function Page({ params }: { params: { customerId: string; childId: string } }) {
-  const customerId = params.customerId;
-  const childId = params.childId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
+  const childId = parseInt(params.childId);
+  if (isNaN(childId)) {
+    throw new Error("Invalid childId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/children-profiles/add-child/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/children-profiles/add-child/page.tsx
@@ -5,7 +5,10 @@ import { AuthContext } from "@/app/admins/(authenticated)/authContext";
 import AddChildForm from "@/app/components/customers-dashboard/children-profiles/AddChildForm";
 
 function Page({ params }: { params: { customerId: string; childId: string } }) {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/page.tsx
@@ -9,7 +9,10 @@ const ClassDetailPage = ({
 }: {
   params: { customerId: string; classId: string };
 }) => {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const classId = parseInt(params.classId);
 
   // Check the authentication of the admin.

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/page.tsx
@@ -14,6 +14,9 @@ const ClassDetailPage = ({
     throw new Error("Invalid customerId");
   }
   const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/reschedule/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/reschedule/page.tsx
@@ -9,7 +9,10 @@ function Page({ params }: { params: { customerId: string; classId: string } }) {
   if (isNaN(customerId)) {
     throw new Error("Invalid customerId");
   }
-  const classId = params.classId;
+  const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/reschedule/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/[classId]/reschedule/page.tsx
@@ -5,7 +5,10 @@ import { AuthContext } from "@/app/admins/(authenticated)/authContext";
 import RescheduleClass from "@/app/components/customers-dashboard/classes/RescheduleClass";
 
 function Page({ params }: { params: { customerId: string; classId: string } }) {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const classId = params.classId;
 
   // Check the authentication of the admin.

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/book/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/classes/book/page.tsx
@@ -5,7 +5,10 @@ import { AuthContext } from "@/app/admins/(authenticated)/authContext";
 import BookClass from "@/app/components/customers-dashboard/classes/BookClass";
 
 function Page({ params }: { params: { customerId: string } }) {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/page.tsx
@@ -11,7 +11,10 @@ import { useTabSelect } from "@/app/hooks/useTabSelect";
 import Loading from "@/app/components/Loading";
 
 function Page({ params }: { params: { customerId: string } }) {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const breadcrumb = [
     "Customer List",
     `/admins/customer-list`,

--- a/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/regular-classes/edit/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/[customerId]/regular-classes/edit/page.tsx
@@ -5,7 +5,10 @@ import { AuthContext } from "@/app/admins/(authenticated)/authContext";
 import EditRegularClass from "@/app/components/customers-dashboard/regular-classes/EditRegularClass";
 
 function Page({ params }: { params: { customerId: string } }) {
-  const customerId = params.customerId;
+  const customerId = parseInt(params.customerId);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/instructor-list/[instructorId]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/instructor-list/[instructorId]/class-schedule/[classId]/page.tsx
@@ -11,6 +11,9 @@ const Page = ({
 }) => {
   const instructorId = parseInt(params.instructorId);
   const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
 
   // Check the authentication of the admin.
   const { isAuthenticated } = useContext(AuthContext);

--- a/frontend/src/app/admins/(authenticated)/instructor-list/[instructorId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/instructor-list/[instructorId]/page.tsx
@@ -11,7 +11,10 @@ import InstructorSchedule from "./InstructorSchedule";
 import Loading from "@/app/components/Loading";
 
 function Page({ params }: { params: { instructorId: string } }) {
-  const instructorId = params.instructorId;
+  const instructorId = parseInt(params.instructorId);
+  if (isNaN(instructorId)) {
+    throw new Error("Invalid instructorId");
+  }
   const breadcrumb = [
     "Instructor List",
     `/admins/instructor-list`,
@@ -33,7 +36,7 @@ function Page({ params }: { params: { instructorId: string } }) {
       label: "Class Schedule",
       content: (
         <InstructorCalendar
-          id={parseInt(instructorId)}
+          id={instructorId}
           isAdminAuthenticated={isAuthenticated}
         />
       ),
@@ -49,11 +52,11 @@ function Page({ params }: { params: { instructorId: string } }) {
     },
     {
       label: "Instructor's Availability",
-      content: <AvailabilityCalendar instructorId={parseInt(instructorId)} />,
+      content: <AvailabilityCalendar instructorId={instructorId} />,
     },
     {
       label: "Instructor's Schedule",
-      content: <InstructorSchedule instructorId={parseInt(instructorId)} />,
+      content: <InstructorSchedule instructorId={instructorId} />,
     },
   ];
 

--- a/frontend/src/app/components/CalendarView.tsx
+++ b/frontend/src/app/components/CalendarView.tsx
@@ -63,9 +63,7 @@ const CalendarView: React.FC<InstructorCalendarViewProps> = ({
     if (!customerId) return;
 
     try {
-      const classes: ClassType[] = await getClassesByCustomerId(
-        customerId.toString(),
-      );
+      const classes: ClassType[] = await getClassesByCustomerId(customerId);
       setClasses(classes);
     } catch (error) {
       console.error("Failed to fetch classes:", error);
@@ -287,7 +285,7 @@ const CalendarView: React.FC<InstructorCalendarViewProps> = ({
           {customerId ? (
             <ClassDetail
               classDetail={classDetail}
-              customerId={customerId.toString()}
+              customerId={customerId}
               timeZone="Asia/Tokyo"
               handleCancel={handleCancel}
               isAdminAuthenticated

--- a/frontend/src/app/components/ClassDetail.tsx
+++ b/frontend/src/app/components/ClassDetail.tsx
@@ -31,7 +31,7 @@ const ClassDetail = ({
   isAdminAuthenticated, // Necessary when implimenting the Rescheduling functionality
   handleModalClose,
 }: {
-  customerId: string;
+  customerId: number;
   classDetail: ClassType | null;
   timeZone: string;
   handleCancel: (classId: number, classDateTime: string) => void;

--- a/frontend/src/app/components/ClassesTable.tsx
+++ b/frontend/src/app/components/ClassesTable.tsx
@@ -24,7 +24,7 @@ const ClassesTable = ({
   timeZone: string;
   selectedClasses: { classId: number; classDateTime: string }[];
   toggleSelectClass: (classId: number, classDateTime: string) => void;
-  userId: string;
+  userId: number;
   handleBulkCancel: () => void;
   isAdminAuthenticated?: boolean;
   handleCancelingModalClose: () => void;

--- a/frontend/src/app/components/customers-dashboard/children-profiles/AddChildForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/AddChildForm.tsx
@@ -20,7 +20,7 @@ function AddChildForm({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [childName, onChildNameChange] = useInput();

--- a/frontend/src/app/components/customers-dashboard/children-profiles/ChildrenProfiles.tsx
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/ChildrenProfiles.tsx
@@ -22,7 +22,7 @@ function ChildrenProfiles({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [children, setChildren] = useState<Child[] | undefined>([]);

--- a/frontend/src/app/components/customers-dashboard/children-profiles/EditChildForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/EditChildForm.tsx
@@ -19,7 +19,7 @@ function EditChildForm({
   child,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   child: Child;
   isAdminAuthenticated?: boolean;
 }) {

--- a/frontend/src/app/components/customers-dashboard/children-profiles/EditChildProfile.tsx
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/EditChildProfile.tsx
@@ -9,14 +9,14 @@ function EditChildProfile({
   childId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
-  childId: string;
+  customerId: number;
+  childId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [child, setChild] = useState<Child | null>(null);
 
   useEffect(() => {
-    const fetchChildById = async (id: string) => {
+    const fetchChildById = async (id: number) => {
       try {
         const child = await getChildById(id);
         setChild(child);

--- a/frontend/src/app/components/customers-dashboard/classes/BookClass.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/BookClass.tsx
@@ -11,7 +11,7 @@ function BookClass({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [instructors, setInstructors] = useState<Instructor[] | undefined>(
@@ -36,7 +36,7 @@ function BookClass({
   }, []);
 
   useEffect(() => {
-    const fetchChildrenByCustomerId = async (customerId: string) => {
+    const fetchChildrenByCustomerId = async (customerId: number) => {
       try {
         const children = await getChildrenByCustomerId(customerId);
         setChildren(children);
@@ -49,7 +49,7 @@ function BookClass({
   }, [customerId]);
 
   useEffect(() => {
-    const fetchRebookableClassesByCustomerId = async (customerId: string) => {
+    const fetchRebookableClassesByCustomerId = async (customerId: number) => {
       try {
         const classes: ClassType[] = await getClassesByCustomerId(customerId);
         const rebookableClasses = classes.filter((eachClass) => {

--- a/frontend/src/app/components/customers-dashboard/classes/BookClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/BookClassForm.tsx
@@ -21,7 +21,7 @@ function BookClassForm({
   classToRebook,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   instructors: Instructor[];
   children: Child[];
   classToRebook: ClassType | undefined;
@@ -112,7 +112,7 @@ function BookClassForm({
 
       // Check if there is already a booked class for this customer at the same time
       const classDoubleBookingResult = await checkDoubleBooking(
-        parseInt(customerId),
+        customerId,
         selectedDateTime,
       );
 
@@ -131,7 +131,7 @@ function BookClassForm({
         classId: classToRebook.id,
         dateTime: selectedDateTime,
         instructorId: selectedInstructorId,
-        customerId: parseInt(customerId),
+        customerId,
         status: "booked",
         childrenIds: selectedChildrenIdsArray,
         recurringClassId: classToRebook.recurringClassId,

--- a/frontend/src/app/components/customers-dashboard/classes/ClassCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/ClassCalendar.tsx
@@ -20,7 +20,7 @@ function ClassCalendar({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [classesForCalendar, setClassesForCalendar] = useState<EventType[]>([]);
@@ -40,7 +40,7 @@ function ClassCalendar({
   const fetchData = useCallback(async () => {
     try {
       const classesData: ClassForCalendar[] = await fetchClassesForCalendar(
-        parseInt(customerId),
+        customerId,
         "customer",
       );
 
@@ -234,7 +234,7 @@ function ClassCalendar({
             events={classesForCalendar}
             // TODO: Fetch holidays from the backend
             // holidays={["2024-07-29", "2024-07-30", "2024-07-31"]}
-            customerId={parseInt(customerId)}
+            customerId={customerId}
             isAdminAuthenticated={isAdminAuthenticated}
             fetchData={fetchData}
           />

--- a/frontend/src/app/components/customers-dashboard/classes/ClassDetails.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/ClassDetails.tsx
@@ -14,7 +14,7 @@ function ClassDetails({
   classId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   classId: number;
   isAdminAuthenticated?: boolean;
 }) {

--- a/frontend/src/app/components/customers-dashboard/classes/EditClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/EditClassForm.tsx
@@ -14,7 +14,7 @@ function EditClassForm({
   editedClass,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   instructors: Instructor[];
   children: Child[];
   editedClass: ClassType;

--- a/frontend/src/app/components/customers-dashboard/classes/RescheduleClass.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/RescheduleClass.tsx
@@ -10,7 +10,7 @@ function RescheduleClass({
   isAdminAuthenticated,
 }: {
   customerId: number;
-  classId: string;
+  classId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [editedClass, setEditedClass] = useState<ClassType | null>(null);
@@ -44,7 +44,7 @@ function RescheduleClass({
   }, [customerId]);
 
   useEffect(() => {
-    const fetchClassById = async (id: string) => {
+    const fetchClassById = async (id: number) => {
       try {
         const editedClass = await getClassById(id);
         setEditedClass(editedClass);

--- a/frontend/src/app/components/customers-dashboard/classes/RescheduleClass.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/RescheduleClass.tsx
@@ -9,7 +9,7 @@ function RescheduleClass({
   classId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   classId: string;
   isAdminAuthenticated?: boolean;
 }) {
@@ -31,7 +31,7 @@ function RescheduleClass({
   }, []);
 
   useEffect(() => {
-    const fetchChildrenByCustomerId = async (customerId: string) => {
+    const fetchChildrenByCustomerId = async (customerId: number) => {
       try {
         const children = await getChildrenByCustomerId(customerId);
         setChildren(children);

--- a/frontend/src/app/components/customers-dashboard/profile/CustomerProfile.tsx
+++ b/frontend/src/app/components/customers-dashboard/profile/CustomerProfile.tsx
@@ -3,11 +3,7 @@
 import styles from "./CustomerProfile.module.scss";
 import { useEffect, useState } from "react";
 import { getCustomerById, editCustomer } from "@/app/helper/customersApi";
-import {
-  UserCircleIcon,
-  EnvelopeIcon,
-  HomeIcon,
-} from "@heroicons/react/24/solid";
+import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { prefectures } from "@/app/helper/data";
 import ActionButton from "../../ActionButton";
 import { CheckIcon } from "@heroicons/react/24/outline";
@@ -15,7 +11,7 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Loading from "../../Loading";
 
-function CustomerProfile({ customerId }: { customerId: string }) {
+function CustomerProfile({ customerId }: { customerId: number }) {
   const [customer, setCustomer] = useState<Customer | undefined>();
   const [latestCustomerData, setLatestCustomerData] = useState<
     Customer | undefined

--- a/frontend/src/app/components/customers-dashboard/regular-classes/AddSubscription.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/AddSubscription.tsx
@@ -14,7 +14,7 @@ function AddSubscription({
   onClose,
   updateSubscription,
 }: {
-  customerId: string;
+  customerId: number;
   isOpen: boolean;
   onClose: () => void;
   updateSubscription: () => void;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/CurrentSubscription.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/CurrentSubscription.tsx
@@ -11,7 +11,7 @@ function CurrentSubscription({
 }: {
   subscriptionsData?: Subscriptions | null;
   isAdminAuthenticated?: boolean | null;
-  customerId: string;
+  customerId: number;
 }) {
   return (
     <div className={styles.outsideContainer}>

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClass.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClass.tsx
@@ -12,7 +12,7 @@ function EditRegularClass({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const searchParams = useSearchParams();

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -21,7 +21,7 @@ function EditRegularClassForm({
   subscriptionId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   subscriptionId?: number | null;
   isAdminAuthenticated?: boolean;
 }) {
@@ -41,7 +41,7 @@ function EditRegularClassForm({
       }
     };
 
-    const fetchChildrenByCustomerId = async (customerId: string) => {
+    const fetchChildrenByCustomerId = async (customerId: number) => {
       try {
         const data = await getChildrenByCustomerId(customerId);
         setChildren(data);

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClasses.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClasses.tsx
@@ -13,7 +13,7 @@ function RegularClasses({
   customerId,
   isAdminAuthenticated,
 }: {
-  customerId: string;
+  customerId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [subscriptionsData, setSubscriptionsData] =

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -15,7 +15,7 @@ function RegularClassesTable({
 }: {
   subscriptionId: number;
   isAdminAuthenticated?: boolean | null;
-  customerId: string;
+  customerId: number;
 }) {
   const [currRecurringClasses, setCurrRecurringClasses] = useState<
     RecurringClass[]

--- a/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -17,15 +17,15 @@ function InstructorProfile({
   instructorId,
   isAdminAuthenticated,
 }: {
-  instructorId: string;
+  instructorId: number;
   isAdminAuthenticated?: boolean;
 }) {
   const [instructor, setInstructor] = useState<Instructor | null>(null);
 
   useEffect(() => {
-    const fetchInstructorById = async (instructorId: string) => {
+    const fetchInstructorById = async (instructorId: number) => {
       try {
-        const id = parseInt(instructorId);
+        const id = instructorId;
         const response = await getInstructor(id);
         if ("message" in response) {
           alert(response.message);

--- a/frontend/src/app/customers/[id]/children-profiles/[childId]/edit/page.tsx
+++ b/frontend/src/app/customers/[id]/children-profiles/[childId]/edit/page.tsx
@@ -3,8 +3,14 @@
 import EditChildProfile from "@/app/components/customers-dashboard/children-profiles/EditChildProfile";
 
 function Page({ params }: { params: { id: string; childId: string } }) {
-  const customerId = params.id;
-  const childId = params.childId;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
+  const childId = parseInt(params.childId);
+  if (isNaN(childId)) {
+    throw new Error("Invalid childId");
+  }
 
   return (
     <>

--- a/frontend/src/app/customers/[id]/children-profiles/add-child/page.tsx
+++ b/frontend/src/app/customers/[id]/children-profiles/add-child/page.tsx
@@ -5,7 +5,10 @@ import styles from "./page.module.scss";
 import Link from "next/link";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   return (
     <>

--- a/frontend/src/app/customers/[id]/children-profiles/page.tsx
+++ b/frontend/src/app/customers/[id]/children-profiles/page.tsx
@@ -4,7 +4,10 @@ import ChildrenProfiles from "@/app/components/customers-dashboard/children-prof
 import styles from "./page.module.scss";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   return (
     <>

--- a/frontend/src/app/customers/[id]/classes/[classId]/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/[classId]/page.tsx
@@ -15,8 +15,14 @@ const ClassDetailPage = ({
 }: {
   params: { id: string; classId: string };
 }) => {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
   const [classDetail, setClassDetail] = useState<ClassType | null>(null);
   const [classes, setClasses] = useState<ClassType[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -26,7 +32,7 @@ const ClassDetailPage = ({
   >([]);
 
   const fetchClassDetails = useCallback(async () => {
-    if (!customerId || isNaN(classId)) return;
+    if (!customerId) return;
 
     try {
       const classes: ClassType[] = await getClassesByCustomerId(customerId);

--- a/frontend/src/app/customers/[id]/classes/[classId]/reschedule/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/[classId]/reschedule/page.tsx
@@ -7,7 +7,10 @@ function Page({ params }: { params: { id: string; classId: string } }) {
   if (isNaN(customerId)) {
     throw new Error("Invalid customerId");
   }
-  const classId = params.classId;
+  const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
 
   return <RescheduleClass customerId={customerId} classId={classId} />;
 }

--- a/frontend/src/app/customers/[id]/classes/[classId]/reschedule/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/[classId]/reschedule/page.tsx
@@ -3,7 +3,10 @@
 import RescheduleClass from "@/app/components/customers-dashboard/classes/RescheduleClass";
 
 function Page({ params }: { params: { id: string; classId: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const classId = params.classId;
 
   return <RescheduleClass customerId={customerId} classId={classId} />;

--- a/frontend/src/app/customers/[id]/classes/book/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/book/page.tsx
@@ -3,7 +3,10 @@
 import BookClass from "@/app/components/customers-dashboard/classes/BookClass";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   return <BookClass customerId={customerId} />;
 }

--- a/frontend/src/app/customers/[id]/classes/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/page.tsx
@@ -3,7 +3,11 @@
 import ClassCalendar from "@/app/components/customers-dashboard/classes/ClassCalendar";
 
 const Page = ({ params }: { params: { id: string } }) => {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
+
   return <ClassCalendar customerId={customerId} />;
 };
 

--- a/frontend/src/app/customers/[id]/layout.tsx
+++ b/frontend/src/app/customers/[id]/layout.tsx
@@ -31,7 +31,10 @@ export default function Layout({
 }) {
   const [customerName, setCustomerName] = useState<string | null>(null);
   const router = useRouter();
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   // Check the authentication of the customer.
   // const { isLoading } = CustomerAuthentication(customerId);

--- a/frontend/src/app/customers/[id]/profile/page.tsx
+++ b/frontend/src/app/customers/[id]/profile/page.tsx
@@ -2,7 +2,10 @@ import CustomerProfile from "@/app/components/customers-dashboard/profile/Custom
 import styles from "./page.module.scss";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
 
   return (
     <>

--- a/frontend/src/app/customers/[id]/regular-classes/edit/page.tsx
+++ b/frontend/src/app/customers/[id]/regular-classes/edit/page.tsx
@@ -5,7 +5,11 @@ import InstructorsSchedule from "@/app/components/customers-dashboard/regular-cl
 import styles from "./page.module.scss";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
+
   return (
     <div>
       <div className={styles.header}>Editing Regular Classes</div>

--- a/frontend/src/app/customers/[id]/regular-classes/page.tsx
+++ b/frontend/src/app/customers/[id]/regular-classes/page.tsx
@@ -8,7 +8,10 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 function Page({ params }: { params: { id: string } }) {
-  const customerId = params.id;
+  const customerId = parseInt(params.id);
+  if (isNaN(customerId)) {
+    throw new Error("Invalid customerId");
+  }
   const searchParams = useSearchParams();
 
   useEffect(() => {

--- a/frontend/src/app/helper/childrenApi.ts
+++ b/frontend/src/app/helper/childrenApi.ts
@@ -2,7 +2,7 @@ const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
 // GET children data by customer id
-export const getChildrenByCustomerId = async (customerId: string) => {
+export const getChildrenByCustomerId = async (customerId: number) => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/children?customerId=${customerId}`,
@@ -19,7 +19,7 @@ export const getChildrenByCustomerId = async (customerId: string) => {
 };
 
 // GET a child data by the child's id
-export const getChildById = async (id: string) => {
+export const getChildById = async (id: number) => {
   try {
     const response = await fetch(`${BACKEND_ORIGIN}/children/${id}`);
     if (!response.ok) {
@@ -38,7 +38,7 @@ export const addChild = async (
   childName: string,
   childBirthdate: string,
   childPersonalInfo: string,
-  customerId: string,
+  customerId: number,
 ) => {
   // Define the data to be sent to the server side.
   const childrenURL = `${BACKEND_ORIGIN}/children`;
@@ -47,7 +47,7 @@ export const addChild = async (
     name: childName,
     birthdate: childBirthdate,
     personalInfo: childPersonalInfo,
-    customerId: Number(customerId),
+    customerId,
   });
 
   const response = await fetch(childrenURL, {
@@ -69,16 +69,16 @@ export const addChild = async (
 export const editChild = async (
   childId: number,
   childName: string,
-  childBirthedate: string,
+  childBirthdate: string,
   childInfo: string,
-  customerId: string,
+  customerId: number,
 ) => {
   // Define the data to be sent to the server side.
   const childrenURL = `${BACKEND_ORIGIN}/children/${childId}`;
   const headers = { "Content-Type": "application/json" };
   const body = JSON.stringify({
     name: childName,
-    birthdate: childBirthedate,
+    birthdate: childBirthdate,
     personalInfo: childInfo,
     customerId: Number(customerId),
   });

--- a/frontend/src/app/helper/classesApi.ts
+++ b/frontend/src/app/helper/classesApi.ts
@@ -2,7 +2,7 @@ const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
 // GET classes by customer id
-export const getClassesByCustomerId = async (customerId: string) => {
+export const getClassesByCustomerId = async (customerId: number) => {
   try {
     const response = await fetch(`${BACKEND_ORIGIN}/classes/${customerId}`);
     if (!response.ok) {

--- a/frontend/src/app/helper/classesApi.ts
+++ b/frontend/src/app/helper/classesApi.ts
@@ -75,7 +75,7 @@ export const bookClass = async (classData: {
 };
 
 // GET a class by id
-export const getClassById = async (classId: string) => {
+export const getClassById = async (classId: number) => {
   try {
     const response = await fetch(`${BACKEND_ORIGIN}/classes/class/${classId}`);
     if (!response.ok) {

--- a/frontend/src/app/helper/customersApi.ts
+++ b/frontend/src/app/helper/customersApi.ts
@@ -19,7 +19,7 @@ export const getCustomerById = async (customerId: number) => {
 
 // PATCH customer data
 export const editCustomer = async (
-  customerId: string,
+  customerId: number,
   customerName: string,
   customerEmail: string,
   customerPrefecture: string,

--- a/frontend/src/app/helper/customersApi.ts
+++ b/frontend/src/app/helper/customersApi.ts
@@ -1,7 +1,7 @@
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
-export const getCustomerById = async (customerId: string) => {
+export const getCustomerById = async (customerId: number) => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/customers/${customerId}/customer`,

--- a/frontend/src/app/helper/subscriptionsApi.ts
+++ b/frontend/src/app/helper/subscriptionsApi.ts
@@ -2,7 +2,7 @@ const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
 // GET subscriptions by a customer id
-export const getSubscriptionsByCustomerId = async (customerId: string) => {
+export const getSubscriptionsByCustomerId = async (customerId: number) => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/customers/${customerId}/subscriptions`,
@@ -21,7 +21,7 @@ export const getSubscriptionsByCustomerId = async (customerId: string) => {
 
 // Register a subscription
 export const registerSubscription = async (
-  customerId: string,
+  customerId: number,
   subscriptionData: RegisterSubscription,
 ) => {
   try {

--- a/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
@@ -5,6 +5,9 @@ import ClassDetails from "@/app/components/instructors-dashboard/class-schedule/
 const Page = ({ params }: { params: { id: string; classId: string } }) => {
   const instructorId = parseInt(params.id);
   const classId = parseInt(params.classId);
+  if (isNaN(classId)) {
+    throw new Error("Invalid classId");
+  }
 
   return <ClassDetails instructorId={instructorId} classId={classId} />;
 };

--- a/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
@@ -4,6 +4,9 @@ import ClassDetails from "@/app/components/instructors-dashboard/class-schedule/
 
 const Page = ({ params }: { params: { id: string; classId: string } }) => {
   const instructorId = parseInt(params.id);
+  if (isNaN(instructorId)) {
+    throw new Error("Invalid instructorId");
+  }
   const classId = parseInt(params.classId);
   if (isNaN(classId)) {
     throw new Error("Invalid classId");

--- a/frontend/src/app/instructors/[id]/layout.tsx
+++ b/frontend/src/app/instructors/[id]/layout.tsx
@@ -26,7 +26,10 @@ export default function Layout({
 }) {
   const [instructorName, setInstructorName] = useState<string | null>(null);
   const router = useRouter();
-  const instructorId = params.id;
+  const instructorId = parseInt(params.id);
+  if (isNaN(instructorId)) {
+    throw new Error("Invalid instructorId");
+  }
 
   // Check the authentication of the instructor.
   // const { isLoading } = InstructorAuthentication(instructorId);
@@ -52,7 +55,7 @@ export default function Layout({
   // TODO: Get the instructor name from the session?
   useEffect(() => {
     const fetchInstructor = async () => {
-      const response = await getInstructor(parseInt(instructorId));
+      const response = await getInstructor(instructorId);
       if ("instructor" in response) {
         setInstructorName(response.instructor.nickname);
       } else {

--- a/frontend/src/app/instructors/[id]/profile/page.tsx
+++ b/frontend/src/app/instructors/[id]/profile/page.tsx
@@ -3,7 +3,10 @@
 import InstructorProfile from "@/app/components/instructors-dashboard/instructor-profile/InstructorProfile";
 
 const Page = ({ params }: { params: { id: string } }) => {
-  const instructorId = params.id;
+  const instructorId = parseInt(params.id);
+  if (isNaN(instructorId)) {
+    throw new Error("Invalid instructorId");
+  }
 
   return <InstructorProfile instructorId={instructorId} />;
 };


### PR DESCRIPTION
### Overview
Standardized the types of `customerId`, `childId`, `instructorId` and `classId` to `number` in the frontend.

### Review Points
Since no logic is involved, it's fine to approve the PR directly.
Although I did my best to standardize all the IDs, if anyone notices during development from now on that an ID type isn't set to `number`, please correct it each time using the following format:

```
const id = parseInt(params.id);
  if (isNaN(id)) {
    throw new Error("Invalid id");
  }
```
Thank you!