### PR TITLE
Set the time limitation on Prisma

### DIFF
--- a/backend/prisma/prismaClient.ts
+++ b/backend/prisma/prismaClient.ts
@@ -1,3 +1,9 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+export const prisma = new PrismaClient({
+  transactionOptions: {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    maxWait: 5000, // default: 2000
+    timeout: 10000, // default: 5000
+  },
+});


### PR DESCRIPTION
## Overview
To solve the timeout problem, set the time limitation on Prisma.

We can't see if this bug is fixed in the local environment, so after merging it to main, I will check it.
So, please check only the code at this stage.