### PR TITLE
Create admin profile page

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { kv } from "@vercel/kv";
 import { createAdmin, getAdmin } from "../services/adminsService";
-import { getAllAdmins } from "../services/adminsService";
+import { getAllAdmins, getAdminById } from "../services/adminsService";
 import {
   getAllInstructors,
   createInstructor,
@@ -130,6 +130,34 @@ interface SingleChildSubscription extends Omit<Subscription, "customer"> {
     };
   };
 }
+
+function setErrorResponse(res: Response, error: unknown) {
+  return res
+    .status(500)
+    .json({ message: error instanceof Error ? error.message : `${error}` });
+}
+
+export const getAdminController = async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) {
+    return res.status(400).json({ message: "Invalid ID provided." });
+  }
+  try {
+    const admin = await getAdminById(id);
+    if (!admin) {
+      return res.status(404).json({ message: "Admin not found." });
+    }
+    return res.status(200).json({
+      admin: {
+        id: admin.id,
+        name: admin.name,
+        email: admin.email,
+      },
+    });
+  } catch (error) {
+    return setErrorResponse(res, error);
+  }
+};
 
 // Admin dashboard for displaying admins' information
 export const getAllAdminsController = async (_: Request, res: Response) => {

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -4,6 +4,7 @@ import {
   logoutAdminController,
   registerAdminController,
   registerInstructorController,
+  getAdminController,
   getAllAdminsController,
   getAllInstructorsController,
   getAllCustomersController,
@@ -29,6 +30,7 @@ adminsRouter.post(
   requireAuthentication,
   registerInstructorController,
 );
+adminsRouter.get("/admin-list/:id", getAdminController);
 adminsRouter.get("/admin-list", getAllAdminsController);
 adminsRouter.get("/instructor-list", getAllInstructorsController);
 adminsRouter.get("/customer-list", getAllCustomersController);

--- a/backend/src/services/adminsService.ts
+++ b/backend/src/services/adminsService.ts
@@ -45,3 +45,15 @@ export const getAdmin = async (email: string) => {
     throw new Error("Failed to fetch admin.");
   }
 };
+
+// Fetch the admin using the ID
+export async function getAdminById(id: number) {
+  try {
+    return prisma.admins.findUnique({
+      where: { id },
+    });
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch admin.");
+  }
+}

--- a/frontend/src/app/admins/(authenticated)/admin-list/[adminId]/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/admin-list/[adminId]/page.tsx
@@ -1,0 +1,13 @@
+import AdminDashboardForAdmin from "@/app/components/admins-dashboard/AdminDashboardForAdmin";
+
+function Page({ params }: { params: { adminId: string } }) {
+  const adminId = parseInt(params.adminId);
+
+  if (isNaN(adminId)) {
+    throw new Error("Invalid adminId");
+  }
+
+  return <AdminDashboardForAdmin adminId={adminId} />;
+}
+
+export default Page;

--- a/frontend/src/app/components/admins-dashboard/AdminDashboardClient.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminDashboardClient.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import TabFunction from "@/app/components/admins-dashboard/TabFunction";
+import AdminProfile from "@/app/components/admins-dashboard/AdminProfile";
+import { useContext } from "react";
+import { AuthContext } from "@/app/admins/(authenticated)/authContext";
+import { useTabSelect } from "@/app/hooks/useTabSelect";
+import Loading from "@/app/components/elements/loading/Loading";
+
+export default function AdminTabs({
+  adminId,
+  admin,
+}: {
+  adminId: number;
+  admin: Admin | string;
+}) {
+  const breadcrumb = ["Admin List", `/admins/admin-list`, `ID: ${adminId}`];
+  const activeTabName = "activeAdminTab";
+
+  // Check the authentication of the admin.
+  const { isAuthenticated } = useContext(AuthContext);
+
+  // Get the active tab from the local storage.
+  const { initialActiveTab, isTabInitialized } = useTabSelect("activeAdminTab");
+
+  // Tabs with labels and content
+  const tabs = [
+    {
+      label: "Admin's Profile",
+      content: (
+        <AdminProfile admin={admin} isAdminAuthenticated={isAuthenticated} />
+      ),
+    },
+  ];
+
+  // Display a loading message while initializing the tab.
+  if (!isTabInitialized) {
+    return <Loading />;
+  }
+
+  return (
+    <TabFunction
+      tabs={tabs}
+      breadcrumb={breadcrumb}
+      activeTabName={activeTabName}
+      initialActiveTab={initialActiveTab}
+    />
+  );
+}

--- a/frontend/src/app/components/admins-dashboard/AdminDashboardForAdmin.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminDashboardForAdmin.tsx
@@ -1,0 +1,19 @@
+import AdminTabs from "@/app/components/admins-dashboard/AdminDashboardClient";
+import { getAdmin } from "@/app/helper/api/adminsApi";
+
+export default async function AdminDashboardForAdmin({
+  adminId,
+}: {
+  adminId: number;
+}) {
+  // Fetch admin's data
+  const data = await getAdmin(adminId);
+  let admin = null;
+  if ("message" in data) {
+    admin = data.message;
+  } else {
+    admin = data.admin;
+  }
+
+  return <AdminTabs adminId={adminId} admin={admin} />;
+}

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
@@ -1,0 +1,114 @@
+@import "../../variables.module.scss";
+
+.container {
+  padding: 30px;
+  border: 1px solid $gray-background;
+  border-radius: 0.5rem;
+  box-shadow: 2px 4px 6px rgba(0, 0, 0, 0.3);
+  width: 100%;
+
+  .pic {
+    padding: 1rem;
+    width: 150px;
+    height: 150px;
+  }
+
+  h3 {
+    margin-bottom: 1rem;
+  }
+}
+
+.insideContainer {
+  background-color: #f9fafb;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.1);
+}
+
+.icon {
+  width: 2rem;
+  height: 2rem;
+  margin-right: 1rem;
+}
+
+.urlInfo {
+  display: flex;
+  font-size: 0.8rem;
+}
+
+.url {
+  color: $blue_primary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.info {
+  font-size: 0.8rem;
+}
+
+// name
+.adminName {
+  display: flex;
+  align-items: center;
+  gap: 30px;
+  height: 66px;
+  margin-bottom: 24px;
+
+  &__nameSection {
+    width: 100%;
+    margin-right: 10px;
+  }
+  &__text {
+    font-size: 16px;
+    font-weight: 300;
+    width: 100%;
+  }
+  &__inputField {
+    margin: 0px 50px 0px 0px;
+    font-size: 20px;
+    font-weight: 500;
+    padding: 3px 6px;
+    border-radius: 6px;
+    width: 50%;
+  }
+
+  &__name {
+    font-size: 24px;
+    font-weight: 500;
+  }
+}
+
+// email
+.email {
+  &__inputField {
+    margin: 0px 50px 0px 0px;
+    padding: 3px 6px;
+    font-size: 20px;
+    font-weight: 400;
+    border-radius: 6px;
+    width: 100%;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+}
+
+// buttons
+.buttons {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.addBtn {
+  margin-top: 10px;
+  margin-bottom: 20px;
+}

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import styles from "./AdminProfile.module.scss";
+import { useState, useEffect } from "react";
+import { useFormState } from "react-dom";
+import { updateUser } from "@/app/actions/updateUser";
+import InputField from "../elements/inputField/InputField";
+import ActionButton from "../elements/buttons/actionButton/ActionButton";
+import { CheckIcon } from "@heroicons/react/24/outline";
+import { EnvelopeIcon } from "@heroicons/react/24/outline";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import Loading from "@/app/components/elements/loading/Loading";
+
+function AdminProfile({
+  admin,
+  isAdminAuthenticated,
+}: {
+  admin: Admin | string;
+  isAdminAuthenticated?: boolean;
+}) {
+  const [updateResultState, formAction] = useFormState(updateUser, {});
+  const [previousAdmin, setPreviousAdmin] = useState<Admin | null>(
+    typeof admin !== "string" ? admin : null,
+  );
+  const [latestAdmin, setLatestAdmin] = useState<Admin | null>(
+    typeof admin !== "string" ? admin : null,
+  );
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    field: keyof Admin,
+  ) => {
+    if (latestAdmin) {
+      setLatestAdmin({ ...latestAdmin, [field]: e.target.value });
+    }
+  };
+
+  const handleCancelClick = () => {
+    if (latestAdmin) {
+      setLatestAdmin(previousAdmin);
+      setIsEditing(false);
+    }
+  };
+
+  useEffect(() => {
+    if (updateResultState !== undefined) {
+      if ("admin" in updateResultState) {
+        const result = updateResultState as { admin: Admin };
+        toast.success("Profile updated successfully!");
+        setIsEditing(false);
+        setPreviousAdmin(result.admin);
+        setLatestAdmin(result.admin);
+      } else {
+        const result = updateResultState as { errorMessage: string };
+        toast.error(result.errorMessage);
+      }
+    }
+  }, [updateResultState]);
+
+  if (typeof admin === "string") {
+    return <p>{admin}</p>;
+  }
+
+  return (
+    <>
+      <h2>Profile Page</h2>
+      <div className={styles.container}>
+        {latestAdmin ? (
+          <form action={formAction} className={styles.profileCard}>
+            {/* Admin name */}
+            <div className={styles.adminName__nameSection}>
+              <p className={styles.adminName__text}>Name</p>
+              {isEditing ? (
+                <InputField
+                  name="name"
+                  value={latestAdmin.name}
+                  onChange={(e) => handleInputChange(e, "name")}
+                  className={`${styles.adminName__inputField} ${isEditing ? styles.editable : ""}`}
+                />
+              ) : (
+                <h3 className={styles.adminName__name}>{latestAdmin.name}</h3>
+              )}
+            </div>
+
+            {/* Admin email */}
+            <div className={styles.insideContainer}>
+              <EnvelopeIcon className={styles.icon} />
+              <div>
+                <p>Email</p>
+                {isEditing ? (
+                  <InputField
+                    name="email"
+                    type="email"
+                    value={latestAdmin.email}
+                    onChange={(e) => handleInputChange(e, "email")}
+                    className={`${styles.email__inputField} ${isEditing ? styles.editable : ""}`}
+                  />
+                ) : (
+                  <h4>{latestAdmin.email}</h4>
+                )}
+              </div>
+            </div>
+
+            {/* Hidden input fields */}
+            <input type="hidden" name="userType" value="admin" />
+            <input type="hidden" name="id" value={latestAdmin.id} />
+
+            {/* Action buttons for only admin */}
+            {isAdminAuthenticated ? (
+              <>
+                {isEditing ? (
+                  <div className={styles.buttons}>
+                    <ActionButton
+                      className="cancelEditingInstructor"
+                      btnText="Cancel"
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleCancelClick();
+                      }}
+                    />
+
+                    <ActionButton
+                      className="saveInstructor"
+                      btnText="Save"
+                      type="submit"
+                      Icon={CheckIcon}
+                    />
+                  </div>
+                ) : (
+                  <div className={styles.buttons}>
+                    <ActionButton
+                      className="editInstructor"
+                      btnText="Edit"
+                      onClick={handleEditClick}
+                    />
+                  </div>
+                )}
+              </>
+            ) : null}
+          </form>
+        ) : (
+          <Loading />
+        )}
+      </div>
+    </>
+  );
+}
+
+export default AdminProfile;

--- a/frontend/src/app/helper/api/adminsApi.ts
+++ b/frontend/src/app/helper/api/adminsApi.ts
@@ -2,6 +2,19 @@ const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 const BASE_URL = `${BACKEND_ORIGIN}/admins`;
 
+export type Response<T> = T | { message: string };
+
+export const getAdmin = async (
+  id: number,
+): Promise<Response<{ admin: Admin }>> => {
+  const apiUrl = `${BASE_URL}/admin-list/${id}`;
+  const data: Response<{ admin: Admin }> = await fetch(apiUrl, {
+    cache: "no-store",
+  }).then((res) => res.json());
+
+  return data;
+};
+
 // GET all admins data
 export const getAllAdmins = async () => {
   try {

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -60,6 +60,12 @@ type ClassType = {
   recurringClassId: number;
 };
 
+type Admin = {
+  id: number;
+  name: string;
+  email: string;
+};
+
 type Customer = {
   id: number;
   name: string;


### PR DESCRIPTION
## Overview

Create admin profile page referring to PR #53. 

###

<img width="993" alt="Screenshot 2025-04-28 at 3 35 28" src="https://github.com/user-attachments/assets/c81c9dbe-eae3-4a14-9980-d6a78104df0b" />

## Structure
```mermaid
graph 
    A[Page.tsx] --> B[AdminDashboardForAdmin.tsx]
    B --> C[AdminDashboardClient.tsx<br>'use client'] --> E[AdminProfile.tsx<br>'use client']
    B --> D[adminApi.ts]
```

## Review points

Confirm the following points without any issues:

- Admin information (e.g, ID1) is displayed on the admin dashboard
        http://localhost:3000/admins/admin-list/1
-  The message "Admin not found." (e.g, ID100) is displayed when there is no data on the database
        http://localhost:3000/admins/admin-list/100

Note: The edit button does not work as of this PR

## Future improvement

- Implement edit profile function
- Add redirection from admin list page to admin profile page
