### PR TITLE
Implement admin deletion feature

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -4,6 +4,7 @@ import {
   getAllAdmins,
   getAdminById,
   updateAdmin,
+  deleteAdmin,
 } from "../services/adminsService";
 import {
   getAllInstructors,
@@ -81,6 +82,26 @@ export const updateAdminProfileController = async (
     });
   } catch (error) {
     res.status(500).json({ error: `${error}` });
+  }
+};
+
+export const deleteAdminController = async (req: Request, res: Response) => {
+  const adminId = parseInt(req.params.id);
+
+  if (isNaN(adminId)) {
+    return res.status(400).json({ error: "Invalid admin ID." });
+  }
+
+  try {
+    const deletedAdmin = await deleteAdmin(adminId);
+
+    res.status(200).json({
+      message: "The admin profile was deleted successfully",
+      id: deletedAdmin.id,
+    });
+  } catch (error) {
+    console.error("Failed to delete the child profile:", error);
+    res.status(500).json({ error: "Failed to delete the Admin profile." });
   }
 };
 

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -24,7 +24,11 @@ adminsRouter.post(
   registerAdminController,
 );
 adminsRouter.patch("/:id", verifyAuthentication, updateAdminProfileController);
-adminsRouter.delete("/admin-list/:id", deleteAdminController);
+adminsRouter.delete(
+  "/admin-list/:id",
+  verifyAuthentication,
+  deleteAdminController,
+);
 adminsRouter.post(
   "/instructor-list/register",
   verifyAuthentication,

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -3,6 +3,7 @@ import {
   registerAdminController,
   registerInstructorController,
   updateAdminProfileController,
+  deleteAdminController,
   getAdminController,
   getAllAdminsController,
   getAllInstructorsController,
@@ -23,6 +24,7 @@ adminsRouter.post(
   registerAdminController,
 );
 adminsRouter.patch("/:id", verifyAuthentication, updateAdminProfileController);
+adminsRouter.delete("/admin-list/:id", deleteAdminController);
 adminsRouter.post(
   "/instructor-list/register",
   verifyAuthentication,

--- a/backend/src/services/adminsService.ts
+++ b/backend/src/services/adminsService.ts
@@ -42,6 +42,21 @@ export const updateAdmin = async (id: number, name: string, email: string) => {
   }
 };
 
+// Delete the selected admin
+export const deleteAdmin = async (adminId: number) => {
+  try {
+    // Delete the Admin data.
+    const admin = await prisma.admins.delete({
+      where: { id: adminId },
+    });
+
+    return admin;
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to delete a admin.");
+  }
+};
+
 // Fetch all admins information
 export const getAllAdmins = async () => {
   try {

--- a/frontend/src/app/actions/deleteUser.ts
+++ b/frontend/src/app/actions/deleteUser.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { deleteAdmin } from "@/app/helper/api/adminsApi";
+import { GENERAL_ERROR_MESSAGE } from "../helper/messages/formValidation";
+import { revalidateAdminList } from "./revalidate";
+import { getCookie } from "../../middleware";
+
+export async function deleteAdminAction(
+  prevState: DeleteFormState | undefined,
+  formData: FormData,
+): Promise<DeleteFormState> {
+  try {
+    // Hidden input tag fields
+    const id = Number(formData.get("id"));
+
+    // Get the cookies from the request headers
+    const cookie = await getCookie();
+
+    // Delete the admin using the API
+    const response = await deleteAdmin(id, cookie);
+
+    // Refresh cached admin data for the admin list page
+    revalidateAdminList();
+
+    return response;
+  } catch (error) {
+    console.error("Unexpected error in deleteUser server action:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
+  }
+}

--- a/frontend/src/app/components/admins-dashboard/AdminDashboardClient.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminDashboardClient.tsx
@@ -32,7 +32,11 @@ export default function AdminTabs({
     {
       label: "Admin's Profile",
       content: (
-        <AdminProfile admin={admin} isAdminAuthenticated={isAuthenticated} />
+        <AdminProfile
+          userId={userId}
+          admin={admin}
+          isAdminAuthenticated={isAuthenticated}
+        />
       ),
     },
   ];

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
@@ -5,6 +5,11 @@ import { useState, useEffect } from "react";
 import { useFormState } from "react-dom";
 import { useFormMessages } from "@/app/hooks/useFormMessages";
 import { updateAdminAction } from "@/app/actions/updateUser";
+import { deleteAdminAction } from "@/app/actions/deleteUser";
+import {
+  ADMIN_UPDATE_SUCCESS_MESSAGE,
+  ADMIN_DELETE_SUCCESS_MESSAGE,
+} from "@/app/helper/messages/formValidation";
 import InputField from "../elements/inputField/InputField";
 import ActionButton from "../elements/buttons/actionButton/ActionButton";
 import { CheckIcon } from "@heroicons/react/24/outline";
@@ -14,13 +19,20 @@ import "react-toastify/dist/ReactToastify.css";
 import Loading from "@/app/components/elements/loading/Loading";
 
 function AdminProfile({
+  userId,
   admin,
   isAdminAuthenticated,
 }: {
+  userId: number;
   admin: Admin | string;
   isAdminAuthenticated?: boolean;
 }) {
+  // Use `useFormState` hook for updating an admin profile
   const [updateResultState, formAction] = useFormState(updateAdminAction, {});
+  // Use `useState` hook and FormData for deleting an admin profile
+  const [deleteResultState, setDeleteResultState] = useState<DeleteFormState>(
+    {},
+  );
   const { localMessages, clearErrorMessage } =
     useFormMessages(updateResultState);
   const [previousAdmin, setPreviousAdmin] = useState<Admin | null>(
@@ -53,24 +65,56 @@ function AdminProfile({
     }
   };
 
-  useEffect(() => {
-    if (updateResultState !== undefined) {
-      if ("admin" in updateResultState) {
-        const result = updateResultState as { admin: Admin };
-        toast.success("Profile updated successfully!");
-        setIsEditing(false);
-        setPreviousAdmin(result.admin);
-        setLatestAdmin(result.admin);
-      } else {
-        const result = updateResultState as { errorMessage: string };
-        toast.error(result.errorMessage);
-      }
-    }
-  }, [updateResultState]);
+  const handleDeleteClick = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to delete this admin's profile?",
+    );
+    if (confirmed && latestAdmin) {
+      const formData = new FormData();
+      formData.append("id", String(latestAdmin.id));
 
+      const result = await deleteAdminAction(deleteResultState, formData);
+      setDeleteResultState(result);
+    }
+  };
+
+  useEffect(() => {
+    // Check if the updateResultState has changed
+    if ("admin" in updateResultState && updateResultState.admin) {
+      const admin = updateResultState.admin as Admin;
+      toast.success(ADMIN_UPDATE_SUCCESS_MESSAGE);
+      setIsEditing(false);
+      setPreviousAdmin(admin);
+      setLatestAdmin(admin);
+      // Clear updateResultState to avoid re-rendering
+      updateResultState.admin = null;
+      return;
+
+      // Check if the deleteResultState has changed
+    } else if ("id" in deleteResultState && deleteResultState.id) {
+      toast.success(ADMIN_DELETE_SUCCESS_MESSAGE);
+      setIsEditing(false);
+      setLatestAdmin(null);
+      // Clear deleteResultState to avoid re-rendering
+      deleteResultState.id = null;
+      return;
+
+      // Show an error message if there is an error in either update or delete operation,
+    } else {
+      const updateResult = updateResultState as { errorMessage: string };
+      const deleteResult = deleteResultState as { errorMessage: string };
+      const errorMessage =
+        updateResult.errorMessage || deleteResult.errorMessage;
+      toast.error(errorMessage);
+      return;
+    }
+  }, [updateResultState, deleteResultState]);
+
+  // Error message is displayed if the admin data is not found.
   if (typeof admin === "string") {
     return <p>{admin}</p>;
   }
+  const adminId = admin.id;
 
   return (
     <>
@@ -112,42 +156,50 @@ function AdminProfile({
               </div>
             </div>
 
-            {/* Hidden input fields */}
+            {/* Hidden input */}
             <input type="hidden" name="id" value={latestAdmin.id} />
 
             {/* Action buttons for only admin */}
-            {isAdminAuthenticated ? (
-              <>
-                {isEditing ? (
-                  <div className={styles.buttons}>
+            {isAdminAuthenticated &&
+              (isEditing ? (
+                <div className={styles.buttons}>
+                  <ActionButton
+                    className="cancelEditingInstructor"
+                    btnText="Cancel"
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleCancelClick();
+                    }}
+                  />
+                  <ActionButton
+                    className="saveInstructor"
+                    btnText="Save"
+                    type="submit"
+                    Icon={CheckIcon}
+                  />
+                </div>
+              ) : (
+                <div className={styles.buttons}>
+                  <div>
                     <ActionButton
-                      className="cancelEditingInstructor"
-                      btnText="Cancel"
+                      className="deleteAdmin"
+                      btnText="Delete"
                       type="button"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        handleCancelClick();
-                      }}
-                    />
-
-                    <ActionButton
-                      className="saveInstructor"
-                      btnText="Save"
-                      type="submit"
-                      Icon={CheckIcon}
+                      onClick={() => handleDeleteClick()}
+                      disabled={userId === adminId}
                     />
                   </div>
-                ) : (
-                  <div className={styles.buttons}>
+                  <div>
                     <ActionButton
-                      className="editInstructor"
+                      className="editAdmin"
                       btnText="Edit"
+                      type="button"
                       onClick={handleEditClick}
                     />
                   </div>
-                )}
-              </>
-            ) : null}
+                </div>
+              ))}
           </form>
         ) : (
           <Loading />

--- a/frontend/src/app/components/elements/buttons/actionButton/ActionButton.module.scss
+++ b/frontend/src/app/components/elements/buttons/actionButton/ActionButton.module.scss
@@ -251,6 +251,7 @@
   }
 }
 
+.deleteAdmin,
 .deleteChild,
 .cancelEditingChild,
 .cancelEditingInstructor,
@@ -280,6 +281,7 @@
   height: 40px;
 }
 
+.editAdmin,
 .editChild,
 .editInstructor,
 .editCustomer,

--- a/frontend/src/app/helper/api/adminsApi.ts
+++ b/frontend/src/app/helper/api/adminsApi.ts
@@ -204,6 +204,31 @@ export const updateAdmin = async (
   }
 };
 
+// DELETE admin data
+export const deleteAdmin = async (adminId: number, cookie: string) => {
+  try {
+    // Define the data to be sent to the server side.
+    const apiURL = `${BACKEND_ORIGIN}/admins/admin-list/${adminId}`;
+    const headers = { "Content-Type": "application/json", Cookie: cookie };
+    const response = await fetch(apiURL, {
+      method: "DELETE",
+      headers,
+    });
+
+    if (response.status !== 200) {
+      return { errorMessage: ERROR_PAGE_MESSAGE_EN };
+    }
+    const result = await response.json();
+
+    return result;
+  } catch (error) {
+    console.error("Failed to delete the admin:", error);
+    return {
+      errorMessage: GENERAL_ERROR_MESSAGE,
+    };
+  }
+};
+
 export const logoutAdmin = async () => {
   try {
     const response = await fetch(`${BASE_URL}/logout`, {

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -42,6 +42,12 @@ export const INSTRUCTOR_REGISTRATION_SUCCESS_MESSAGE =
 export const ADMIN_REGISTRATION_SUCCESS_MESSAGE =
   "The admin account has been created successfully.";
 
+export const ADMIN_UPDATE_SUCCESS_MESSAGE =
+  "The admin account has been updated successfully.";
+
+export const ADMIN_DELETE_SUCCESS_MESSAGE =
+  "The admin account has been deleted successfully.";
+
 // LoginForm
 export const LOGIN_FAILED_MESSAGE = {
   ja: "メールアドレスまたはパスワードが正しくありません。",

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -238,6 +238,11 @@ type UpdateFormState = {
   successMessage?: string;
 };
 
+type DeleteFormState = {
+  errorMessage?: string;
+  successMessage?: string;
+};
+
 type UpcomingClass = {
   id: number;
   dateTime: string;


### PR DESCRIPTION
# Overview

- Implement an admin profile deletion feature for admin dashboard

# Review points
1. Log in to the app as an admin user (email: `admin@example.com`, password: `AaasoBo!Admin`) 
2. Go to ID1 admin's profile page (http://localhost:3000/admins/1/admin-list/1)
3. Confirm that the "Delete" button is disabled since the admin's ID is the same as logged in user's ID
4. Move to ID2 admin's profile page (http://localhost:3000/admins/1/admin-list/2)
5. Click the "Delete" button and confirm that the applicable admin profile is deleted without any issues
<img width="800" alt="Screenshot 2025-06-25 at 17 11 19" src="https://github.com/user-attachments/assets/9b473865-2733-4487-977b-3fe6f2db5bc1" />
6. Return to admin list page and confirm that the deleted admin information is no longer displayed
<img width="800" alt="Screenshot 2025-06-25 at 17 11 31" src="https://github.com/user-attachments/assets/566dfb44-81dd-49ed-89a1-cc6b2c4c441e" />