### PR TITLE
Reorganize each list page structure

### DIFF
--- a/frontend/src/app/actions/revalidate.ts
+++ b/frontend/src/app/actions/revalidate.ts
@@ -24,6 +24,22 @@ export async function revalidateUpcomingClasses() {
   revalidateTag("upcoming-classes");
 }
 
-export async function revalidatePlans() {
-  revalidateTag("plans");
+export async function revalidateAdminList() {
+  revalidateTag("admin-list");
+}
+
+export async function revalidateInstructorList() {
+  revalidateTag("instructor-list");
+}
+
+export async function revalidateCustomerList() {
+  revalidateTag("customer-list");
+}
+
+export async function revalidateChildList() {
+  revalidateTag("child-list");
+}
+
+export async function revalidatePlanList() {
+  revalidateTag("plan-list");
 }

--- a/frontend/src/app/admins/(authenticated)/admin-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/admin-list/page.tsx
@@ -1,18 +1,19 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllAdmins } from "@/app/helper/api/adminsApi";
 
-function Page() {
+export default async function Page() {
   const listType = "Admin List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = [""]; // Set the item to be a link
   const replaceItems = ["Admin ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = ["/admins/customer-list/[Admin ID]"]; // Set the link URL
+  const data = await getAllAdmins(); // Fetch all admins data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}
@@ -21,5 +22,3 @@ function Page() {
     </div>
   );
 }
-
-export default Page;

--- a/frontend/src/app/admins/(authenticated)/child-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/child-list/page.tsx
@@ -1,18 +1,19 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllChildren } from "@/app/helper/api/adminsApi";
 
-function Page() {
+export default async function Page() {
   const listType = "Child List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = ["ID"]; // Set the item to be a link
   const replaceItems = ["Customer ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = ["/admins/customer-list/[Customer ID]"]; // Set the link URL
+  const data = await getAllChildren(); // Fetch all children data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}
@@ -21,5 +22,3 @@ function Page() {
     </div>
   );
 }
-
-export default Page;

--- a/frontend/src/app/admins/(authenticated)/class-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/class-list/page.tsx
@@ -1,18 +1,19 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllClasses } from "@/app/helper/api/adminsApi";
 
-function Page() {
+export default async function Page() {
   const listType = "Class List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = [""]; // Set the item to be a link
   const replaceItems = [""]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = [""]; // Set the link URL
+  const data = await getAllClasses(); // Fetch all classes data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}
@@ -21,5 +22,3 @@ function Page() {
     </div>
   );
 }
-
-export default Page;

--- a/frontend/src/app/admins/(authenticated)/customer-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/customer-list/page.tsx
@@ -1,18 +1,19 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllCustomers } from "@/app/helper/api/adminsApi";
 
-function Page() {
+export default async function Page() {
   const listType = "Customer List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = ["ID"]; // Set the item to be a link
   const replaceItems = ["ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = ["/admins/customer-list/[ID]"]; // Set the link URL
+  const data = await getAllCustomers(); // Fetch all customers data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}
@@ -21,5 +22,3 @@ function Page() {
     </div>
   );
 }
-
-export default Page;

--- a/frontend/src/app/admins/(authenticated)/instructor-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/instructor-list/page.tsx
@@ -1,19 +1,20 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllInstructors } from "@/app/helper/api/adminsApi";
 
-export default function Page() {
+export default async function Page() {
   const listType = "Instructor List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = ["ID"]; // Set the item to be a link
   const replaceItems = ["ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = ["/admins/instructor-list/[ID]"]; // Set the link URL
   const addUserLink = ["/admins/instructor-list/register", "Add instructor"]; // Set the link URL and name to add a user
+  const data = await getAllInstructors(); // Fetch all instructors data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}

--- a/frontend/src/app/admins/(authenticated)/plan-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/plan-list/page.tsx
@@ -1,18 +1,19 @@
-"use client";
-
 import ListTable from "@/app/components/admins-dashboard/ListTable";
+import { getAllPlans } from "@/app/helper/api/adminsApi";
 
-function Page() {
+export default async function Page() {
   const listType = "Plan List";
   const omitItems = [""]; // Omit the item from the table
   const linkItems = [""]; // Set the item to be a link
   const replaceItems = [""]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = [""]; // Set the link URL
+  const data = await getAllPlans(); // Fetch all plans data
 
   return (
     <div>
       <ListTable
         listType={listType}
+        fetchedData={data}
         omitItems={omitItems}
         linkItems={linkItems}
         linkUrls={linkUrls}
@@ -21,5 +22,3 @@ function Page() {
     </div>
   );
 }
-
-export default Page;

--- a/frontend/src/app/components/admins-dashboard/ListTable.tsx
+++ b/frontend/src/app/components/admins-dashboard/ListTable.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useMemo } from "react";
 import styles from "./ListTable.module.scss";
 import { PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
@@ -10,18 +12,11 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import Link from "next/link";
-import {
-  getAllAdmins,
-  getAllInstructors,
-  getAllCustomers,
-  getAllChildren,
-  getAllPlans,
-  getAllClasses,
-} from "@/app/helper/api/adminsApi";
 import RedirectButton from "../elements/buttons/redirectButton/RedirectButton";
 
 type ListTableProps = {
   listType: string;
+  fetchedData: any[];
   omitItems: string[];
   linkItems: string[];
   linkUrls: string[];
@@ -31,6 +26,7 @@ type ListTableProps = {
 
 function ListTable({
   listType,
+  fetchedData,
   omitItems,
   linkItems,
   linkUrls,
@@ -44,46 +40,34 @@ function ListTable({
   const [selectedCellId, setSelectedCellId] = useState<string | null>(null);
 
   useEffect(() => {
-    // Fetch the applicable based on the list type
-    const fetchData = async () => {
+    const listData = async () => {
       try {
-        let fetchData;
+        let listData = fetchedData;
+
         switch (listType) {
-          case "Admin List":
-            fetchData = await getAllAdmins();
-            break;
           case "Instructor List":
-            fetchData = await getAllInstructors();
             // Set the active tab to the instructor calendar tab.
             localStorage.setItem("activeInstructorTab", "0");
             break;
           case "Customer List":
-            fetchData = await getAllCustomers();
             // Set the active tab to the customer calendar tab.
             localStorage.setItem("activeCustomerTab", "0");
             break;
           case "Child List":
-            fetchData = await getAllChildren();
             // Set the active tab to the children profiles tab.
             localStorage.setItem("activeCustomerTab", "2");
             break;
-          case "Plan List":
-            fetchData = await getAllPlans();
-            break;
-          case "Class List":
-            fetchData = await getAllClasses();
-            break;
           default:
-            fetchData = [];
+            break;
         }
-        setData(fetchData);
+        setData(listData);
       } catch (error) {
         console.error(error);
       }
     };
 
-    fetchData();
-  }, [listType]);
+    listData();
+  }, [fetchedData, listType]);
 
   useEffect(() => {
     // Handle the click event on the table cell

--- a/frontend/src/app/helper/api/adminsApi.ts
+++ b/frontend/src/app/helper/api/adminsApi.ts
@@ -5,7 +5,10 @@ const BASE_URL = `${BACKEND_ORIGIN}/admins`;
 // GET all admins data
 export const getAllAdmins = async () => {
   try {
-    const response = await fetch(`${BASE_URL}/admin-list`);
+    const apiUrl = `${BASE_URL}/admin-list`;
+    const response = await fetch(apiUrl, {
+      next: { tags: ["admin-list"] },
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -20,7 +23,10 @@ export const getAllAdmins = async () => {
 // GET all instructors data
 export const getAllInstructors = async () => {
   try {
-    const response = await fetch(`${BASE_URL}/instructor-list`);
+    const apiUrl = `${BASE_URL}/instructor-list`;
+    const response = await fetch(apiUrl, {
+      next: { tags: ["instructor-list"] },
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -35,7 +41,10 @@ export const getAllInstructors = async () => {
 // GET all customers data
 export const getAllCustomers = async () => {
   try {
-    const response = await fetch(`${BASE_URL}/customer-list`);
+    const apiUrl = `${BASE_URL}/customer-list`;
+    const response = await fetch(apiUrl, {
+      next: { tags: ["customer-list"] },
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -50,7 +59,10 @@ export const getAllCustomers = async () => {
 // GET all children data
 export const getAllChildren = async () => {
   try {
-    const response = await fetch(`${BASE_URL}/child-list`);
+    const apiUrl = `${BASE_URL}/child-list`;
+    const response = await fetch(apiUrl, {
+      next: { tags: ["child-list"] },
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -67,7 +79,7 @@ export const getAllPlans = async () => {
   try {
     const apiUrl = `${BASE_URL}/plan-list`;
     const response = await fetch(apiUrl, {
-      next: { tags: ["plans"] },
+      next: { tags: ["plan-list"] },
     });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Overview

Reorganize the structure of the existing list pages (Admin dashboard) to fetch data from server components.
Applicable pages: Class List, Admin List, Instructor List, Customer List, Child List, and Plan List

[Before]
```mermaid
graph 
    A[Page.tsx<br>'use client'] --> B[ListTable.tsx]
    A --> C[adminApi.ts]
```

[After]
```mermaid
graph 
    A[Page.tsx] --> B[ListTable.tsx<br>'use client']
    A --> C[adminApi.ts]
```


## Review point
Log in to the app as admin and confirm that each list page is displayed without any issues.

<img width="1422" alt="Screenshot 2025-04-25 at 1 06 00" src="https://github.com/user-attachments/assets/36eff8c7-a5db-4041-8e77-2a943717360f" />
