### PR TITLE
Improve event registration and update features

### DIFF
--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -1013,15 +1013,15 @@ async function insertEvents() {
     data: [
       {
         name: "AaasoBo! Holiday", // お休み
-        color: "rgb(250,215,205)",
+        color: "#FAD7CD",
       },
       {
         name: "AaasoBo! Substitute Holiday", // お休み振替対象日
-        color: "rgb(255,0,0)",
+        color: "#FF0000",
       },
       {
         name: "Theme Class Week", // テーマクラスウィーク
-        color: "rgb(255,255,0)",
+        color: "#FFFF00",
       },
     ],
   });

--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.module.scss
@@ -71,23 +71,39 @@
   display: flex;
 
   &__colorBox {
-    width: 20px;
-    height: 20px;
+    width: 25px;
+    height: 25px;
     border-radius: 4px;
     border: 1px solid #ccc;
     margin-right: 8px;
   }
 
   &__inputField {
-    margin: 0px 50px 5px 0px;
+    margin: 0px 10px 5px 0px;
     padding: 3px 6px;
     font-size: 19px;
     font-weight: 500;
+    border: 1.5px solid #000000;
     border-radius: 6px;
-    width: 100%;
+    width: 400px;
+    height: 35px;
     word-break: break-word;
     overflow-wrap: break-word;
     white-space: normal;
+  }
+
+  &__editText {
+    height: 35px;
+    font-size: 19px;
+    font-weight: 500;
+    border: 1.5px solid #000000;
+    border-radius: 6px;
+    padding: 0.15rem 0.75rem;
+  }
+
+  &__displayText {
+    font-size: 20px;
+    font-weight: 500;
   }
 }
 

--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.tsx
@@ -144,15 +144,19 @@ function EventProfile({
                 <div>
                   <p className={styles.eventName__text}>Color</p>
                   {isEditing ? (
-                    <InputField
-                      name="color"
-                      value={latestEvent.color
-                        .toUpperCase()
-                        .replace(/,\s*/g, ", ")}
-                      error={localMessages.color}
-                      onChange={(e) => handleInputChange(e, "color")}
-                      className={`${styles.eventColor__inputField} ${isEditing ? styles.editable : ""}`}
-                    />
+                    <div className={styles.eventColor}>
+                      <InputField
+                        name="color"
+                        type="color"
+                        value={latestEvent.color.toUpperCase()}
+                        error={localMessages.color}
+                        onChange={(e) => handleInputChange(e, "color")}
+                        className={`${styles.eventColor__inputField} ${isEditing ? styles.editable : ""}`}
+                      />
+                      <div className={styles.eventColor__editText}>
+                        {latestEvent.color.toUpperCase()}
+                      </div>
+                    </div>
                   ) : (
                     <div className={styles.eventColor}>
                       <div
@@ -161,9 +165,9 @@ function EventProfile({
                           backgroundColor: latestEvent.color,
                         }}
                       />
-                      <h4>
-                        {latestEvent.color.toUpperCase().replace(/,\s*/g, ", ")}
-                      </h4>
+                      <h3 className={styles.eventColor__displayText}>
+                        {latestEvent.color.toUpperCase()}
+                      </h3>
                     </div>
                   )}
                 </div>

--- a/frontend/src/app/components/elements/textInput/TextInput.tsx
+++ b/frontend/src/app/components/elements/textInput/TextInput.tsx
@@ -10,7 +10,7 @@ type TextInputProps = {
   type: string;
   value?: string;
   defaultValue?: string;
-  placeholder: string;
+  placeholder?: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   icon?: React.ReactNode;
   inputRequired?: boolean;

--- a/frontend/src/app/components/features/registerForm/RegisterForm.module.scss
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.module.scss
@@ -28,3 +28,24 @@
   width: 1.2rem;
   height: 1.2rem;
 }
+
+.eventColor {
+  display: flex;
+  align-items: flex-start;
+
+  input[type="color"] {
+    width: 400px;
+    padding: 0;
+    background: none;
+  }
+
+  &__text {
+    margin: 25px 0 0 10px;
+    font-size: 18px;
+    font-weight: 500;
+    border: 1px solid #ccc;
+    border-radius: 0.3rem;
+    padding: 0.5rem;
+    flex-shrink: 0;
+  }
+}

--- a/frontend/src/app/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.tsx
@@ -44,6 +44,7 @@ const RegisterForm = ({
 
   const [password, onPasswordChange] = useInput();
   const [showPassword, setShowPassword] = useState(false);
+  const [colorValue, setColorValue] = useState("#000000"); // Default color value
   const { localMessages, clearErrorMessage } =
     useFormMessages(registerResultState);
   const { passwordStrength } = usePasswordStrength(password);
@@ -248,17 +249,25 @@ const RegisterForm = ({
             error={localMessages.name}
             onChange={() => clearErrorMessage("name")}
           />
-          <TextInput
-            id="color"
-            label="Color Code"
-            type="text"
-            name="color"
-            placeholder="e.g., RGB(255, 255, 255)"
-            icon={<DocumentTextIcon className={styles.icon} />}
-            inputRequired
-            error={localMessages.color}
-            onChange={() => clearErrorMessage("color")}
-          />{" "}
+          <div className={styles.eventColor}>
+            <TextInput
+              id="color"
+              label="Color Code"
+              type="color"
+              name="color"
+              value={colorValue}
+              icon={<DocumentTextIcon className={styles.icon} />}
+              inputRequired
+              error={localMessages.color}
+              onChange={(e) => {
+                setColorValue(e.target.value);
+                clearErrorMessage("color");
+              }}
+            />
+            <div className={styles.eventColor__text}>
+              {colorValue.toUpperCase()}
+            </div>
+          </div>
         </>
       )}
 


### PR DESCRIPTION
### Overview
- Implement color selection feature in both event registration and profile pages (Note: no need to review both behavior and code, just confirming the screenshots below is sufficient)

**[Event registration page]**
<img width="800" height="743" alt="Screenshot 2025-07-16 at 23 43 09" src="https://github.com/user-attachments/assets/ac5288c0-afe8-4a82-ab52-a24b143c849d" />
<img width="800" height="753" alt="Screenshot 2025-07-16 at 23 43 29" src="https://github.com/user-attachments/assets/a91cbdb7-f0cb-4415-83bb-8bce761cdc95" />
<img width="800" height="743" alt="Screenshot 2025-07-16 at 23 43 45" src="https://github.com/user-attachments/assets/78fe7c5c-2485-47e6-8e4f-8a672bb2b832" />

###

**[Event profile page]**
<img width="800" height="746" alt="Screenshot 2025-07-16 at 23 44 09" src="https://github.com/user-attachments/assets/6a54db9a-787b-4276-8456-2d24c97c6e20" />
<img width="800" height="744" alt="Screenshot 2025-07-16 at 23 44 26" src="https://github.com/user-attachments/assets/b3ce89e5-e059-41eb-8908-3685f777c661" />
<img width="800" height="376" alt="Screenshot 2025-07-16 at 23 45 01" src="https://github.com/user-attachments/assets/c5403de9-2a8c-4a5a-a194-fc4a31350cb9" />
<img width="800" height="742" alt="Screenshot 2025-07-16 at 23 46 00" src="https://github.com/user-attachments/assets/506f6852-43ca-4897-8a04-dda9d8183df0" />
