### PR TITLE
Export hash functions instead of saltRound

### DIFF
--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -26,7 +26,7 @@ import {
   generatePasswordResetToken,
   getPasswordResetTokenByToken,
 } from "../services/passwordResetTokensService";
-import { saltRounds } from "../helper/commonUtils";
+import { hashPassword } from "../helper/commonUtils";
 import { Customer } from "@prisma/client";
 
 const getUserByEmail = async (userType: UserType, email: string) => {
@@ -173,7 +173,7 @@ export const updatePasswordController = async (req: Request, res: Response) => {
       return res.sendStatus(410); // Token is expired. 410 Gone
     }
 
-    const hashedPassword = await bcrypt.hash(password, saltRounds);
+    const hashedPassword = await hashPassword(password);
 
     switch (userType) {
       case "admin":

--- a/backend/src/helper/commonUtils.ts
+++ b/backend/src/helper/commonUtils.ts
@@ -1,5 +1,7 @@
 // This file contains common functions that are used in multiple controllers or services.
 
+import bcrypt from "bcrypt";
+
 // Create a new object that contains only the properties specified in the array.
 export const pickProperties = (
   dBData: any,
@@ -21,4 +23,12 @@ export const pickProperties = (
 };
 
 // Standardize salt rounds for hashing passwords
-export const saltRounds = 12;
+const saltRounds = 12;
+
+export const hashPassword = async (password: string): Promise<string> => {
+  return bcrypt.hash(password, saltRounds);
+};
+
+export const hashPasswordSync = (password: string): string => {
+  return bcrypt.hashSync(password, saltRounds);
+};

--- a/backend/src/services/adminsService.ts
+++ b/backend/src/services/adminsService.ts
@@ -1,7 +1,6 @@
 import { prisma } from "../../prisma/prismaClient";
 import { Admins } from "@prisma/client";
-import bcrypt from "bcrypt";
-import { saltRounds } from "../helper/commonUtils";
+import { hashPassword } from "../helper/commonUtils";
 
 // Register a new admin in the DB
 export const registerAdmin = async (data: {
@@ -9,7 +8,7 @@ export const registerAdmin = async (data: {
   email: string;
   password: string;
 }) => {
-  const hashedPassword = await bcrypt.hash(data.password, saltRounds);
+  const hashedPassword = await hashPassword(data.password);
 
   await prisma.admins.create({
     data: {

--- a/backend/src/services/customersService.ts
+++ b/backend/src/services/customersService.ts
@@ -1,7 +1,6 @@
 import { Customer, Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
-import bcrypt from "bcrypt";
-import { saltRounds } from "../helper/commonUtils";
+import { hashPassword } from "../helper/commonUtils";
 
 export const getCustomerById = async (customerId: number) => {
   const customer = await prisma.customer.findUnique({
@@ -61,7 +60,7 @@ export const registerCustomer = async (
   tx?: Prisma.TransactionClient,
 ) => {
   const db = tx ?? prisma;
-  const hashedPassword = await bcrypt.hash(data.password, saltRounds);
+  const hashedPassword = await hashPassword(data.password);
 
   const customer = await db.customer.create({
     data: {

--- a/backend/src/services/instructorsService.ts
+++ b/backend/src/services/instructorsService.ts
@@ -1,7 +1,6 @@
 import { prisma } from "../../prisma/prismaClient";
 import { Instructor, Prisma } from "@prisma/client";
-import bcrypt from "bcrypt";
-import { saltRounds } from "../helper/commonUtils";
+import { hashPassword } from "../helper/commonUtils";
 
 // Register a new instructor account in the DB
 export const registerInstructor = async (data: {
@@ -15,7 +14,7 @@ export const registerInstructor = async (data: {
   passcode: string;
   introductionURL: string;
 }) => {
-  const hashedPassword = await bcrypt.hash(data.password, saltRounds);
+  const hashedPassword = await hashPassword(data.password);
 
   await prisma.instructor.create({
     data: {

--- a/backend/src/test/helper.ts
+++ b/backend/src/test/helper.ts
@@ -1,7 +1,4 @@
 import { vi } from "vitest";
-import bcrypt from "bcrypt";
-
-const saltRounds = 12;
 
 export const createMockPrisma = () => {
   const mock = {
@@ -90,7 +87,3 @@ export const createTestInstructor = () => ({
   updatedAt: new Date(),
   inactiveAt: null,
 });
-
-export const hashPassword = (password: string) => {
-  return bcrypt.hashSync(password, saltRounds);
-};

--- a/backend/src/test/instructor.test.ts
+++ b/backend/src/test/instructor.test.ts
@@ -4,8 +4,8 @@ import {
   createMockResend,
   createTestAdmin,
   createTestInstructor,
-  hashPassword,
 } from "./helper";
+import { hashPasswordSync } from "../helper/commonUtils";
 
 vi.mock("../../prisma/prismaClient", () => ({
   prisma: createMockPrisma(),
@@ -25,7 +25,7 @@ const loginAsAdmin = async (admin = createTestAdmin()) => {
   mockPrisma.admins.findUnique.mockResolvedValue({
     id: admin.id,
     email: admin.email,
-    password: hashPassword(admin.password),
+    password: hashPasswordSync(admin.password),
     name: admin.name,
   });
 
@@ -106,7 +106,7 @@ describe("Instructor Registration", () => {
       .expect(200);
 
     // Step 3: Instructor can login
-    const hashedPassword = hashPassword(newInstructor.password);
+    const hashedPassword = hashPasswordSync(newInstructor.password);
     mockPrisma.instructor.findUnique.mockResolvedValue({
       ...newInstructor,
       password: hashedPassword,

--- a/backend/src/test/user.test.ts
+++ b/backend/src/test/user.test.ts
@@ -5,8 +5,8 @@ import {
   createTestAdmin,
   createTestCustomer,
   createTestInstructor,
-  hashPassword,
 } from "./helper";
+import { hashPasswordSync } from "../helper/commonUtils";
 
 vi.mock("../../prisma/prismaClient", () => ({
   prisma: createMockPrisma(),
@@ -31,7 +31,7 @@ describe("Admin Login", () => {
       id: admin.id,
       name: admin.name,
       email: admin.email,
-      password: hashPassword(admin.password),
+      password: hashPasswordSync(admin.password),
     });
 
     const response = await request(server)
@@ -65,7 +65,7 @@ describe("Admin Login", () => {
       id: admin.id,
       name: admin.name,
       email: admin.email,
-      password: hashPassword(admin.password),
+      password: hashPasswordSync(admin.password),
     });
 
     await request(server)
@@ -84,7 +84,7 @@ describe("Customer Login", () => {
     const customer = createTestCustomer();
     mockPrisma.customer.findUnique.mockResolvedValue({
       ...customer,
-      password: hashPassword(customer.password),
+      password: hashPasswordSync(customer.password),
     });
 
     const response = await request(server)
@@ -105,7 +105,7 @@ describe("Instructor Login", () => {
     const instructor = createTestInstructor();
     mockPrisma.instructor.findUnique.mockResolvedValue({
       ...instructor,
-      password: hashPassword(instructor.password),
+      password: hashPasswordSync(instructor.password),
     });
 
     const response = await request(server)
@@ -129,7 +129,7 @@ describe("Admin Password Reset", () => {
     // Setup mocks
     mockPrisma.admins.findUnique.mockResolvedValue({
       ...mockAdmin,
-      password: hashPassword(mockAdmin.password),
+      password: hashPasswordSync(mockAdmin.password),
     });
     mockPrisma.passwordResetToken.create.mockResolvedValue({
       id: 1,
@@ -183,7 +183,7 @@ describe("Admin Password Reset", () => {
     const newPassword = "newPassword456";
     const updatedMockAdmin = {
       ...mockAdmin,
-      password: hashPassword(newPassword),
+      password: hashPasswordSync(newPassword),
     };
     mockPrisma.admins.update.mockResolvedValue(updatedMockAdmin);
 


### PR DESCRIPTION
Resolve #160 

I think it would be better if commonUtils.ts exports hash functions instead of exporting `saltRound`. This way, someone who wants to use the hash function can directly call `hashPassword()` and don't have to care about the salt round or bcrypt.