### PR TITLE
Add "npm run build" for frontend to GitHub Action

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -12,6 +12,8 @@ jobs:
         working-directory: ./frontend
       - run: npm run format-check
         working-directory: ./frontend
+      - run: npm run build
+        working-directory: ./frontend
       - run: npm ci
         working-directory: ./backend
       - run: npm run format-check


### PR DESCRIPTION
### Overview
Add `npm run build` for the frontend to the GitHub Action to ensure developers don't forget to run the build before deploying to the production environment.