### PR TITLE
Implement admin profile edit feature

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -1,7 +1,11 @@
 import { Request, Response } from "express";
 import { kv } from "@vercel/kv";
 import { registerAdmin, getAdminByEmail } from "../services/adminsService";
-import { getAllAdmins, getAdminById } from "../services/adminsService";
+import {
+  getAllAdmins,
+  getAdminById,
+  updateAdmin,
+} from "../services/adminsService";
 import {
   getAllInstructors,
   registerInstructor,
@@ -96,6 +100,39 @@ export const registerAdminController = async (req: Request, res: Response) => {
   } catch (error) {
     console.error("Error registering admin", { error });
     res.sendStatus(500);
+  }
+};
+
+// Update the applicable admin data
+export const updateAdminProfileController = async (
+  req: Request,
+  res: Response,
+) => {
+  const adminId = parseInt(req.params.id);
+  const { name, email } = req.body;
+
+  try {
+    if (!name || !email) {
+      return res.sendStatus(400);
+    }
+
+    // Normalize email
+    const normalizedEmail = email.trim().toLowerCase();
+
+    // Check if the updated email already exists
+    const existingAdmin = await getAdminByEmail(normalizedEmail);
+    if (existingAdmin && existingAdmin.id !== adminId) {
+      return res.sendStatus(409);
+    }
+
+    const admin = await updateAdmin(adminId, name, email);
+
+    res.status(200).json({
+      message: "Admin is updated successfully",
+      admin,
+    });
+  } catch (error) {
+    res.status(500).json({ error: `${error}` });
   }
 };
 

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -4,6 +4,7 @@ import {
   logoutAdminController,
   registerAdminController,
   registerInstructorController,
+  updateAdminProfileController,
   getAdminController,
   getAllAdminsController,
   getAllInstructorsController,
@@ -25,6 +26,7 @@ adminsRouter.post("/login", loginAdminController);
 adminsRouter.get("/logout", logoutAdminController);
 // TODO: add authentication middleware to this route
 adminsRouter.post("/register", registerAdminController);
+adminsRouter.patch("/:id", updateAdminProfileController);
 adminsRouter.get("/authentication", authenticateAdminSession);
 // TODO: add authentication middleware to this route
 adminsRouter.post("/instructor-list/register", registerInstructorController);

--- a/backend/src/services/adminsService.ts
+++ b/backend/src/services/adminsService.ts
@@ -22,10 +22,34 @@ export const registerAdmin = async (data: {
   return;
 };
 
+// Update the selected admin
+export const updateAdmin = async (id: number, name: string, email: string) => {
+  try {
+    // Update the admin data.
+    const admin = await prisma.admins.update({
+      where: {
+        id,
+      },
+      data: {
+        name,
+        email,
+      },
+    });
+    return admin;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to update the admin data.");
+  }
+};
+
 // Fetch all admins information
 export const getAllAdmins = async () => {
   try {
-    return await prisma.admins.findMany();
+    return await prisma.admins.findMany({
+      orderBy: {
+        id: "asc",
+      },
+    });
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to fetch admins.");

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
@@ -34,24 +34,6 @@
   margin-right: 1rem;
 }
 
-.urlInfo {
-  display: flex;
-  font-size: 0.8rem;
-}
-
-.url {
-  color: $blue_primary;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
-.info {
-  font-size: 0.8rem;
-}
-
 // name
 .adminName {
   display: flex;
@@ -87,7 +69,7 @@
 // email
 .email {
   &__inputField {
-    margin: 0px 50px 0px 0px;
+    margin: 0px 200px 0px 0px;
     padding: 3px 6px;
     font-size: 20px;
     font-weight: 400;

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
@@ -3,7 +3,8 @@
 import styles from "./AdminProfile.module.scss";
 import { useState, useEffect } from "react";
 import { useFormState } from "react-dom";
-import { updateUser } from "@/app/actions/updateUser";
+import { useFormMessages } from "@/app/hooks/useFormMessages";
+import { updateAdminAction } from "@/app/actions/updateUser";
 import InputField from "../elements/inputField/InputField";
 import ActionButton from "../elements/buttons/actionButton/ActionButton";
 import { CheckIcon } from "@heroicons/react/24/outline";
@@ -19,7 +20,9 @@ function AdminProfile({
   admin: Admin | string;
   isAdminAuthenticated?: boolean;
 }) {
-  const [updateResultState, formAction] = useFormState(updateUser, {});
+  const [updateResultState, formAction] = useFormState(updateAdminAction, {});
+  const { localMessages, clearErrorMessage } =
+    useFormMessages(updateResultState);
   const [previousAdmin, setPreviousAdmin] = useState<Admin | null>(
     typeof admin !== "string" ? admin : null,
   );
@@ -38,6 +41,7 @@ function AdminProfile({
   ) => {
     if (latestAdmin) {
       setLatestAdmin({ ...latestAdmin, [field]: e.target.value });
+      clearErrorMessage(field);
     }
   };
 
@@ -45,6 +49,7 @@ function AdminProfile({
     if (latestAdmin) {
       setLatestAdmin(previousAdmin);
       setIsEditing(false);
+      clearErrorMessage("email");
     }
   };
 
@@ -97,6 +102,7 @@ function AdminProfile({
                     name="email"
                     type="email"
                     value={latestAdmin.email}
+                    error={localMessages.email}
                     onChange={(e) => handleInputChange(e, "email")}
                     className={`${styles.email__inputField} ${isEditing ? styles.editable : ""}`}
                   />

--- a/frontend/src/app/components/elements/inputField/InputField.tsx
+++ b/frontend/src/app/components/elements/inputField/InputField.tsx
@@ -1,27 +1,39 @@
 import clsx from "clsx";
+import FormValidationMessage from "../formValidationMessage/FormValidationMessage";
 
 function InputField({
   name,
+  error,
   value,
   onChange,
   type = "text",
   className,
 }: {
   name?: string;
+  error?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   type?: string;
   className?: string;
 }) {
   return (
-    <input
-      name={name}
-      className={clsx(className)}
-      type={type}
-      value={value}
-      onChange={onChange}
-      required
-    />
+    <div>
+      <input
+        name={name}
+        className={clsx(className)}
+        type={type}
+        value={value}
+        onChange={onChange}
+        required
+      />
+      {error && (
+        <FormValidationMessage
+          type="error"
+          message={error}
+          className="textInputError"
+        />
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import styles from "./InstructorProfile.module.scss";
 import { useState, useEffect } from "react";
 import { useFormState } from "react-dom";
-import { updateUser } from "@/app/actions/updateUser";
+import { updateInstructorAction } from "@/app/actions/updateUser";
 import InputField from "../../elements/inputField/InputField";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
 import { CheckIcon } from "@heroicons/react/24/outline";
@@ -26,7 +26,10 @@ function InstructorProfile({
   instructor: Instructor | string;
   isAdminAuthenticated?: boolean;
 }) {
-  const [updateResultState, formAction] = useFormState(updateUser, {});
+  const [updateResultState, formAction] = useFormState(
+    updateInstructorAction,
+    {},
+  );
   const [previousInstructor, setPreviousInstructor] =
     useState<Instructor | null>(
       typeof instructor !== "string" ? instructor : null,

--- a/frontend/src/app/helper/api/adminsApi.ts
+++ b/frontend/src/app/helper/api/adminsApi.ts
@@ -3,6 +3,7 @@ import {
   GENERAL_ERROR_MESSAGE,
   ADMIN_REGISTRATION_SUCCESS_MESSAGE,
 } from "../messages/formValidation";
+import { ERROR_PAGE_MESSAGE_EN } from "../messages/generalMessages";
 
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
@@ -153,6 +154,46 @@ export const registerAdmin = async (userData: {
     return {
       successMessage: ADMIN_REGISTRATION_SUCCESS_MESSAGE,
     };
+  } catch (error) {
+    console.error("API error while registering admin:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
+  }
+};
+
+// PATCH admin data
+export const updateAdmin = async (
+  adminId: number,
+  adminName: string,
+  adminEmail: string,
+): Promise<UpdateFormState> => {
+  try {
+    // Define the data to be sent to the server side.
+    const apiURL = `${BACKEND_ORIGIN}/admins/${adminId}`;
+    const headers = { "Content-Type": "application/json" };
+    const body = JSON.stringify({
+      name: adminName,
+      email: adminEmail,
+    });
+
+    const response = await fetch(apiURL, {
+      method: "PATCH",
+      headers,
+      body,
+    });
+
+    if (response.status === 409) {
+      return { email: EMAIL_ALREADY_REGISTERED_ERROR };
+    }
+
+    const data = await response.json();
+
+    if (response.status !== 200) {
+      return { errorMessage: data.message || ERROR_PAGE_MESSAGE_EN };
+    }
+
+    return data;
   } catch (error) {
     console.error("API error while registering admin:", error);
     return {

--- a/frontend/src/app/schemas/authSchema.ts
+++ b/frontend/src/app/schemas/authSchema.ts
@@ -100,8 +100,7 @@ export const adminRegisterSchema = z
     path: ["password"],
   });
 
-// TODO: Need to separate the instructor and customer update schemas
-export const userUpdateSchema = z.object({
+export const instructorUpdateSchema = z.object({
   name: z.string().min(1, "Name is required."),
   nickname: z.string().min(1, "Nickname is required."),
   email: z
@@ -123,6 +122,17 @@ export const userUpdateSchema = z.object({
   // .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
   //   message: "URL must start with http:// or https://",
   // }),
+  userType: z.enum(["admin", "customer", "instructor"], {
+    message: "Invalid user type.",
+  }),
+});
+
+export const adminUpdateSchema = z.object({
+  name: z.string().min(1, "Name is required."),
+  email: z
+    .string()
+    .email("Please enter a valid email address.")
+    .min(1, "Email is required."),
   userType: z.enum(["admin", "customer", "instructor"], {
     message: "Invalid user type.",
   }),


### PR DESCRIPTION
## Overview

- Implement admin profile edit feature for admin dashboard

## Review points

1. Log in to the app as admin (e.g., email: `admin@example.com` / password: `admin`) and move to one admin's profile page (e.g., `http://localhost:3000/admins/admin-list/1`).
2. Click "Edit" button and update the email to existing one (ID2: `aaa@aaa.com`) and then confirm that duplication message will be displayed.

###
<img width="800" alt="Screenshot 2025-05-24 at 23 21 21" src="https://github.com/user-attachments/assets/d4f7829d-f859-425b-addd-5302c91200d1" />

###
3. Once the profile has been successfully updated, go to the admin list page and verify that the edited information is shown correctly.

###
<img width="800" alt="Screenshot 2025-05-24 at 23 24 16" src="https://github.com/user-attachments/assets/a9a770d2-086e-43e0-acb5-4ebce3a5f9cf" />
↓
<img width="1108" alt="Screenshot 2025-05-24 at 23 26 25" src="https://github.com/user-attachments/assets/d9e9395e-c07a-4ae0-885d-e5f9521b90b6" />

## Future improvements

1. Implement delete admin account feature
2. Add a scrollbar to admin List page for better responsiveness

## Consideration

- Currently the app has two similar components:
    `frontend/src/app/components/elements/textInput/TextInput.tsx`
    `frontend/src/app/components/elements/inputField/InputField.tsx` (I have created the one based on [the previous PR's feedback comment](https://github.com/KivSystemAdmin/aaasobo-management-system/pull/27#discussion_r1974163976))
   Do you think it would be better to unify them into a single common component? I would appreciate hearing your thoughts!
