### PR TITLE
Disable to edit or delete some events

### DIFF
--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
@@ -40,6 +40,9 @@ function EventProfile({
   );
   const [isEditing, setIsEditing] = useState(false);
 
+  // Define event IDs that should be disabled for editing or deleting
+  const disabledEventIds = [1, 2, 3];
+
   const handleEditClick = () => {
     setIsEditing(true);
   };
@@ -197,6 +200,7 @@ function EventProfile({
                           btnText="Delete"
                           type="button"
                           onClick={() => handleDeleteClick()}
+                          disabled={disabledEventIds.includes(event.id)}
                         />
                       </div>
                       <div>
@@ -205,6 +209,7 @@ function EventProfile({
                           btnText="Edit"
                           type="button"
                           onClick={handleEditClick}
+                          disabled={disabledEventIds.includes(event.id)}
                         />
                       </div>
                     </div>

--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
@@ -10,6 +10,7 @@ import {
   CONTENT_UPDATE_SUCCESS_MESSAGE,
   CONTENT_DELETE_SUCCESS_MESSAGE,
 } from "@/app/helper/messages/formValidation";
+import { defaultEventIds } from "@/app/helper/data/data";
 import InputField from "../../elements/inputField/InputField";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
 import { PencilIcon, CheckIcon } from "@heroicons/react/24/outline";
@@ -39,9 +40,6 @@ function EventProfile({
     typeof event !== "string" ? event : null,
   );
   const [isEditing, setIsEditing] = useState(false);
-
-  // Define event IDs that should be disabled for editing or deleting
-  const disabledEventIds = [1, 2, 3];
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -114,6 +112,9 @@ function EventProfile({
   if (typeof event === "string") {
     return <p>{event}</p>;
   }
+
+  // Check if the event is one of the default events
+  const isEventDisabled = defaultEventIds.includes(event.id);
 
   return (
     <>
@@ -200,7 +201,7 @@ function EventProfile({
                           btnText="Delete"
                           type="button"
                           onClick={() => handleDeleteClick()}
-                          disabled={disabledEventIds.includes(event.id)}
+                          disabled={isEventDisabled}
                         />
                       </div>
                       <div>
@@ -209,7 +210,7 @@ function EventProfile({
                           btnText="Edit"
                           type="button"
                           onClick={handleEditClick}
-                          disabled={disabledEventIds.includes(event.id)}
+                          disabled={isEventDisabled}
                         />
                       </div>
                     </div>

--- a/frontend/src/app/helper/data/data.ts
+++ b/frontend/src/app/helper/data/data.ts
@@ -1,3 +1,5 @@
+export const defaultEventIds = [1, 2, 3];
+
 export const prefectures = [
   "海外 / Overseas",
   "北海道 / Hokkaido",


### PR DESCRIPTION
### Overview
Set a condition to prevent editing or deleting default events ("AaasoBo! Holiday", "AaasoBo! Substitute Holiday", and "Theme Class Week")

Note: This implementation is based on the suggestion in the following link from a previous PR comment:
https://github.com/KivSystemAdmin/aaasobo-management-system/pull/138#issuecomment-3054994221
↓
> Suggestion: Consider making the event name "AaasoBo! Holiday" unchangeable to prevent unexpected future bugs.


###
**Events with IDs 1, 2, or 3 cannot be edited or deleted**
<img width="800" height="745" alt="Screenshot 2025-07-10 at 18 18 00" src="https://github.com/user-attachments/assets/96f00de9-1208-42a8-93d0-c296963cafaf" />
<img width="800" height="740" alt="Screenshot 2025-07-10 at 18 21 01" src="https://github.com/user-attachments/assets/c7bb819c-828b-4754-a0ef-4cab57e6c946" />
<img width="800" height="738" alt="Screenshot 2025-07-10 at 18 21 16" src="https://github.com/user-attachments/assets/30410925-0450-4431-97df-c8ab002d6b3c" />

**Other events can be operated**
<img width="800" height="738" alt="Screenshot 2025-07-10 at 18 18 17" src="https://github.com/user-attachments/assets/9c90a6c4-de35-4f16-ada6-d6700195448e" />
