### PR TITLE
64 remove instructor email verification

### DIFF
--- a/backend/prisma/migrations/20250520153506_remove_email_verified/migration.sql
+++ b/backend/prisma/migrations/20250520153506_remove_email_verified/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `emailVerified` on the `Instructor` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Instructor" DROP COLUMN "emailVerified";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,7 +18,6 @@ model Instructor {
   id                              Int                               @id @default(autoincrement())
   name                            String
   email                           String                            @unique
-  emailVerified                   DateTime?
   password                        String
   instructorAvailability          InstructorAvailability[]
   classes                         Class[]

--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -3,21 +3,18 @@ import bcrypt from "bcrypt";
 import {
   getCustomerByEmail,
   updateCustomerPassword,
-  verifyCustomerEmail,
 } from "../services/customersService";
 import {
   getInstructorByEmail,
   updateInstructorPassword,
-  verifyInstructorEmail,
 } from "../services/instructorsService";
 import {
   deleteVerificationToken,
   generateVerificationToken,
-  getVerificationTokenByToken,
 } from "../services/verificationTokensService";
 import {
+  resendVerificationEmail,
   sendPasswordResetEmail,
-  sendVerificationEmail,
   UserType,
 } from "../helper/mail";
 import {
@@ -26,6 +23,7 @@ import {
   getPasswordResetTokenByToken,
 } from "../services/passwordResetTokensService";
 import { saltRounds } from "../helper/commonUtils";
+import { Customer } from "@prisma/client";
 
 const getUserByEmail = async (userType: UserType, email: string) => {
   if (userType === "customer") {
@@ -62,23 +60,27 @@ export const authenticateUserController = async (
       return res.sendStatus(401);
     }
 
-    // TODO: Remove the 'userType === "customer"' condition if email verification is required for instructors too.
-    if (userType === "customer" && !user.emailVerified) {
-      // Resend email to verify the registered email address
-      const verificationToken = await generateVerificationToken(email);
+    // Email verification is only required for customers.
+    if (userType === "customer") {
+      const customer = user as Customer;
 
-      const sendResult = await sendVerificationEmail(
-        verificationToken.email,
-        user.name,
-        verificationToken.token,
-        userType,
-      );
+      // Resend email to verify the registered email address if it is not verified yet.
+      if (!customer.emailVerified) {
+        const verificationToken = await generateVerificationToken(email);
 
-      if (!sendResult.success) {
-        await deleteVerificationToken(email);
-        return res.sendStatus(503); // Failed to send password reset email. 503 Service Unavailable
+        const resendResult = await resendVerificationEmail(
+          verificationToken.email,
+          user.name,
+          verificationToken.token,
+        );
+
+        if (!resendResult.success) {
+          await deleteVerificationToken(email);
+          return res.sendStatus(503); // Failed to resend verification email. 503 Service Unavailable
+        }
+
+        return res.sendStatus(403); // Email is not verified yet. 403 Forbidden
       }
-      return res.sendStatus(403); // Email is not verified yet. 403 Forbidden
     }
 
     res.status(200).json({ id: user.id });
@@ -87,61 +89,6 @@ export const authenticateUserController = async (
       error,
       context: {
         email: normalizedEmail,
-        time: new Date().toISOString(),
-      },
-    });
-    res.sendStatus(500);
-  }
-};
-
-export const verifyUserEmailController = async (
-  req: Request,
-  res: Response,
-) => {
-  const { token, userType } = req.body;
-
-  if (!token || !userType) {
-    return res.sendStatus(400);
-  }
-
-  try {
-    const existingToken = await getVerificationTokenByToken(token);
-
-    if (!existingToken) {
-      return res.sendStatus(404);
-    }
-
-    const existingUser = await getUserByEmail(userType, existingToken.email);
-
-    if (!existingUser) {
-      return res.sendStatus(404);
-    }
-
-    // This is for cases where a user who has already been verified clicks the email link again.
-    if (existingUser.emailVerified) {
-      return res.sendStatus(200);
-    }
-
-    const isTokenExpired = new Date(existingToken.expires) < new Date();
-
-    if (isTokenExpired) {
-      return res.sendStatus(410); // 410 Gone
-    }
-
-    if (userType === "customer") {
-      await verifyCustomerEmail(existingUser.id, existingToken.email);
-      // TODO: Remove this section if we decide not to require email verification for instructors
-    } else if (userType === "instructor") {
-      await verifyInstructorEmail(existingUser.id, existingToken.email);
-    }
-
-    return res.sendStatus(200);
-  } catch (error) {
-    console.error("Error verifying user email", {
-      error,
-      context: {
-        token,
-        userType,
         time: new Date().toISOString(),
       },
     });

--- a/backend/src/routes/customersRouter.ts
+++ b/backend/src/routes/customersRouter.ts
@@ -8,6 +8,7 @@ import {
   getCustomerByIdController,
   getClassesController,
   getRebookableClassesController,
+  verifyCustomerEmailController,
 } from "../../src/controllers/customersController";
 import { authenticateCustomerSession } from "../../src/middlewares/auth.middleware";
 import {
@@ -20,6 +21,7 @@ export const customersRouter = express.Router();
 // http://localhost:4000/customers
 
 customersRouter.post("/register", registerCustomerController);
+customersRouter.patch("/verify-email", verifyCustomerEmailController);
 
 customersRouter.get("/:id/subscriptions", getSubscriptionsByIdController);
 customersRouter.get("/:id/customer", parseId, (req, res) =>
@@ -36,5 +38,6 @@ customersRouter.get("/:id/classes", parseId, (req, res) =>
 );
 
 customersRouter.patch("/:id", updateCustomerProfile);
+
 customersRouter.post("/:id/subscription", registerSubscriptionController);
 customersRouter.get("/:id/authentication", authenticateCustomerSession);

--- a/backend/src/routes/usersRouter.ts
+++ b/backend/src/routes/usersRouter.ts
@@ -3,7 +3,6 @@ import {
   authenticateUserController,
   sendUserResetEmailController,
   updatePasswordController,
-  verifyUserEmailController,
 } from "../controllers/usersController";
 
 export const usersRouter = express.Router();
@@ -12,5 +11,4 @@ export const usersRouter = express.Router();
 
 usersRouter.post("/authenticate", authenticateUserController);
 usersRouter.post("/send-password-reset", sendUserResetEmailController);
-usersRouter.patch("/verify-email", verifyUserEmailController);
 usersRouter.patch("/update-password", updatePasswordController);

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -7,7 +7,6 @@ async function insertInstructors() {
   await prisma.instructor.create({
     data: {
       email: "helen@example.com",
-      emailVerified: "2025-03-08T14:31:26.816Z",
       name: "Helene Gay Santos",
       nickname: "Helen",
       icon: "helen-1.jpg",
@@ -23,7 +22,6 @@ async function insertInstructors() {
   await prisma.instructor.create({
     data: {
       email: "elian@example.com",
-      emailVerified: "2025-03-08T14:31:26.816Z",
       name: "Elian P.Quilisadio",
       nickname: "Elian",
       icon: "elian-1.jpg",

--- a/backend/src/services/instructorsService.ts
+++ b/backend/src/services/instructorsService.ts
@@ -28,7 +28,6 @@ export const registerInstructor = async (data: {
       passcode: data.passcode,
       introductionURL: data.introductionURL,
       nickname: data.nickname,
-      emailVerified: new Date(),
     },
   });
 
@@ -417,21 +416,6 @@ export async function getInstructorProfile(instructorId: number) {
 
   return instructorProfile;
 }
-
-export const verifyInstructorEmail = async (
-  id: number,
-  email: string,
-): Promise<void> => {
-  await prisma.instructor.update({
-    where: {
-      id,
-    },
-    data: {
-      emailVerified: new Date(),
-      email,
-    },
-  });
-};
 
 export const updateInstructorPassword = async (
   id: number,

--- a/frontend/src/app/auth/new-verification/[token]/page.module.scss
+++ b/frontend/src/app/auth/new-verification/[token]/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@import "../../../variables.module.scss";
 
 .outsideContainer {
   display: flex;
@@ -18,12 +18,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 350px;
+  max-width: 360px;
   width: 100%;
-
-  h2 {
-    margin-bottom: 1rem;
-  }
 }
 
 .logo {

--- a/frontend/src/app/auth/new-verification/[token]/page.tsx
+++ b/frontend/src/app/auth/new-verification/[token]/page.tsx
@@ -3,8 +3,23 @@ import styles from "./page.module.scss";
 import Image from "next/image";
 import { Suspense } from "react";
 import Loading from "@/app/components/elements/loading/Loading";
+import { EMAIL_VERIFICATION_TOKEN_NOT_FOUND } from "@/app/helper/messages/formValidation";
+import { verifyCustomerEmail } from "@/app/helper/api/customersApi";
 
-export default function EmailVerificationPage() {
+export default async function EmailVerificationPage({
+  params,
+}: {
+  params: { token: string };
+}) {
+  const token = params.token;
+
+  if (!token) {
+    console.error("Email verification token not found.");
+    throw new Error(EMAIL_VERIFICATION_TOKEN_NOT_FOUND);
+  }
+
+  const resultMessage = await verifyCustomerEmail(token);
+
   return (
     <main className={styles.outsideContainer}>
       <div className={styles.container}>
@@ -16,7 +31,7 @@ export default function EmailVerificationPage() {
           className={styles.logo}
           priority={true}
         />
-        <h2>Email Verification</h2>
+
         <Suspense
           fallback={
             <div className={styles.loaderWrapper}>
@@ -24,7 +39,7 @@ export default function EmailVerificationPage() {
             </div>
           }
         >
-          <EmailVerificationForm />
+          <EmailVerificationForm resultMessage={resultMessage} />
         </Suspense>
       </div>
     </main>

--- a/frontend/src/app/auth/new-verification/[token]/page.tsx
+++ b/frontend/src/app/auth/new-verification/[token]/page.tsx
@@ -3,7 +3,6 @@ import styles from "./page.module.scss";
 import Image from "next/image";
 import { Suspense } from "react";
 import Loading from "@/app/components/elements/loading/Loading";
-import { EMAIL_VERIFICATION_TOKEN_NOT_FOUND } from "@/app/helper/messages/formValidation";
 import { verifyCustomerEmail } from "@/app/helper/api/customersApi";
 
 export default async function EmailVerificationPage({
@@ -12,11 +11,6 @@ export default async function EmailVerificationPage({
   params: { token: string };
 }) {
   const token = params.token;
-
-  if (!token) {
-    console.error("Email verification token not found.");
-    throw new Error(EMAIL_VERIFICATION_TOKEN_NOT_FOUND);
-  }
 
   const resultMessage = await verifyCustomerEmail(token);
 

--- a/frontend/src/app/components/features/emailVerificationForm/EmailVerificationForm.module.scss
+++ b/frontend/src/app/components/features/emailVerificationForm/EmailVerificationForm.module.scss
@@ -1,9 +1,13 @@
 .verificationForm {
-  min-height: 10rem;
+  min-height: 12rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 1rem;
+
+  &__title {
+    text-align: center;
+  }
 
   &__loaderWrapper {
     height: 3rem;
@@ -18,5 +22,6 @@
 
   &__loginLink {
     margin: 0 auto;
+    text-decoration: none;
   }
 }

--- a/frontend/src/app/components/features/emailVerificationForm/EmailVerificationForm.tsx
+++ b/frontend/src/app/components/features/emailVerificationForm/EmailVerificationForm.tsx
@@ -1,92 +1,46 @@
 "use client";
 
-import { verifyUserEmail } from "@/app/helper/api/usersApi";
-import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
-import Loading from "../../elements/loading/Loading";
 import Link from "next/link";
 import styles from "./EmailVerificationForm.module.scss";
-import {
-  EMAIL_VERIFICATION_TOKEN_NOT_FOUND,
-  EMAIL_VERIFICATION_USER_TYPE_ERROR,
-} from "@/app/helper/messages/formValidation";
 import FormValidationMessage from "../../elements/formValidationMessage/FormValidationMessage";
+import { useLanguage } from "@/app/contexts/LanguageContext";
 
-export const EmailVerificationForm = () => {
-  const [message, setMessage] = useState<{
-    type: "success" | "error";
-    text: string;
-  } | null>(null);
-
-  const searchParams = useSearchParams();
-  const token = searchParams.get("token");
-  const userType = searchParams.get("type") as UserType;
-
-  const onSubmit = useCallback(async () => {
-    // Prevents multiple API requests if a message (success or error) is already set.
-    if (message) return;
-
-    if (!token) {
-      setMessage({
-        type: "error",
-        // TODO: Determine the language (jp or en) for the message based on context.
-        text: EMAIL_VERIFICATION_TOKEN_NOT_FOUND,
-      });
-      return;
-    }
-
-    if (!userType || !["customer", "instructor"].includes(userType)) {
-      setMessage({
-        type: "error",
-        // TODO: Determine the language (jp or en) for the message based on context.
-        text: EMAIL_VERIFICATION_USER_TYPE_ERROR,
-      });
-      return;
-    }
-
-    const data = await verifyUserEmail(token, userType);
-
-    if (data.error) {
-      setMessage({ type: "error", text: data.error });
-    } else {
-      setMessage({ type: "success", text: data.success! });
-    }
-  }, [token, userType, message]);
-
-  useEffect(() => {
-    if (!message) {
-      onSubmit();
-    }
-  }, [onSubmit, message]);
+export const EmailVerificationForm = ({
+  resultMessage,
+}: {
+  resultMessage: {
+    success?: { ja: string; en: string };
+    error?: { ja: string; en: string };
+  };
+}) => {
+  const { language } = useLanguage();
 
   return (
     <div className={styles.verificationForm}>
-      {!message ? (
-        <div className={styles.verificationForm__loaderWrapper}>
-          <Loading />
-        </div>
-      ) : (
-        <>
-          {/* {message?.type === "success" && <p>{message.text}</p>} */}
-          {message?.type === "success" && (
-            <FormValidationMessage type="success" message={message.text} />
-          )}
+      <h2 className={styles.verificationForm__title}>
+        {language === "ja" ? "メールアドレスの認証" : "Email Verification"}
+      </h2>
 
-          {message?.type === "error" && (
-            <FormValidationMessage type="error" message={message.text} />
-          )}
-          <Link
-            className={styles.verificationForm__loginLink}
-            href={
-              userType === "customer"
-                ? "/customers/login"
-                : "/instructors/login"
-            }
-          >
-            Login here
-          </Link>
-        </>
+      {resultMessage.success && (
+        <FormValidationMessage
+          type="success"
+          message={resultMessage.success[language]}
+        />
       )}
+
+      {resultMessage.error && (
+        <FormValidationMessage
+          type="error"
+          message={resultMessage.error[language]}
+        />
+      )}
+
+      <Link
+        className={styles.verificationForm__loginLink}
+        href={"/customers/login"}
+      >
+        {language === "ja" ? "ログイン" : "Login"}
+      </Link>
     </div>
   );
 };

--- a/frontend/src/app/helper/api/usersApi.ts
+++ b/frontend/src/app/helper/api/usersApi.ts
@@ -1,11 +1,7 @@
 import {
   CONFIRMATION_EMAIL_RESEND_FAILURE,
   EMAIL_NOT_REGISTERED_MESSAGE,
-  EMAIL_VERIFICATION_FAILED_MESSAGE,
   EMAIL_VERIFICATION_RESENT_NOTICE,
-  EMAIL_VERIFICATION_SUCCESS_MESSAGE,
-  EMAIL_VERIFICATION_TOKEN_EXPIRED,
-  EMAIL_VERIFICATION_UNEXPECTED_ERROR,
   GENERAL_ERROR_MESSAGE,
   GENERAL_ERROR_MESSAGE_JA,
   LOGIN_FAILED_MESSAGE,
@@ -60,48 +56,6 @@ export const authenticateUser = async (
     return {
       errorMessage:
         language === "ja" ? GENERAL_ERROR_MESSAGE_JA : GENERAL_ERROR_MESSAGE,
-    };
-  }
-};
-
-export const verifyUserEmail = async (
-  token: string,
-  userType: UserType,
-): Promise<{ success?: string; error?: string }> => {
-  const apiUrl = `${BACKEND_ORIGIN}/users/verify-email`;
-  const headers = { "Content-Type": "application/json" };
-  const body = JSON.stringify({
-    token,
-    userType,
-  });
-
-  const statusErrorMessages: Record<number, string> = {
-    400: EMAIL_VERIFICATION_FAILED_MESSAGE,
-    404: EMAIL_VERIFICATION_FAILED_MESSAGE,
-    410: EMAIL_VERIFICATION_TOKEN_EXPIRED,
-  };
-
-  try {
-    const response = await fetch(apiUrl, {
-      method: "PATCH",
-      headers,
-      body,
-    });
-
-    const errorMessage = statusErrorMessages[response.status];
-    if (errorMessage) {
-      return { error: errorMessage };
-    }
-
-    if (!response.ok) {
-      throw new Error(`HTTP Status: ${response.status} ${response.statusText}`);
-    }
-
-    return { success: EMAIL_VERIFICATION_SUCCESS_MESSAGE };
-  } catch (error) {
-    console.error("API error while verifying user email:", error);
-    return {
-      error: EMAIL_VERIFICATION_UNEXPECTED_ERROR,
     };
   }
 };

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -50,9 +50,6 @@ export const EMAIL_VERIFICATION_RESENT_NOTICE = {
 };
 
 // EmailVerificationForm
-export const EMAIL_VERIFICATION_TOKEN_NOT_FOUND =
-  "We couldn't verify your request. Please click the confirmation button in the email again. / 認証リクエストを確認できませんでした。もう一度メール内の認証ボタンをクリックしてください。";
-
 export const EMAIL_VERIFICATION_SUCCESS_MESSAGE = {
   ja: "メールアドレスが認証されました。ログインページからログインしてください。",
   en: "Your email address has been verified. Please log in from the login page.",

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -45,28 +45,38 @@ export const CONFIRMATION_EMAIL_RESEND_FAILURE = {
 };
 
 export const EMAIL_VERIFICATION_RESENT_NOTICE = {
-  ja: "メールアドレスがまだ認証されていません。確認リンクをメールで再送しましたのでご確認ください。",
+  ja: "メールアドレスがまだ認証されていません。認証リンクをメールで再送しましたのでご確認ください。",
   en: "Your email address is not verified yet. We have resent the verification link via email.",
 };
 
 // EmailVerificationForm
 export const EMAIL_VERIFICATION_TOKEN_NOT_FOUND =
-  "We couldn't verify your request. Please click the confirmation button in the email again.";
+  "We couldn't verify your request. Please click the confirmation button in the email again. / 認証リクエストを確認できませんでした。もう一度メール内の認証ボタンをクリックしてください。";
 
-export const EMAIL_VERIFICATION_USER_TYPE_ERROR =
-  "We couldn't determine your account type. Please click the confirmation button in the email again.";
+export const EMAIL_VERIFICATION_SUCCESS_MESSAGE = {
+  ja: "メールアドレスが認証されました。ログインページからログインしてください。",
+  en: "Your email address has been verified. Please log in from the login page.",
+};
 
-export const EMAIL_VERIFICATION_SUCCESS_MESSAGE =
-  "Your email address has been verified. Please log in from the login page.";
+export const EMAIL_VERIFICATION_FAILED_MESSAGE = {
+  ja: "認証リクエストを確認できませんでした。認証メールが複数届いている場合は、最新のメールの認証ボタンをクリックしてみてください。うまくいかない場合は、下のリンクからログインし、新しい認証メールをリクエストしてください。",
+  en: "We couldn't verify your request. Please click the confirmation button in the latest verification email. If that doesn't work, try logging in using the link below to request a new one.",
+};
 
-export const EMAIL_VERIFICATION_FAILED_MESSAGE =
-  "We couldn't verify your request. Please click the confirmation button in the email again. If that doesn't work, try logging in using the link below to request a new one.";
+export const EMAIL_VERIFICATION_TOKEN_EXPIRED = {
+  ja: "認証リンクの有効期限が切れています。新しいリンクをメールで再送しましたのでご確認ください。",
+  en: "The confirmation link has expired. A new link has been sent to your email, so please check it.",
+};
 
-export const EMAIL_VERIFICATION_TOKEN_EXPIRED =
-  "This confirmation link has expired. Please try logging in using the link below to request a new confirmation email.";
+export const EMAIL_VERIFICATION_UNEXPECTED_ERROR = {
+  ja: "認証リクエストを確認できませんでした。しばらくしてから下のリンクからログインし、新しい認証メールをリクエストしてください。問題が解決しない場合は、スタッフまでお問い合わせください。ご不便をおかけして申し訳ありません。",
+  en: "We couldn't verify your request. Please try logging in using the link below to request a new confirmation link later. If the issue persists, contact our staff. We apologize for the inconvenience.",
+};
 
-export const EMAIL_VERIFICATION_UNEXPECTED_ERROR =
-  "Something went wrong. Please try logging in using the link below. If that doesn't work, click the confirmation button in the email again.";
+export const CONFIRMATION_LINK_EXPIRED_RESEND_FAILED = {
+  ja: "認証リンクの有効期限が切れていたため再送を試みましたが、失敗しました。しばらくしてから下のリンクからログインし、新しい認証メールをリクエストしてください。問題が解決しない場合は、スタッフまでお問い合わせください。ご不便をおかけして申し訳ありません。",
+  en: "The confirmation link has expired, and resending it failed. Please try logging in using the link below to request a new one later. If the issue persists, contact our staff. We apologize for the inconvenience.",
+};
 
 // ForgotPasswordForm
 export const PASSWORD_RESET_INSTRUCTION =


### PR DESCRIPTION
### Overview

1. Removes email verification logic related to instructors
2. Converts `EmailVerificationPage` to a server component
3. Adds Japanese language support to `EmailVerificationForm`

### Preparation for Review

1. Set your browser's language to Japanese.
2. Run `npm run build` and `npm run prisma:init` in the `/backend` directory.

### Review Points

1. Create a new customer account using `kiv-developers@googlegroups.com` and confirm that a verification email is sent.
![スクリーンショット 2025-05-22 午前8 44 35](https://github.com/user-attachments/assets/c5382c6b-0596-42a3-ab45-466ff9a63e31)
![スクリーンショット 2025-05-22 午前8 48 40](https://github.com/user-attachments/assets/baf21d79-58e2-494a-9d9a-a9c7e985efdc)

2. Using Prisma Studio, update the `expires` field of the corresponding `VerificationToken` to a past date (e.g., yesterday) and save the change.
![スクリーンショット 2025-05-22 午前8 51 02](https://github.com/user-attachments/assets/275bcd95-0b77-4b08-bb2c-ffb68fa5500e)

3. Click the 「メールアドレスを認証」 button in the email and confirm that the message shown in the screenshot below appears.
![スクリーンショット 2025-05-22 午前9 02 42](https://github.com/user-attachments/assets/0d9c32e6-b656-495f-9506-a89b75960412)

4. Return to the inbox and confirm that a new verification email has been sent.
![スクリーンショット 2025-05-22 午前8 58 31](https://github.com/user-attachments/assets/b904d5f5-b5a7-40fd-88c5-9759607e865e)

5. Click the 「メールアドレスを認証」 button again and confirm that the message in the screenshot below appears.
![スクリーンショット 2025-05-22 午前9 01 41](https://github.com/user-attachments/assets/cf4c43a1-fbef-46a0-bc29-1738bf08a712)



