### PR TITLE
Feature/1 make a validation for recurring classes

### DIFF
--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -152,13 +152,19 @@ export const updateRecurringClassesController = async (
   }
 
   // If classStartDate is shorter than today, it shouldn't be executed.
-  // This validation is commented out as of now.
-  // TODO: Japan time should be converted to local time.
-  const today = new Date();
-  const jpnToday = new Date(today.getTime() + JAPAN_TIME_DIFF * 60 * 60 * 1000);
-  // if (new Date(classStartDate) <= jpnToday) {
-  //   return res.status(400).json({ message: "Invalid Start From Date" });
-  // }
+  const now = new Date();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const todayStr = now.toLocaleDateString("en-US", {
+    timeZone,
+  });
+
+  const [month, date, year] = todayStr.split("/").map(Number);
+  const today = new Date(year, month - 1, date);
+
+  if (new Date(classStartDate) <= today) {
+    return res.status(400).json({ message: "Invalid Start From Date" });
+  }
 
   try {
     const updatedRecurringClasses = await prisma.$transaction(async (tx) => {

--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -155,12 +155,6 @@ export const updateRecurringClassesController = async (
   const jstTodayStr = new Date().toLocaleDateString("en-CA", {
     timeZone: "Asia/Tokyo",
   });
-
-  // Convert the local class start date to UTC time.
-  const localClassStartDateTime = classStartDate + "T00:00:00"; // In the new Date object, the time will change based on the local date.
-  const utcClassStartDate =
-    new Date(localClassStartDateTime).toISOString().split("T")[0] +
-    "T00:00:00.000Z"; // In the new Date object, the time will remain unchanged at 00:00.
   const utcToday = new Date();
 
   // Compare the local classStart date and Japan today.
@@ -207,14 +201,14 @@ export const updateRecurringClassesController = async (
       const { endAt, startAt } = recurringClass;
 
       const firstClassDate = calculateFirstDate(
-        new Date(utcClassStartDate),
+        new Date(classStartDate),
         utcDay,
         utcTime,
       );
 
       let dateTimes: Date[] = [];
       const newStartAt = calculateFirstDate(
-        new Date(utcClassStartDate),
+        new Date(classStartDate),
         utcDay,
         utcTime,
       );
@@ -232,9 +226,9 @@ export const updateRecurringClassesController = async (
       // -> All upcoming classes are deleted and recreated new recurring ones until the end of the next two months.
 
       const condition1 =
-        endAt !== null && new Date(endAt) <= new Date(utcClassStartDate);
+        endAt !== null && new Date(endAt) <= new Date(classStartDate);
       const condition2 =
-        endAt !== null && new Date(utcClassStartDate) < new Date(endAt);
+        endAt !== null && new Date(classStartDate) < new Date(endAt);
       const condition3 = endAt === null;
 
       // Condition1
@@ -243,12 +237,12 @@ export const updateRecurringClassesController = async (
       }
 
       // Terminate the current recurring class.
-      await terminateRecurringClass(tx, req.id, new Date(utcClassStartDate));
+      await terminateRecurringClass(tx, req.id, new Date(classStartDate));
 
       // Delete unnecessary future recurring class.
       if (
         startAt === null ||
-        (startAt !== null && new Date(utcClassStartDate) < new Date(startAt))
+        (startAt !== null && new Date(classStartDate) < new Date(startAt))
       ) {
         await deleteRecurringClass(tx, req.id);
       }

--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -151,9 +151,8 @@ export const updateRecurringClassesController = async (
     return res.status(400).json({ message: "Invalid parameters provided." });
   }
 
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const localTodayStr = new Date().toLocaleDateString("en-CA", {
-    timeZone,
+  const jstTodayStr = new Date().toLocaleDateString("en-CA", {
+    timeZone: "Asia/Tokyo",
   });
 
   // Convert the local class start date to UTC time.
@@ -165,7 +164,7 @@ export const updateRecurringClassesController = async (
 
   // Compare the local classStart date and local today.
   // If classStartDate is equal to or shorter than today, it shouldn't be executed.
-  if (classStartDate <= localTodayStr) {
+  if (classStartDate <= jstTodayStr) {
     return res.status(400).json({ message: "Invalid Start From Date" });
   }
 
@@ -179,19 +178,33 @@ export const updateRecurringClassesController = async (
         tx,
         utcToday,
       );
-      allValidRecurringClasses.find((recurringClass) => {
+      // allValidRecurringClasses.find((recurringClass) => {
+      //   const recurringClassDay = recurringClass.startAt?.getDay();
+      //   const recurringClassTime = formatTime(recurringClass.startAt as Date);
+      //   if (
+      //     recurringClass.instructorId === instructorId &&
+      //     recurringClassDay === getDayNumber(utcDay) &&
+      //     recurringClassTime === utcTime
+      //   ) {
+      //     throw new Error("Recurring class is already taken");
+      //   }
+      // });
+
+      // console.log(allValidRecurringClasses);
+
+      const isTaken = allValidRecurringClasses.some((recurringClass) => {
         const recurringClassDay = recurringClass.startAt?.getDay();
         const recurringClassTime = formatTime(recurringClass.startAt as Date);
-        if (
+        return (
           recurringClass.instructorId === instructorId &&
           recurringClassDay === getDayNumber(utcDay) &&
           recurringClassTime === utcTime
-        ) {
-          throw new Error("Recurring class is already taken");
-        }
+        );
       });
 
-      console.log(allValidRecurringClasses);
+      if (isTaken) {
+        throw new Error("Recurring class is already taken");
+      }
 
       // GET the current recurring class by recurring class id
       const recurringClass = await getRecurringClassByRecurringClassId(

--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -315,8 +315,17 @@ export const updateRecurringClassesController = async (
       return { updatedRecurringClass, canceledClasses };
     });
 
+    const messages = ["Regular Class is updated successfully"];
+
+    // Check if there are any unbookable classes
+    if (updatedRecurringClasses.canceledClasses.length > 0) {
+      messages.push(
+        "There are classes that cannot be booked. Please book alternative classes instead.",
+      );
+    }
+
     res.status(200).json({
-      message: "Regular Class is updated successfully",
+      messages,
       updatedRecurringClasses,
     });
   } catch (error) {

--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -152,15 +152,15 @@ export const updateRecurringClassesController = async (
   }
 
   // Convert the local class start date to UTC time.
-  const LocalClassStartDateTime = classStartDate + "T00:00:00"; // In the new Date object, the time will change based on the local date.
+  const localClassStartDateTime = classStartDate + "T00:00:00"; // In the new Date object, the time will change based on the local date.
   const utcClassStartDate =
-    new Date(LocalClassStartDateTime).toISOString().split("T")[0] +
+    new Date(localClassStartDateTime).toISOString().split("T")[0] +
     "T00:00:00.000Z"; // In the new Date object, the time will remain unchanged at 00:00.
   const utcToday = new Date();
 
   // Compare the classStart date and today's date in UTC time.
   // If classStartDate is equal to or shorter than today, it shouldn't be executed.
-  if (new Date(LocalClassStartDateTime) <= new Date(utcToday)) {
+  if (new Date(localClassStartDateTime) <= new Date(utcToday)) {
     return res.status(400).json({ message: "Invalid Start From Date" });
   }
 

--- a/backend/src/helper/dateUtils.ts
+++ b/backend/src/helper/dateUtils.ts
@@ -50,7 +50,7 @@ export function createDatesBetween(start: Date, end: Date): Date[] {
   }
   return dates;
 }
-const getDayNumber = (day: Day): number => {
+export const getDayNumber = (day: Day): number => {
   return days.indexOf(day);
 };
 
@@ -73,4 +73,16 @@ export function calculateFirstDate(from: Date, day: Day, time: string): Date {
 
 export const getMonthNumber = (month: Month): number => {
   return months.indexOf(month);
+};
+
+export const formatTime = (date: Date) => {
+  // TODO: The local time zone should be used. 
+  // const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timeZone = "Asia/Tokyo";
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone,
+  }).format(date);
 };

--- a/backend/src/helper/dateUtils.ts
+++ b/backend/src/helper/dateUtils.ts
@@ -66,7 +66,8 @@ export function calculateFirstDate(from: Date, day: Day, time: string): Date {
   );
 
   const [hour, minute] = time.split(":");
-  date.setUTCHours(parseInt(hour) - JAPAN_TIME_DIFF);
+  // TODO: Consider the affected part.
+  date.setUTCHours(parseInt(hour));
   date.setUTCMinutes(parseInt(minute));
   return date;
 }
@@ -75,6 +76,7 @@ export const getMonthNumber = (month: Month): number => {
   return months.indexOf(month);
 };
 
+// Function to format time for a given time zone(e.g., 19:00)
 export const formatTime = (date: Date) => {
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return new Intl.DateTimeFormat("en-US", {
@@ -84,3 +86,31 @@ export const formatTime = (date: Date) => {
     timeZone,
   }).format(date);
 };
+
+// Convert local day and time to UTC day and time (e.g., {day: Fri, time: 07:30 } )
+export function convertDayTimeToUTC(day: Day, time: string) {
+  const [hour, minute] = time.split(":");
+
+  // Get current date
+  const now = new Date();
+  const utcTodayIndex = now.getDay();
+  const localDayIndex = days.indexOf(day);
+
+  // Calculate the date difference between today and the local day
+  let dayDifference = localDayIndex - utcTodayIndex;
+  if (dayDifference < 0) dayDifference += 7; // Adjust the week if needed
+
+  // Adjust the date based on the day difference and set the time.
+  const adjustedDate = new Date();
+  adjustedDate.setDate(now.getDate() + dayDifference);
+  adjustedDate.setHours(Number(hour), Number(minute), 0, 0);
+
+  // Convert to UTC
+  const utcDayIndex = adjustedDate.getUTCDay();
+  const utcTime = `${adjustedDate.getUTCHours().toString().padStart(2, "0")}:${adjustedDate.getUTCMinutes().toString().padStart(2, "0")}`;
+
+  return {
+    utcDay: days[utcDayIndex],
+    utcTime,
+  };
+}

--- a/backend/src/helper/dateUtils.ts
+++ b/backend/src/helper/dateUtils.ts
@@ -50,6 +50,8 @@ export function createDatesBetween(start: Date, end: Date): Date[] {
   }
   return dates;
 }
+
+// Return the number of the week day (e.g., Sun: 0, Mon: 1...)
 export const getDayNumber = (day: Day): number => {
   return days.indexOf(day);
 };
@@ -76,7 +78,7 @@ export const getMonthNumber = (month: Month): number => {
   return months.indexOf(month);
 };
 
-// Function to format time for a given time zone(e.g., 19:00)
+// Function to format time (e.g., 19:00)
 export const formatTime = (date: Date) => {
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return new Intl.DateTimeFormat("en-US", {

--- a/backend/src/helper/dateUtils.ts
+++ b/backend/src/helper/dateUtils.ts
@@ -89,6 +89,16 @@ export const formatTime = (date: Date) => {
   }).format(date);
 };
 
+// Function to format UTC time (e.g., 19:00)
+export const formatUTCTime = (date: Date) => {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(date);
+};
+
 // Convert local day and time to UTC day and time (e.g., {day: Fri, time: 07:30 } )
 export function convertDayTimeToUTC(day: Day, time: string) {
   const [hour, minute] = time.split(":");

--- a/backend/src/helper/dateUtils.ts
+++ b/backend/src/helper/dateUtils.ts
@@ -76,9 +76,7 @@ export const getMonthNumber = (month: Month): number => {
 };
 
 export const formatTime = (date: Date) => {
-  // TODO: The local time zone should be used. 
-  // const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const timeZone = "Asia/Tokyo";
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return new Intl.DateTimeFormat("en-US", {
     hour: "2-digit",
     minute: "2-digit",

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -760,7 +760,7 @@ async function insertRecurringClasses() {
       recurringClassAttendance: {
         create: [
           {
-            childrenId: alice.children[0].id,
+            childrenId: bob.children[0].id,
           },
         ],
       },

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -131,6 +131,23 @@ async function insertInstructorAvailabilities() {
     "2025-02-10T07:00:00Z",
     "2025-02-17T07:00:00Z",
     "2025-02-24T07:00:00Z",
+    "2025-03-03T07:00:00Z",
+    "2025-03-10T07:00:00Z",
+    "2025-03-17T07:00:00Z",
+    "2025-03-24T07:00:00Z",
+    "2025-03-31T07:00:00Z",
+  ]);
+
+  await insertAvailabilities(helen.id, "2025-02-03T07:30:00Z", [
+    "2025-02-03T07:30:00Z",
+    "2025-02-10T07:30:00Z",
+    "2025-02-17T07:30:00Z",
+    "2025-02-24T07:30:00Z",
+    "2025-03-03T07:30:00Z",
+    "2025-03-10T07:30:00Z",
+    "2025-03-17T07:30:00Z",
+    "2025-03-24T07:30:00Z",
+    "2025-03-31T07:30:00Z",
   ]);
 
   await insertAvailabilities(elian.id, "2025-02-03T07:00:00Z", [
@@ -138,7 +155,25 @@ async function insertInstructorAvailabilities() {
     "2025-02-10T07:00:00Z",
     "2025-02-17T07:00:00Z",
     "2025-02-24T07:00:00Z",
+    "2025-03-03T07:00:00Z",
+    "2025-03-10T07:00:00Z",
+    "2025-03-17T07:00:00Z",
+    "2025-03-24T07:00:00Z",
+    "2025-03-31T07:00:00Z",
   ]);
+
+  await insertAvailabilities(elian.id, "2025-02-03T07:30:00Z", [
+    "2025-02-03T07:30:00Z",
+    "2025-02-10T07:30:00Z",
+    "2025-02-17T07:30:00Z",
+    "2025-02-24T07:30:00Z",
+    "2025-03-03T07:30:00Z",
+    "2025-03-10T07:30:00Z",
+    "2025-03-17T07:30:00Z",
+    "2025-03-24T07:30:00Z",
+    "2025-03-31T07:30:00Z",
+  ]);
+
   // await insertAvailabilities(helen.id, "2024-07-01T07:30:00Z", [
   //   "2024-07-01T07:30:00Z",
   //   "2024-07-08T07:30:00Z",
@@ -217,12 +252,12 @@ async function insertCustomers() {
         password: "alice",
         prefecture: "Aomori",
       },
-      // {
-      //   name: "Bob",
-      //   email: "bob@example.com",
-      //   password: "bob",
-      //   prefecture: "Hokkaido",
-      // },
+      {
+        name: "Bob",
+        email: "bob@example.com",
+        password: "bob",
+        prefecture: "Hokkaido",
+      },
     ],
   });
 }
@@ -559,7 +594,7 @@ async function insertClasses() {
 
 async function insertChildren() {
   const alice = await getCustomer("Alice");
-  // const bob = await getCustomer("Bob");
+  const bob = await getCustomer("Bob");
 
   await prisma.children.createMany({
     data: [
@@ -577,13 +612,13 @@ async function insertChildren() {
         personalInfo:
           "Age: 6 years, English Level: Beginner. Likes playing with dolls and has a pet sheep named Woolly.",
       },
-      // {
-      //   name: "Emily",
-      //   customerId: bob.id,
-      //   birthdate: new Date("2017-11-02"),
-      //   personalInfo:
-      //     "Age: 7 years, English Level: Intermediate. Loves drawing and is very creative. Enjoys reading stories.",
-      // },
+      {
+        name: "Emily",
+        customerId: bob.id,
+        birthdate: new Date("2017-11-02"),
+        personalInfo:
+          "Age: 7 years, English Level: Intermediate. Loves drawing and is very creative. Enjoys reading stories.",
+      },
     ],
   });
 }
@@ -656,7 +691,7 @@ async function insertPlans() {
 
 async function insertSubscriptions() {
   const alice = await getCustomer("Alice");
-  // const bob = await getCustomer("Bob");
+  const bob = await getCustomer("Bob");
   const plan1 = await getPlan("3,180 yen/month");
   const plan2 = await getPlan("7,980 yen/month");
 
@@ -668,18 +703,19 @@ async function insertSubscriptions() {
         startAt: new Date("2024-08-01"),
         endAt: null,
       },
-      // {
-      //   customerId: bob.id,
-      //   planId: plan2.id,
-      //   startAt: new Date("2024-06-01"),
-      //   endAt: null,
-      // },
+      {
+        customerId: bob.id,
+        planId: plan2.id,
+        startAt: new Date("2024-06-01"),
+        endAt: null,
+      },
     ],
   });
 }
 
 async function insertRecurringClasses() {
   const alice = await getCustomer("Alice");
+  const bob = await getCustomer("Bob");
   const helen = await getInstructor("Helen");
   // const elian = await getInstructor("Elian");
 
@@ -706,6 +742,21 @@ async function insertRecurringClasses() {
       subscriptionId: alice.subscription[0].id,
       instructorId: helen.id,
       startAt: "2025-02-04T07:00:00Z",
+      recurringClassAttendance: {
+        create: [
+          {
+            childrenId: alice.children[0].id,
+          },
+        ],
+      },
+    },
+  });
+
+  await prisma.recurringClass.create({
+    data: {
+      subscriptionId: bob.subscription[0].id,
+      instructorId: helen.id,
+      startAt: "2025-02-05T07:00:00Z",
       recurringClassAttendance: {
         create: [
           {
@@ -790,11 +841,11 @@ async function insertInstructorUnavailabilities() {
     data: [
       {
         instructorId: helen.id,
-        dateTime: new Date("2024-08-20T07:30:00Z"),
+        dateTime: new Date("2025-03-17T07:00:00Z"),
       },
       {
         instructorId: helen.id,
-        dateTime: new Date("2024-08-22T07:30:00Z"),
+        dateTime: new Date("2025-03-17T07:30:00Z"),
       },
     ],
   });
@@ -877,7 +928,7 @@ async function main() {
     await insertClasses();
 
     // Dependant on the above
-    // await insertInstructorUnavailabilities();
+    await insertInstructorUnavailabilities();
 
     // Dependant on the above
     await insertClassAttendance();

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -18,29 +18,83 @@ async function insertInstructors() {
         "https://select-type.com/rsv/?id=9krPgyM7znE&c_id=129259",
     },
   });
-  // await prisma.instructor.create({
-  //   data: {
-  //     email: "elian@example.com",
-  //     name: "Elian P.Quilisadio",
-  //     nickname: "Elian",
-  //     icon: "elian-1.jpg",
-  //     classURL: "https://zoom.us/j/67890?pwd=FGHij",
-  //     meetingId: "234 567 8901",
-  //     passcode: "elian",
-  //     password: "$2b$12$Oe8qdMedbkuqhY31pgkH7OaMukvbUawE63inMCoDSeY5CHRS3Gc.u", // password: elian
-  //     introductionURL:
-  //       "https://select-type.com/rsv/?id=9krPgyM7znE&c_id=127929",
-  //   },
-  // });
+  await prisma.instructor.create({
+    data: {
+      email: "elian@example.com",
+      name: "Elian P.Quilisadio",
+      nickname: "Elian",
+      icon: "elian-1.jpg",
+      classURL: "https://zoom.us/j/67890?pwd=FGHij",
+      meetingId: "234 567 8901",
+      passcode: "elian",
+      password: "$2b$12$Oe8qdMedbkuqhY31pgkH7OaMukvbUawE63inMCoDSeY5CHRS3Gc.u", // password: elian
+      introductionURL:
+        "https://select-type.com/rsv/?id=9krPgyM7znE&c_id=127929",
+    },
+  });
 }
 
 async function insertInstructorAvailabilities() {
   const helen = await getInstructor("Helen");
-  // const elian = await getInstructor("Elian");
+  const elian = await getInstructor("Elian");
   await prisma.instructorRecurringAvailability.createMany({
     data: [
-      { startAt: "2024-08-05T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
-      { startAt: "2024-08-06T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
+      { startAt: "2025-02-03T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
+      { startAt: "2025-02-03T07:30:00Z", instructorId: helen.id }, // 16:30 in Japan
+      { startAt: "2025-02-03T08:00:00Z", instructorId: helen.id }, // 17:00 in Japan
+      { startAt: "2025-02-03T08:30:00Z", instructorId: helen.id }, // 17:30 in Japan
+      { startAt: "2025-02-03T09:00:00Z", instructorId: helen.id }, // 18:00 in Japan
+      { startAt: "2025-02-03T09:30:00Z", instructorId: helen.id }, // 18:30 in Japan
+      { startAt: "2025-02-03T10:00:00Z", instructorId: helen.id }, // 19:00 in Japan
+      { startAt: "2025-02-04T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
+      { startAt: "2025-02-04T07:30:00Z", instructorId: helen.id }, // 16:30 in Japan
+      { startAt: "2025-02-04T08:00:00Z", instructorId: helen.id }, // 17:00 in Japan
+      { startAt: "2025-02-04T08:30:00Z", instructorId: helen.id }, // 17:30 in Japan
+      { startAt: "2025-02-04T09:00:00Z", instructorId: helen.id }, // 18:00 in Japan
+      { startAt: "2025-02-04T09:30:00Z", instructorId: helen.id }, // 18:30 in Japan
+      { startAt: "2025-02-04T10:00:00Z", instructorId: helen.id }, // 19:00 in Japan
+      { startAt: "2025-02-05T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
+      { startAt: "2025-02-05T07:30:00Z", instructorId: helen.id }, // 16:30 in Japan
+      { startAt: "2025-02-05T08:30:00Z", instructorId: helen.id }, // 17:30 in Japan
+      { startAt: "2025-02-05T09:30:00Z", instructorId: helen.id }, // 18:30 in Japan
+      { startAt: "2025-02-05T10:00:00Z", instructorId: helen.id }, // 19:00 in Japan
+      { startAt: "2025-02-05T10:30:00Z", instructorId: helen.id }, // 19:30 in Japan
+      { startAt: "2025-02-05T11:00:00Z", instructorId: helen.id }, // 20:00 in Japan
+      { startAt: "2025-02-07T07:00:00Z", instructorId: helen.id }, // 16:00 in Japan
+      { startAt: "2025-02-07T07:30:00Z", instructorId: helen.id }, // 16:30 in Japan
+      { startAt: "2025-02-07T08:30:00Z", instructorId: helen.id }, // 17:30 in Japan
+      { startAt: "2025-02-07T09:30:00Z", instructorId: helen.id }, // 18:30 in Japan
+      { startAt: "2025-02-07T10:00:00Z", instructorId: helen.id }, // 19:00 in Japan
+      { startAt: "2025-02-07T10:30:00Z", instructorId: helen.id }, // 19:30 in Japan
+      { startAt: "2025-02-07T11:00:00Z", instructorId: helen.id }, // 20:00 in Japan
+      { startAt: "2025-02-03T07:00:00Z", instructorId: elian.id }, // 16:00 in Japan
+      { startAt: "2025-02-03T07:30:00Z", instructorId: elian.id }, // 16:30 in Japan
+      { startAt: "2025-02-03T08:00:00Z", instructorId: elian.id }, // 17:00 in Japan
+      { startAt: "2025-02-03T08:30:00Z", instructorId: elian.id }, // 17:30 in Japan
+      { startAt: "2025-02-03T09:00:00Z", instructorId: elian.id }, // 18:00 in Japan
+      { startAt: "2025-02-03T09:30:00Z", instructorId: elian.id }, // 18:30 in Japan
+      { startAt: "2025-02-03T10:00:00Z", instructorId: elian.id }, // 19:00 in Japan
+      { startAt: "2025-02-04T07:00:00Z", instructorId: elian.id }, // 16:00 in Japan
+      { startAt: "2025-02-04T07:30:00Z", instructorId: elian.id }, // 16:30 in Japan
+      { startAt: "2025-02-04T08:00:00Z", instructorId: elian.id }, // 17:00 in Japan
+      { startAt: "2025-02-04T08:30:00Z", instructorId: elian.id }, // 17:30 in Japan
+      { startAt: "2025-02-04T09:00:00Z", instructorId: elian.id }, // 18:00 in Japan
+      { startAt: "2025-02-04T09:30:00Z", instructorId: elian.id }, // 18:30 in Japan
+      { startAt: "2025-02-04T10:00:00Z", instructorId: elian.id }, // 19:00 in Japan
+      { startAt: "2025-02-05T07:00:00Z", instructorId: elian.id }, // 16:00 in Japan
+      { startAt: "2025-02-05T07:30:00Z", instructorId: elian.id }, // 16:30 in Japan
+      { startAt: "2025-02-05T08:30:00Z", instructorId: elian.id }, // 17:30 in Japan
+      { startAt: "2025-02-05T09:30:00Z", instructorId: elian.id }, // 18:30 in Japan
+      { startAt: "2025-02-05T10:00:00Z", instructorId: elian.id }, // 19:00 in Japan
+      { startAt: "2025-02-05T10:30:00Z", instructorId: elian.id }, // 19:30 in Japan
+      { startAt: "2025-02-05T11:00:00Z", instructorId: elian.id }, // 20:00 in Japan
+      { startAt: "2025-02-07T07:00:00Z", instructorId: elian.id }, // 16:00 in Japan
+      { startAt: "2025-02-07T07:30:00Z", instructorId: elian.id }, // 16:30 in Japan
+      { startAt: "2025-02-07T08:30:00Z", instructorId: elian.id }, // 17:30 in Japan
+      { startAt: "2025-02-07T09:30:00Z", instructorId: elian.id }, // 18:30 in Japan
+      { startAt: "2025-02-07T10:00:00Z", instructorId: elian.id }, // 19:00 in Japan
+      { startAt: "2025-02-07T10:30:00Z", instructorId: elian.id }, // 19:30 in Japan
+      { startAt: "2025-02-07T11:00:00Z", instructorId: elian.id }, // 20:00 in Japan
       // { startAt: "2024-07-01T07:30:00Z", instructorId: helen.id }, // 16:30 in Japan
       // { startAt: "2024-07-01T08:00:00Z", instructorId: elian.id }, // 17:00 in Japan
       // { startAt: "2024-07-02T08:00:00Z", instructorId: elian.id }, // 17:00 in Japan
@@ -72,19 +126,18 @@ async function insertInstructorAvailabilities() {
     });
   };
 
-  await insertAvailabilities(helen.id, "2024-08-05T07:00:00Z", [
-    "2024-08-05T07:00:00Z",
-    "2024-08-12T07:00:00Z",
-    "2024-08-19T07:00:00Z",
-    "2024-08-26T07:00:00Z",
-    // "2024-07-29T07:00:00Z",
+  await insertAvailabilities(helen.id, "2025-02-03T07:00:00Z", [
+    "2025-02-03T07:00:00Z",
+    "2025-02-10T07:00:00Z",
+    "2025-02-17T07:00:00Z",
+    "2025-02-24T07:00:00Z",
   ]);
 
-  await insertAvailabilities(helen.id, "2024-08-06T07:00:00Z", [
-    "2024-08-06T07:00:00Z",
-    "2024-08-13T07:00:00Z",
-    "2024-08-20T07:00:00Z",
-    "2024-08-27T07:00:00Z",
+  await insertAvailabilities(elian.id, "2025-02-03T07:00:00Z", [
+    "2025-02-03T07:00:00Z",
+    "2025-02-10T07:00:00Z",
+    "2025-02-17T07:00:00Z",
+    "2025-02-24T07:00:00Z",
   ]);
   // await insertAvailabilities(helen.id, "2024-07-01T07:30:00Z", [
   //   "2024-07-01T07:30:00Z",
@@ -634,7 +687,7 @@ async function insertRecurringClasses() {
     data: {
       subscriptionId: alice.subscription[0].id,
       instructorId: helen.id,
-      startAt: "2024-08-05T00:00:00Z",
+      startAt: "2025-02-03T07:00:00Z",
       recurringClassAttendance: {
         create: [
           {
@@ -652,7 +705,7 @@ async function insertRecurringClasses() {
     data: {
       subscriptionId: alice.subscription[0].id,
       instructorId: helen.id,
-      startAt: "2024-08-06T00:00:00Z",
+      startAt: "2025-02-04T07:00:00Z",
       recurringClassAttendance: {
         create: [
           {

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -448,3 +448,21 @@ export const checkDoubleBooking = async (
     throw new Error("Failed to check class booking.");
   }
 };
+
+// Fetch valid classes by instructor id.
+export const getValidClassesByInstructorId = async (
+  tx: Prisma.TransactionClient,
+  instructorId: number,
+  date: Date,
+) => {
+  try {
+    const classes = await tx.class.findMany({
+      where: { instructorId, dateTime: { gte: date } },
+    });
+
+    return classes;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch classes.");
+  }
+};

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -466,3 +466,51 @@ export const getValidClassesByInstructorId = async (
     throw new Error("Failed to fetch classes.");
   }
 };
+
+// Create new canceled classes
+export const createCanceledClasses = async ({
+  tx,
+  dateTimes,
+  instructorId,
+  customerId,
+  subscriptionId,
+  recurringClassId,
+  childrenIds,
+}: {
+  tx: Prisma.TransactionClient;
+  dateTimes: Date[];
+  instructorId: number;
+  customerId: number;
+  subscriptionId: number;
+  recurringClassId: number;
+  childrenIds: number[];
+}) => {
+  try {
+    const createdClasses = await tx.class.createManyAndReturn({
+      data: dateTimes.map((dateTime) => ({
+        instructorId,
+        customerId,
+        recurringClassId,
+        subscriptionId,
+        dateTime,
+        status: "canceledByInstructor",
+      })),
+    });
+    // Add the Class Attendance to the ClassAttendance Table based on the Class ID.
+    await tx.classAttendance.createMany({
+      data: createdClasses
+        .map((createdClass) => {
+          return childrenIds.map((childrenId) => ({
+            classId: createdClass.id,
+            childrenId,
+          }));
+        })
+        .flat(),
+    });
+
+    return createdClasses;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to add class.");
+  }
+};

--- a/backend/src/services/instructorsUnavailabilitiesService.ts
+++ b/backend/src/services/instructorsUnavailabilitiesService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 
 export async function getInstructorUnavailabilities(instructorId: number) {
@@ -22,5 +23,20 @@ export async function createInstructorUnavailability(
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to create instructor unavailability.");
+  }
+}
+
+export async function getValidInstructorUnavailabilities(
+  tx: Prisma.TransactionClient,
+  instructorId: number,
+  date: Date,
+) {
+  try {
+    return await tx.instructorUnavailability.findMany({
+      where: { instructorId, dateTime: { gte: date } },
+    });
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch valid instructor unavailabilities.");
   }
 }

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -142,11 +142,17 @@ function EditRegularClassForm({
       );
 
       // Set the URL depending on authenticated admin or not.
-      const targetURL = isAdminAuthenticated
-        ? `/admins/customer-list/${customerId}?message=${encodeURIComponent(data.message)}`
-        : `/customers/${customerId}/regular-classes?message=${encodeURIComponent(data.message)}`;
-
-      router.push(targetURL);
+      if (data.messages[1]) {
+        const targetURL = isAdminAuthenticated
+          ? `/admins/customer-list/${customerId}?successMessage=${encodeURIComponent(data.messages[0])}&warningMessage=${encodeURIComponent(data.messages[1])}`
+          : `/customers/${customerId}/regular-classes?successMessage=${encodeURIComponent(data.messages[0])}&warningMessage=${encodeURIComponent(data.messages[1])}`;
+        router.push(targetURL);
+      } else {
+        const targetURL = isAdminAuthenticated
+          ? `/admins/customer-list/${customerId}?successMessage=${encodeURIComponent(data.messages[0])}`
+          : `/customers/${customerId}/regular-classes?successMessage=${encodeURIComponent(data.messages[0])}`;
+        router.push(targetURL);
+      }
     } catch (error) {
       console.error("Failed to edit a new recurring class data:", error);
     }

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -69,8 +69,15 @@ function EditRegularClassForm({
             let time = null;
 
             if (dateTime) {
-              day = getWeekday(new Date(dateTime), timeZone);
-              time = formatTime(new Date(dateTime), timeZone);
+
+              // Convert dateTime to local time.
+              const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+              const dateTimeStr = new Date(dateTime).toLocaleString("en-US", {
+                timeZone,
+              });
+
+              day = getWeekday(new Date(dateTimeStr), timeZone);
+              time = formatTime(new Date(dateTimeStr), timeZone);
             }
 
             return {

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -155,6 +155,8 @@ function EditRegularClassForm({
         router.push(targetURL);
       }
     } catch (error) {
+      const err = error as Error;
+      toast.error(err.message);
       console.error("Failed to edit a new recurring class data:", error);
     }
   };

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -29,6 +29,7 @@ function EditRegularClassForm({
   const [children, setChildren] = useState<Child[] | undefined>([]);
   const [states, setStates] = useState<RecurringClassState[]>([]);
   const [keepStates, setKeepStates] = useState<RecurringClassState[]>([]);
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const router = useRouter();
 
   useEffect(() => {
@@ -68,8 +69,8 @@ function EditRegularClassForm({
             let time = null;
 
             if (dateTime) {
-              day = getWeekday(new Date(dateTime), "Asia/Tokyo");
-              time = formatTime(new Date(dateTime), "Asia/Tokyo");
+              day = getWeekday(new Date(dateTime), timeZone);
+              time = formatTime(new Date(dateTime), timeZone);
             }
 
             return {

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.tsx
@@ -29,7 +29,6 @@ function EditRegularClassForm({
   const [children, setChildren] = useState<Child[] | undefined>([]);
   const [states, setStates] = useState<RecurringClassState[]>([]);
   const [keepStates, setKeepStates] = useState<RecurringClassState[]>([]);
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const router = useRouter();
 
   useEffect(() => {
@@ -69,15 +68,9 @@ function EditRegularClassForm({
             let time = null;
 
             if (dateTime) {
-
-              // Convert dateTime to local time.
               const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-              const dateTimeStr = new Date(dateTime).toLocaleString("en-US", {
-                timeZone,
-              });
-
-              day = getWeekday(new Date(dateTimeStr), timeZone);
-              time = formatTime(new Date(dateTimeStr), timeZone);
+              day = getWeekday(new Date(dateTime), timeZone);
+              time = formatTime(new Date(dateTime), timeZone);
             }
 
             return {

--- a/frontend/src/app/components/customers-dashboard/regular-classes/InstructorsSchedule.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/InstructorsSchedule.tsx
@@ -26,6 +26,7 @@ function InstructorsSchedule() {
     Sat: [],
     Sun: [],
   });
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   useEffect(() => {
     const fetchInstructorAvailabilities = async () => {
@@ -47,9 +48,9 @@ function InstructorsSchedule() {
         data.forEach((availability: RecurringAvailability) => {
           const day = getWeekday(
             new Date(availability.startAt),
-            "Asia/Tokyo",
+            timeZone,
           ) as Day;
-          const time = formatTime(new Date(availability.startAt), "Asia/Tokyo");
+          const time = formatTime(new Date(availability.startAt), timeZone);
 
           setSlots((prevSlots) => ({
             ...prevSlots,

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
@@ -46,10 +46,9 @@ function RecurringClassEntry({
   const [slots, setSlots] = useState<SlotsOfDays>(emptySlots);
   const [times, setTimes] = useState<string[]>([]);
 
-  // Get tomorrow's date
-  const now = new Date();
+  // Get the local tomorrow's date
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const todayStr = now.toLocaleDateString("en-US", {
+  const todayStr = new Date().toLocaleDateString("en-US", {
     timeZone,
   });
   const [month, date, year] = todayStr.split("/").map(Number);

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
@@ -48,12 +48,12 @@ function RecurringClassEntry({
 
   // Get the local tomorrow's date
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const todayStr = new Date().toLocaleDateString("en-US", {
-    timeZone,
+  const jstTodayStr = new Date().toLocaleDateString("en-US", {
+    timeZone: "Asia/Tokyo",
   });
-  const [month, date, year] = todayStr.split("/").map(Number);
-  const tomorrow = new Date(year, month - 1, date + 1);
-  const tomorrowFormatted = tomorrow.toISOString().split("T")[0];
+  const [month, date, year] = jstTodayStr.split("/").map(Number);
+  const jstTomorrow = new Date(year, month - 1, date + 1);
+  const tomorrowFormatted = jstTomorrow.toISOString().split("T")[0];
 
   useEffect(() => {
     if (!instructorId) return;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
@@ -47,10 +47,13 @@ function RecurringClassEntry({
   const [times, setTimes] = useState<string[]>([]);
 
   // Get tomorrow's date
-  // TODO: Tomorrow needs to be fixed.
-  const tomorrow = new Date();
-  tomorrow.setHours(0, 0, 0, 0);
-  tomorrow.setDate(tomorrow.getDate() + 1);
+  const now = new Date();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const todayStr = now.toLocaleDateString("en-US", {
+    timeZone,
+  });
+  const [month, date, year] = todayStr.split("/").map(Number);
+  const tomorrow = new Date(year, month - 1, date + 1);
   const tomorrowFormatted = tomorrow.toISOString().split("T")[0];
 
   useEffect(() => {
@@ -74,12 +77,9 @@ function RecurringClassEntry({
           (recurringClass: RecurringAvailability) => {
             const day = getWeekday(
               new Date(recurringClass.startAt),
-              "Asia/Tokyo",
+              timeZone,
             ) as Day;
-            const time = formatTime(
-              new Date(recurringClass.startAt),
-              "Asia/Tokyo",
-            );
+            const time = formatTime(new Date(recurringClass.startAt), timeZone);
 
             newUnavailableSlots[day].push(time);
           },
@@ -105,9 +105,9 @@ function RecurringClassEntry({
         data.forEach((availability: RecurringAvailability) => {
           const day = getWeekday(
             new Date(availability.startAt),
-            "Asia/Tokyo",
+            timeZone,
           ) as Day;
-          const time = formatTime(new Date(availability.startAt), "Asia/Tokyo");
+          const time = formatTime(new Date(availability.startAt), timeZone);
 
           if (!newUnavailableSlots[day].includes(time)) {
             newSlots[day].push(time);

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.tsx
@@ -163,7 +163,13 @@ function RecurringClassEntry({
           name="instructors"
           value={instructorId || ""}
           onChange={(e) => {
-            setState({ ...state, instructorId: parseInt(e.target.value) });
+            setState({
+              ...state,
+              instructorId: parseInt(e.target.value),
+              day: "",
+              time: "",
+            });
+            setTimes([]);
           }}
         >
           <option key="" value="" hidden></option>

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -35,9 +35,12 @@ function RegularClassesTable({
         const data = await getRecurringClassesBySubscriptionId(subscriptionId);
 
         // Get the local date and the begging of its time.
-        const date = new Date();
-        date.setHours(0, 0, 0, 0);
-        const today = date.toISOString().split("T")[0];
+        const now = new Date();
+        const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const todayStr = now.toLocaleString("en-US", {
+          timeZone,
+        });
+        const todayFormatted = new Date(todayStr).toISOString().split("T")[0];
 
         const curr: RecurringClass[] = [];
         const upcoming: RecurringClass[] = [];
@@ -45,7 +48,10 @@ function RegularClassesTable({
         // Set the current Regular Classes and the up coming Regular Class separately.
         data.recurringClasses.forEach((recurringClass: RecurringClass) => {
           const { dateTime } = recurringClass;
-          if (new Date(today + "T00:00:00Z") < new Date(dateTime)) {
+          const dateTimeStr = new Date(dateTime).toLocaleDateString("en-US", {
+            timeZone,
+          });
+          if (new Date(todayFormatted) < new Date(dateTimeStr)) {
             upcoming.push(recurringClass);
           } else {
             curr.push(recurringClass);
@@ -169,12 +175,19 @@ function Table({ recurringClasses }: { recurringClasses: RecurringClass[] }) {
               </td>
               <td className={styles.bodyText}>
                 {recurringClass.dateTime
-                  ? recurringClass.dateTime.toString().split("T")[0]
+                  ? new Date(recurringClass.dateTime).toLocaleDateString(
+                      "en-US",
+                      {
+                        timeZone,
+                      },
+                    )
                   : ""}
               </td>
               <td className={styles.bodyText}>
                 {recurringClass.endAt
-                  ? recurringClass.endAt.toString().split("T")[0]
+                  ? new Date(recurringClass.endAt).toLocaleDateString("en-US", {
+                      timeZone,
+                    })
                   : ""}
               </td>
             </tr>

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -32,7 +32,7 @@ function RegularClassesTable({
   useEffect(() => {
     const fetchRecurringClassesBySubscriptionId = async () => {
       try {
-        const data = await getRecurringClassesBySubscriptionId(subscriptionId)
+        const data = await getRecurringClassesBySubscriptionId(subscriptionId);
 
         const curr: RecurringClass[] = [];
         const upcoming: RecurringClass[] = [];

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -32,15 +32,7 @@ function RegularClassesTable({
   useEffect(() => {
     const fetchRecurringClassesBySubscriptionId = async () => {
       try {
-        const data = await getRecurringClassesBySubscriptionId(subscriptionId);
-
-        // Get the local date and the begging of its time.
-        const now = new Date();
-        const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        const todayStr = now.toLocaleString("en-US", {
-          timeZone,
-        });
-        const todayFormatted = new Date(todayStr).toISOString().split("T")[0];
+        const data = await getRecurringClassesBySubscriptionId(subscriptionId)
 
         const curr: RecurringClass[] = [];
         const upcoming: RecurringClass[] = [];
@@ -48,10 +40,8 @@ function RegularClassesTable({
         // Set the current Regular Classes and the up coming Regular Class separately.
         data.recurringClasses.forEach((recurringClass: RecurringClass) => {
           const { dateTime } = recurringClass;
-          const dateTimeStr = new Date(dateTime).toLocaleDateString("en-US", {
-            timeZone,
-          });
-          if (new Date(todayFormatted) < new Date(dateTimeStr)) {
+          // Compare the date in UTC time.
+          if (new Date() < new Date(dateTime)) {
             upcoming.push(recurringClass);
           } else {
             curr.push(recurringClass);
@@ -176,7 +166,7 @@ function Table({ recurringClasses }: { recurringClasses: RecurringClass[] }) {
               <td className={styles.bodyText}>
                 {recurringClass.dateTime
                   ? new Date(recurringClass.dateTime).toLocaleDateString(
-                      "en-US",
+                      "en-CA",
                       {
                         timeZone,
                       },
@@ -185,7 +175,7 @@ function Table({ recurringClasses }: { recurringClasses: RecurringClass[] }) {
               </td>
               <td className={styles.bodyText}>
                 {recurringClass.endAt
-                  ? new Date(recurringClass.endAt).toLocaleDateString("en-US", {
+                  ? new Date(recurringClass.endAt).toLocaleDateString("en-CA", {
                       timeZone,
                     })
                   : ""}

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -107,6 +107,7 @@ function RegularClassesTable({
 export default RegularClassesTable;
 
 function Table({ recurringClasses }: { recurringClasses: RecurringClass[] }) {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return (
     <table className={styles.table}>
       <thead className={styles.header}>
@@ -129,15 +130,12 @@ function Table({ recurringClasses }: { recurringClasses: RecurringClass[] }) {
           let day = null;
 
           if (recurringClass.dateTime) {
-            startTime = formatTime(
-              new Date(recurringClass.dateTime),
-              "Asia/Tokyo",
-            );
+            startTime = formatTime(new Date(recurringClass.dateTime), timeZone);
             endTime = formatTime(
               getEndTime(new Date(recurringClass.dateTime)),
-              "Asia/Tokyo",
+              timeZone,
             );
-            day = getWeekday(new Date(recurringClass.dateTime), "Asia/Tokyo");
+            day = getWeekday(new Date(recurringClass.dateTime), timeZone);
           }
 
           return (

--- a/frontend/src/app/customers/[id]/regular-classes/page.tsx
+++ b/frontend/src/app/customers/[id]/regular-classes/page.tsx
@@ -15,9 +15,14 @@ function Page({ params }: { params: { id: string } }) {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    const message = searchParams.get("message");
-    if (message) {
-      toast.success(message);
+    const successMessage = searchParams.get("successMessage");
+    if (successMessage) {
+      toast.success(successMessage);
+    }
+
+    const warningMessage = searchParams.get("warningMessage");
+    if (warningMessage) {
+      toast.warning(warningMessage);
     }
 
     // clean up the URL

--- a/frontend/src/app/helper/api/recurringClassesApi.ts
+++ b/frontend/src/app/helper/api/recurringClassesApi.ts
@@ -76,13 +76,14 @@ export const editRecurringClass = async (
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      const errorData = await response.json();
+      throw new Error(errorData.error || "Failed to an edit regular class");
     }
 
     const data = await response.json();
     return data;
   } catch (error) {
-    console.error("Failed to edit recurring classes:", error);
+    console.error("Failed to an edit regular class:", error);
     throw error;
   }
 };


### PR DESCRIPTION
## Overview
- Add validation for recurring classes.
- Use local time on the frontend UTC time on the backend.

## Review point
1. Run dummy.ts
2. Customer A changes one of the recurring classes. (e.g., Bob changes it to Fri 1:00 am PST)
3. Customer A cancels one or two classes and rebooks a new class. (e.g., Bob rebooks a class for Sun 23:00 PST)
4. Customer B changes one of the recurring classes on the same day and time as No.3. (Alice register a regular class Sun 23:00 PST)
 -> Check if the classes that Customer A booked on No.3 can't be booked and are canceled by instructors. 
5. Customer B changes one of the recurring classes to the date and time when the instructor is unavailable. (Helene Sun 23:00 or 23:30 PST)
 -> Check if the instructor's unavailability classes can't be booked and are canceled by instructors. 

- Ensure that local time is used on the regular classes page.
- Ensure that UTC time is stored in the DB.

## Consideration
- It seems that summertime starts from 2025 Mar 9 Sun, so after this date, time will be 1 hour ahead. (Only PST?)
- If a customer has some classes that can't be booked when they change a regular class, there is no problem when they change the regular class again if they don't book a new class. But if they book a new class, they will get an extra class, so we need to ask Haru-san about it.