### PR TITLE
Implement plan registration feature

### DIFF
--- a/backend/prisma/migrations/20250623092512_update_plan_model/migration.sql
+++ b/backend/prisma/migrations/20250623092512_update_plan_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Plan` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Plan_name_key" ON "Plan"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -131,9 +131,9 @@ model ClassAttendance {
 
 model Plan {
   id               Int            @id @default(autoincrement())
-  name             String
-  description      String
+  name             String         @unique
   weeklyClassTimes Int
+  description      String
   subscription     Subscription[]
 }
 

--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -19,7 +19,7 @@ import {
 import { getClassesWithinPeriod } from "../services/classesService";
 import { getAllCustomers } from "../services/customersService";
 import { getAllChildren } from "../services/childrenService";
-import { getAllPlans } from "../services/plansService";
+import { getAllPlans, registerPlan } from "../services/plansService";
 
 // Register Admin
 export const registerAdminController = async (req: Request, res: Response) => {
@@ -371,6 +371,40 @@ export const getAllPlansController = async (_: Request, res: Response) => {
     res.json({ data });
   } catch (error) {
     res.status(500).json({ error });
+  }
+};
+
+// Register a new plan
+export const registerPlanController = async (req: Request, res: Response) => {
+  const { name, weeklyClassTimes, description } = req.body;
+
+  if (!name || !weeklyClassTimes || !description) {
+    return res.sendStatus(400);
+  }
+
+  // Normalize the plan name
+  const normalizedPlanName = name.trim().toLowerCase();
+
+  try {
+    // Check if the plan with the same name already exists
+    const existingPlans = await getAllPlans();
+    const planExists = existingPlans.some(
+      (plan) => plan.name.trim().toLowerCase() === normalizedPlanName,
+    );
+    if (planExists) {
+      return res.sendStatus(409);
+    }
+
+    await registerPlan({
+      name,
+      weeklyClassTimes,
+      description,
+    });
+
+    res.sendStatus(201);
+  } catch (error) {
+    console.error("Error registering a new plan", { error });
+    res.sendStatus(500);
   }
 };
 

--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -383,13 +383,14 @@ export const registerPlanController = async (req: Request, res: Response) => {
   }
 
   // Normalize the plan name
-  const normalizedPlanName = name.trim().toLowerCase();
+  const normalizedPlanName = name.toLowerCase().replace(/\s/g, "");
 
   try {
     // Check if the plan with the same name already exists
     const existingPlans = await getAllPlans();
     const planExists = existingPlans.some(
-      (plan) => plan.name.trim().toLowerCase() === normalizedPlanName,
+      (plan) =>
+        plan.name.toLowerCase().replace(/\s/g, "") === normalizedPlanName,
     );
     if (planExists) {
       return res.sendStatus(409);

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -2,6 +2,7 @@ import express from "express";
 import {
   registerAdminController,
   registerInstructorController,
+  registerPlanController,
   updateAdminProfileController,
   getAdminController,
   getAllAdminsController,
@@ -27,6 +28,11 @@ adminsRouter.post(
   "/instructor-list/register",
   verifyAuthentication,
   registerInstructorController,
+);
+adminsRouter.post(
+  "/plan-list/register",
+  verifyAuthentication,
+  registerPlanController,
 );
 adminsRouter.get("/admin-list", getAllAdminsController);
 adminsRouter.get("/admin-list/:id", getAdminController);

--- a/backend/src/services/plansService.ts
+++ b/backend/src/services/plansService.ts
@@ -1,5 +1,16 @@
 import { prisma } from "../../prisma/prismaClient";
 
+// Register a new plan in the DB
+export const registerPlan = async (data: {
+  name: string;
+  weeklyClassTimes: number;
+  description: string;
+}) => {
+  await prisma.plan.create({ data });
+
+  return;
+};
+
 // Fetch all plan data.
 export const getAllPlans = async () => {
   try {

--- a/frontend/src/app/actions/registerContent.ts
+++ b/frontend/src/app/actions/registerContent.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { registerPlan } from "../helper/api/plansApi";
+import { GENERAL_ERROR_MESSAGE } from "../helper/messages/formValidation";
+import { extractRegisterValidationErrors } from "../helper/utils/validationErrorUtils";
+import { planRegisterSchema } from "../schemas/authSchema";
+import { revalidatePlanList } from "./revalidate";
+import { getCookie } from "../../middleware";
+
+export async function registerContent(
+  prevState: RegisterFormState | undefined,
+  formData: FormData,
+): Promise<RegisterFormState> {
+  try {
+    const name = formData.get("name");
+    const weeklyClassTimes = Number(formData.get("weeklyClassTimes"));
+    const description = formData.get("description");
+    const categoryType = formData.get("categoryType");
+
+    // Get the cookies from the request headers
+    const cookie = await getCookie();
+
+    let parsedForm;
+    let response;
+
+    switch (categoryType) {
+      case "plan":
+        parsedForm = planRegisterSchema.safeParse({
+          name,
+          weeklyClassTimes,
+          description,
+          cookie,
+        });
+        if (!parsedForm.success) {
+          const validationErrors = parsedForm.error.errors;
+          return extractRegisterValidationErrors(validationErrors);
+        }
+
+        response = await registerPlan({
+          name: parsedForm.data.name,
+          weeklyClassTimes: parsedForm.data.weeklyClassTimes,
+          description: parsedForm.data.description,
+          cookie,
+        });
+
+        // Refresh cached admin data for the admin list page
+        await revalidatePlanList();
+
+        return response;
+
+      default:
+        return {
+          errorMessage: "Invalid category type.",
+        };
+    }
+  } catch (error) {
+    console.error("Unexpected error in registerContent server action:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
+  }
+}

--- a/frontend/src/app/admins/(authenticated)/[id]/plan-list/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/[id]/plan-list/page.tsx
@@ -8,6 +8,7 @@ export default async function Page({ params }: { params: { id: string } }) {
   const linkItems = ["ID"]; // Set the item to be a link
   const replaceItems = ["ID"]; // Replace the item with the value(e.g., ID -> 1,2,3...)
   const linkUrls = [`/admins/${adminId}/plan-list/[ID]`]; // Set the link URL
+  const addUserLink = [`/admins/${adminId}/plan-list/register`, "Add plan"]; // Set the link URL and name to add a user
   const data = await getAllPlans(); // Fetch all plans data
 
   return (
@@ -19,6 +20,7 @@ export default async function Page({ params }: { params: { id: string } }) {
         linkItems={linkItems}
         linkUrls={linkUrls}
         replaceItems={replaceItems}
+        addUserLink={addUserLink}
       />
     </div>
   );

--- a/frontend/src/app/admins/(authenticated)/[id]/plan-list/register/page.module.scss
+++ b/frontend/src/app/admins/(authenticated)/[id]/plan-list/register/page.module.scss
@@ -1,0 +1,18 @@
+@import "../../../../../variables.module.scss";
+
+.formContainer {
+  background-color: #f9fafb;
+  padding: 1rem;
+  border-radius: 0.375rem;
+}
+
+.icon {
+  height: 1.125rem;
+  width: 1.125rem;
+}
+
+.buttonWrapper {
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+}

--- a/frontend/src/app/admins/(authenticated)/[id]/plan-list/register/page.tsx
+++ b/frontend/src/app/admins/(authenticated)/[id]/plan-list/register/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styles from "./page.module.scss";
+import RegisterForm from "@/app/components/features/registerForm/RegisterForm";
+
+function Register() {
+  return (
+    <main>
+      <div className={styles.outsideContainer}>
+        <div className={styles.container}>
+          <h2>Plan Registration</h2>
+          <RegisterForm userType="admin" categoryType="plan" />
+        </div>
+      </div>
+    </main>
+  );
+}
+export default Register;

--- a/frontend/src/app/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.tsx
@@ -20,6 +20,7 @@ import TextInput from "../../elements/textInput/TextInput";
 import PasswordStrengthMeter from "../../elements/passwordStrengthMeter/PasswordStrengthMeter";
 import { useFormState } from "react-dom";
 import { registerUser } from "@/app/actions/registerUser";
+import { registerContent } from "@/app/actions/registerContent";
 import { useFormMessages } from "@/app/hooks/useFormMessages";
 import { usePasswordStrength } from "@/app/hooks/usePasswordStrength";
 import PrefectureSelect from "./prefectureSelect/PrefectureSelect";
@@ -35,10 +36,14 @@ const RegisterForm = ({
   userType: UserType;
   language?: LanguageType;
 }) => {
+  // Handle the action based on userType and categoryType
+  const actionHandler =
+    userType === "admin" && categoryType ? registerContent : registerUser;
   const [registerResultState, formAction] = useFormState(
-    registerUser,
+    actionHandler,
     undefined,
   );
+
   const [password, onPasswordChange] = useInput();
   const [showPassword, setShowPassword] = useState(false);
   const { localMessages, clearErrorMessage } =
@@ -49,11 +54,13 @@ const RegisterForm = ({
     <form action={formAction} className={styles.form}>
       {/* Hidden fields to include in form submission */}
       <input type="hidden" name="userType" value={userType ?? ""} />
+      <input type="hidden" name="categoryType" value={categoryType ?? ""} />
       <input
         type="hidden"
         name="passwordStrength"
         value={passwordStrength ?? ""}
       />
+
       {userType === "customer" && (
         <>
           <TextInput
@@ -263,13 +270,14 @@ const RegisterForm = ({
           )}
         </>
       )}
+
       {/* Plan registration (only for admin) */}
       {userType === "admin" && categoryType === "plan" && (
         <>
           <p className={styles.required}>*Required</p>
           <TextInput
             id="name"
-            label="Plan name"
+            label="Plan Name"
             type="text"
             name="name"
             placeholder="e.g., 3,180 yen/month"
@@ -280,13 +288,13 @@ const RegisterForm = ({
           />
           <TextInput
             id="weeklyClassTimes"
-            label="Weekly class times"
+            label="Weekly Class Times"
             type="number"
             name="weeklyClassTimes"
             placeholder="e.g., 2"
             icon={<CalendarIcon className={styles.icon} />}
             inputRequired
-            error={localMessages.email}
+            error={localMessages.weeklyClassTimes}
             onChange={() => clearErrorMessage("weeklyClassTimes")}
           />
           <TextInput
@@ -297,11 +305,13 @@ const RegisterForm = ({
             placeholder="e.g., 2 classes per week"
             icon={<DocumentTextIcon className={styles.icon} />}
             inputRequired
-            error={localMessages.name}
+            error={localMessages.description}
             onChange={() => clearErrorMessage("description")}
           />{" "}
         </>
       )}
+
+      {/* Error and success messages */}
       <div className={styles.messageWrapper}>
         {localMessages.errorMessage && (
           <FormValidationMessage
@@ -316,6 +326,8 @@ const RegisterForm = ({
           />
         )}
       </div>
+
+      {/* Submission Button */}
       {!categoryType ? (
         <div className={styles.buttonWrapper}>
           <ActionButton

--- a/frontend/src/app/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.tsx
@@ -12,6 +12,8 @@ import {
   KeyIcon,
   LinkIcon,
   PhotoIcon,
+  AcademicCapIcon,
+  CalendarIcon,
 } from "@heroicons/react/24/outline";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
 import TextInput from "../../elements/textInput/TextInput";
@@ -25,9 +27,11 @@ import PrivacyPolicyAgreement from "./privacyPolicyAgreement/PrivacyPolicyAgreem
 import FormValidationMessage from "../../elements/formValidationMessage/FormValidationMessage";
 
 const RegisterForm = ({
+  categoryType,
   userType,
   language,
 }: {
+  categoryType?: CategoryType;
   userType: UserType;
   language?: LanguageType;
 }) => {
@@ -50,7 +54,6 @@ const RegisterForm = ({
         name="passwordStrength"
         value={passwordStrength ?? ""}
       />
-
       {userType === "customer" && (
         <>
           <TextInput
@@ -127,8 +130,8 @@ const RegisterForm = ({
           <input type="hidden" name="language" value={language ?? "en"} />
         </>
       )}
-
-      {(userType === "admin" || userType === "instructor") && (
+      {((userType === "admin" && !categoryType) ||
+        userType === "instructor") && (
         <>
           <p className={styles.required}>*Required</p>
           <TextInput
@@ -260,7 +263,45 @@ const RegisterForm = ({
           )}
         </>
       )}
-
+      {/* Plan registration (only for admin) */}
+      {userType === "admin" && categoryType === "plan" && (
+        <>
+          <p className={styles.required}>*Required</p>
+          <TextInput
+            id="name"
+            label="Plan name"
+            type="text"
+            name="name"
+            placeholder="e.g., 3,180 yen/month"
+            icon={<AcademicCapIcon className={styles.icon} />}
+            inputRequired
+            error={localMessages.name}
+            onChange={() => clearErrorMessage("name")}
+          />
+          <TextInput
+            id="weeklyClassTimes"
+            label="Weekly class times"
+            type="number"
+            name="weeklyClassTimes"
+            placeholder="e.g., 2"
+            icon={<CalendarIcon className={styles.icon} />}
+            inputRequired
+            error={localMessages.email}
+            onChange={() => clearErrorMessage("weeklyClassTimes")}
+          />
+          <TextInput
+            id="description"
+            label="Description"
+            type="text"
+            name="description"
+            placeholder="e.g., 2 classes per week"
+            icon={<DocumentTextIcon className={styles.icon} />}
+            inputRequired
+            error={localMessages.name}
+            onChange={() => clearErrorMessage("description")}
+          />{" "}
+        </>
+      )}
       <div className={styles.messageWrapper}>
         {localMessages.errorMessage && (
           <FormValidationMessage
@@ -275,14 +316,27 @@ const RegisterForm = ({
           />
         )}
       </div>
-
-      <div className={styles.buttonWrapper}>
-        <ActionButton
-          btnText={language === "ja" ? "アカウント登録" : "Create Account"}
-          className="bookBtn"
-          type="submit"
-        />
-      </div>
+      {!categoryType ? (
+        <div className={styles.buttonWrapper}>
+          <ActionButton
+            btnText={language === "ja" ? "アカウント登録" : "Create Account"}
+            className="bookBtn"
+            type="submit"
+          />
+        </div>
+      ) : (
+        <div className={styles.buttonWrapper}>
+          <ActionButton
+            btnText={`Register ${
+              categoryType
+                ? categoryType.charAt(0).toUpperCase() + categoryType.slice(1)
+                : ""
+            }`}
+            className="bookBtn"
+            type="submit"
+          />
+        </div>
+      )}
     </form>
   );
 };

--- a/frontend/src/app/helper/api/plansApi.ts
+++ b/frontend/src/app/helper/api/plansApi.ts
@@ -1,3 +1,9 @@
+import {
+  ITEM_ALREADY_REGISTERED_ERROR,
+  GENERAL_ERROR_MESSAGE,
+  CONTENT_REGISTRATION_SUCCESS_MESSAGE,
+} from "../messages/formValidation";
+
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
@@ -30,4 +36,38 @@ export const getPlanById = async (
   }).then((res) => res.json());
 
   return data;
+};
+
+// Register a new plan
+export const registerPlan = async (userData: {
+  name: string;
+  weeklyClassTimes: number;
+  description: string;
+  cookie: string;
+}): Promise<RegisterFormState> => {
+  try {
+    const registerURL = `${BACKEND_ORIGIN}/admins/plan-list/register`;
+    const response = await fetch(registerURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: userData.cookie },
+      body: JSON.stringify(userData),
+    });
+
+    if (response.status === 409) {
+      return { name: ITEM_ALREADY_REGISTERED_ERROR("Plan Name") };
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP Status: ${response.status} ${response.statusText}`);
+    }
+
+    return {
+      successMessage: CONTENT_REGISTRATION_SUCCESS_MESSAGE("plan"),
+    };
+  } catch (error) {
+    console.error("API error while registering plan:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
+  }
 };

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -12,6 +12,10 @@ export const EMAIL_ALREADY_REGISTERED_ERROR = {
   en: "This email address is already registered. Try a different one.",
 };
 
+export const ITEM_ALREADY_REGISTERED_ERROR = (item: string) => {
+  return "This name is already registered. Try a different one.";
+};
+
 export const SINGLE_ITEM_ALREADY_REGISTERED_ERROR = (item: string) => {
   return (
     "The input value for the following item has already been registered. Please enter a different one: " +
@@ -41,6 +45,12 @@ export const INSTRUCTOR_REGISTRATION_SUCCESS_MESSAGE =
 
 export const ADMIN_REGISTRATION_SUCCESS_MESSAGE =
   "The admin account has been created successfully.";
+
+export const CONTENT_REGISTRATION_SUCCESS_MESSAGE = (
+  categoryType: CategoryType,
+) => {
+  return `The ${categoryType} has been registered successfully.`;
+};
 
 // LoginForm
 export const LOGIN_FAILED_MESSAGE = {

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -209,6 +209,8 @@ type LinkType = {
 
 type UserType = "admin" | "customer" | "instructor";
 
+type CategoryType = "event" | "plan";
+
 type ForgotPasswordFormState = {
   errorMessage?: string;
   successMessage?: string;

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -223,6 +223,8 @@ type RegisterFormState = {
   passConfirmation?: string;
   prefecture?: string;
   isAgreed?: string;
+  weeklyClassTimes?: string;
+  description?: string;
   errorMessage?: string;
   successMessage?: string;
   language?: LanguageType;

--- a/frontend/src/app/schemas/authSchema.ts
+++ b/frontend/src/app/schemas/authSchema.ts
@@ -128,6 +128,12 @@ export const adminRegisterSchema = z
     path: ["password"],
   });
 
+export const planRegisterSchema = z.object({
+  name: z.string().min(1, "Plan Name is required."),
+  weeklyClassTimes: z.number(),
+  description: z.string().min(1, "Description is required."),
+});
+
 export const instructorUpdateSchema = z.object({
   name: z.string().min(1, "Name is required."),
   nickname: z.string().min(1, "Nickname is required."),


### PR DESCRIPTION
# Overview

1. Implement a plan registration feature for admin dashboard referring to #97
2. Set `name` as unique in the Plan model to prevent registering duplicate plan names.

# Review points
1. Log in to the app as an admin user (email: `admin@example.com`, password: `AaasoBo!Admin`) 
2. Go to page list page and click "Add plan" button
3. Input a new plan information and click "Register Plan" button
<img width="800" alt="Screenshot 2025-06-23 at 18 38 26" src="https://github.com/user-attachments/assets/f5f2b7a2-ac1a-44ae-b725-36466d54feaa" />
4. Confirm that the registered plan appears on the plan list page.
<img width="800" alt="Screenshot 2025-06-23 at 18 38 42" src="https://github.com/user-attachments/assets/ee96b71a-6c8c-4296-82cc-ce8e464fca4f" />
5. Check that a duplication error message is shown if the input plan name is the same as an existing one.
<img width="800" alt="Screenshot 2025-06-23 at 18 46 44" src="https://github.com/user-attachments/assets/75d0dba4-da95-4142-ab16-d7cf68e2f8a9" />

# Future improvement
- Implement functionality to edit and delete plans
