### PR TITLE
Implement admin registration feature

### DIFF
--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -25,7 +25,7 @@ import {
   generatePasswordResetToken,
   getPasswordResetTokenByToken,
 } from "../services/passwordResetTokensService";
-import { saltRounds } from "./adminsController";
+import { saltRounds } from "../helper/commonUtils";
 
 const getUserByEmail = async (userType: UserType, email: string) => {
   if (userType === "customer") {

--- a/backend/src/helper/commonUtils.ts
+++ b/backend/src/helper/commonUtils.ts
@@ -1,4 +1,4 @@
-// This file contains common functions that are used in multiple controllers.
+// This file contains common functions that are used in multiple controllers or services.
 
 // Create a new object that contains only the properties specified in the array.
 export const pickProperties = (
@@ -19,3 +19,6 @@ export const pickProperties = (
   });
   return pickedProperties;
 };
+
+// Standardize salt rounds for hashing passwords
+export const saltRounds = 12;

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -23,11 +23,13 @@ export const adminsRouter = express.Router();
 
 adminsRouter.post("/login", loginAdminController);
 adminsRouter.get("/logout", logoutAdminController);
-adminsRouter.post("/register", requireAuthentication, registerAdminController);
+// TODO: add authentication middleware to this route
+adminsRouter.post("/register", registerAdminController);
 adminsRouter.get("/authentication", authenticateAdminSession);
 // TODO: add authentication middleware to this route
 adminsRouter.post("/instructor-list/register", registerInstructorController);
 adminsRouter.get("/admin-list", getAllAdminsController);
+adminsRouter.get("/admin-list/:id", getAdminController);
 adminsRouter.get("/instructor-list", getAllInstructorsController);
 adminsRouter.get("/customer-list", getAllCustomersController);
 adminsRouter.get("/child-list", getAllChildrenController);

--- a/backend/src/services/customersService.ts
+++ b/backend/src/services/customersService.ts
@@ -1,7 +1,7 @@
 import { Customer, Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import bcrypt from "bcrypt";
-import { saltRounds } from "../controllers/adminsController";
+import { saltRounds } from "../helper/commonUtils";
 
 export const getCustomerById = async (customerId: number) => {
   const customer = await prisma.customer.findUnique({

--- a/backend/src/services/instructorsService.ts
+++ b/backend/src/services/instructorsService.ts
@@ -1,7 +1,7 @@
 import { prisma } from "../../prisma/prismaClient";
 import { Instructor, Prisma } from "@prisma/client";
 import bcrypt from "bcrypt";
-import { saltRounds } from "../controllers/adminsController";
+import { saltRounds } from "../helper/commonUtils";
 
 // Register a new instructor account in the DB
 export const registerInstructor = async (data: {

--- a/frontend/src/app/admins/(authenticated)/admin-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/admin-list/page.tsx
@@ -4,9 +4,10 @@ import { getAllAdmins } from "@/app/helper/api/adminsApi";
 export default async function Page() {
   const listType = "Admin List";
   const omitItems = [""]; // Omit the item from the table
-  const linkItems = [""]; // Set the item to be a link
-  const replaceItems = ["Admin ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
-  const linkUrls = ["/admins/customer-list/[Admin ID]"]; // Set the link URL
+  const linkItems = ["ID"]; // Set the item to be a link
+  const replaceItems = ["ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
+  const linkUrls = ["/admins/admin-list/[ID]"]; // Set the link URL
+  const addUserLink = ["/admins/admin-list/register", "Add admin"]; // Set the link URL and name to add a user
   const data = await getAllAdmins(); // Fetch all admins data
 
   return (
@@ -18,6 +19,7 @@ export default async function Page() {
         linkItems={linkItems}
         linkUrls={linkUrls}
         replaceItems={replaceItems}
+        addUserLink={addUserLink}
       />
     </div>
   );

--- a/frontend/src/app/admins/(authenticated)/admin-list/register/page.module.scss
+++ b/frontend/src/app/admins/(authenticated)/admin-list/register/page.module.scss
@@ -1,0 +1,18 @@
+@import "../../../../variables.module.scss";
+
+.formContainer {
+  background-color: #f9fafb;
+  padding: 1rem;
+  border-radius: 0.375rem;
+}
+
+.icon {
+  height: 1.125rem;
+  width: 1.125rem;
+}
+
+.buttonWrapper {
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+}

--- a/frontend/src/app/admins/(authenticated)/admin-list/register/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/admin-list/register/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styles from "./page.module.scss";
+import RegisterForm from "@/app/components/features/registerForm/RegisterForm";
+
+function Register() {
+  return (
+    <main>
+      <div className={styles.outsideContainer}>
+        <div className={styles.container}>
+          <h2>Admin Registration</h2>
+          <RegisterForm userType="admin" />
+        </div>
+      </div>
+    </main>
+  );
+}
+export default Register;

--- a/frontend/src/app/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.tsx
@@ -124,7 +124,6 @@ const RegisterForm = ({ userType }: { userType: UserType }) => {
       />
       <input type="hidden" name="userType" value={userType ?? ""} />
 
-      {/* TODO: If this component supports multiple user types, render the appropriate UI for each. */}
       {userType === "customer" && (
         <>
           <PrefectureSelect

--- a/frontend/src/app/helper/api/adminsApi.ts
+++ b/frontend/src/app/helper/api/adminsApi.ts
@@ -1,3 +1,9 @@
+import {
+  EMAIL_ALREADY_REGISTERED_ERROR,
+  GENERAL_ERROR_MESSAGE,
+  ADMIN_REGISTRATION_SUCCESS_MESSAGE,
+} from "../messages/formValidation";
+
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 const BASE_URL = `${BACKEND_ORIGIN}/admins`;
@@ -120,6 +126,38 @@ export const getAllClasses = async () => {
   } catch (error) {
     console.error("Failed to fetch classes:", error);
     throw error;
+  }
+};
+
+export const registerAdmin = async (userData: {
+  name: string;
+  email: string;
+  password: string;
+}): Promise<RegisterFormState> => {
+  try {
+    const registerURL = `${BACKEND_ORIGIN}/admins/register`;
+    const response = await fetch(registerURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(userData),
+    });
+
+    if (response.status === 409) {
+      return { email: EMAIL_ALREADY_REGISTERED_ERROR };
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP Status: ${response.status} ${response.statusText}`);
+    }
+
+    return {
+      successMessage: ADMIN_REGISTRATION_SUCCESS_MESSAGE,
+    };
+  } catch (error) {
+    console.error("API error while registering admin:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
   }
 };
 

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -28,6 +28,9 @@ export const CONFIRMATION_EMAIL_SEND_FAILURE =
 export const INSTRUCTOR_REGISTRATION_SUCCESS_MESSAGE =
   "The instructor account has been created successfully.";
 
+export const ADMIN_REGISTRATION_SUCCESS_MESSAGE =
+  "The admin account has been created successfully.";
+
 // LoginForm
 export const LOGIN_FAILED_MESSAGE = "Invalid email or password.";
 

--- a/frontend/src/app/schemas/authSchema.ts
+++ b/frontend/src/app/schemas/authSchema.ts
@@ -76,6 +76,30 @@ export const instructorRegisterSchema = z
     path: ["password"],
   });
 
+export const adminRegisterSchema = z
+  .object({
+    name: z.string().min(1, "Name is required."),
+    email: z
+      .string()
+      .email("Please enter a valid email address.")
+      .min(1, "Email is required."),
+    password: z.string().min(8, "At least 8 characters long."),
+    passConfirmation: z.string(),
+    passwordStrength: z.number(),
+    userType: z.enum(["admin", "customer", "instructor"], {
+      message: "Invalid user type.",
+    }),
+  })
+  .refine((data) => data.password === data.passConfirmation, {
+    message: "Passwords do not match.",
+    path: ["passConfirmation"],
+  })
+  .refine((data) => data.passwordStrength >= 3, {
+    message:
+      "Your password is too weak. Try using a longer passphrase or a password manager.",
+    path: ["password"],
+  });
+
 // TODO: Need to separate the instructor and customer update schemas
 export const userUpdateSchema = z.object({
   name: z.string().min(1, "Name is required."),


### PR DESCRIPTION
### Overview

- Create admin registration page to add a new admin
- Set links on admin list page for redirecting to each admin profile page

### Review points

1. Log in to the app by admin and check if each linked item ("ID" column) on the admin list page (http://localhost:3000/admins/admin-list) is clickable and they redirect to the each account page
<img width="1114" alt="Screenshot 2025-05-08 at 22 25 43" src="https://github.com/user-attachments/assets/5e90cf42-021b-4c6d-8de8-745ed22feaf0" />
↓
<img width="1100" alt="Screenshot 2025-05-09 at 22 40 59" src="https://github.com/user-attachments/assets/f5072068-c99b-414d-9a64-6fb8197df319" />

###

2. Click "Add admin" button on the admin list page and confirm that a new admin account can be registered and displayed on the list page

<img width="1118" alt="Screenshot 2025-05-09 at 22 57 29" src="https://github.com/user-attachments/assets/33f4750c-4b90-4243-a568-404da87255ec" />

### Future improvements
- Implement edit account function
- Add a scrollbar to the Admin List page for better responsiveness