### PR TITLE
refactor: always show contact email and LINE URL on unexpected error

### DIFF
--- a/backend/src/helper/mail.ts
+++ b/backend/src/helper/mail.ts
@@ -1,6 +1,8 @@
 import { CreateEmailResponse } from "resend";
 import { resend } from "./resendClient";
+
 export type UserType = "admin" | "customer" | "instructor";
+const CONTACT_EMAIL = "contact@aaasobo.org";
 
 export const sendVerificationEmail = async (
   email: string,
@@ -11,7 +13,7 @@ export const sendVerificationEmail = async (
 
   try {
     const response: CreateEmailResponse = await resend.emails.send({
-      from: "contact@aaasobo.org",
+      from: `${CONTACT_EMAIL}`,
       to: email,
       subject:
         "【KIVこどもオンライン英会話AaasoBo!】メールアドレス認証のお願い / Please confirm your email address",
@@ -72,7 +74,7 @@ export const sendVerificationEmail = async (
         </p>
         <p style="font-size: 14px;">
           KIVこどもオンライン英会話AaasoBo! / KIV Online English Program AaasoBo!<br>
-          contact@aaasobo.org
+          ${CONTACT_EMAIL}
         </p>
       </div>
     `,
@@ -171,7 +173,7 @@ export const resendVerificationEmail = async (
         </p>
         <p style="font-size: 14px;">
           KIVこどもオンライン英会話AaasoBo! / KIV Online English Program AaasoBo!<br>
-          contact@aaasobo.org
+          ${CONTACT_EMAIL}
         </p>
       </div>
     `,
@@ -272,7 +274,7 @@ export const sendPasswordResetEmail = async (
       </p>
       <p style="font-size: 14px;">
         KIVこどもオンライン英会話AaasoBo! / KIV Online English Program AaasoBo!<br>
-        contact@aaasobo.org
+        ${CONTACT_EMAIL}
       </p>
     </div>
   `,
@@ -313,8 +315,8 @@ export const sendAdminSameDayRebookEmail = async (data: {
 }) => {
   try {
     const response: CreateEmailResponse = await resend.emails.send({
-      from: "contact@aaasobo.org",
-      to: "contact@aaasobo.org",
+      from: `${CONTACT_EMAIL}`,
+      to: `${CONTACT_EMAIL}`,
       subject: "【AaasoBo!】当日クラスの予約が入りました。",
       html: `
   <div style="font-family: 'Helvetica Neue', sans-serif; font-size: 16px; line-height: 1.6; color: #333;">
@@ -354,7 +356,7 @@ export const sendAdminSameDayRebookEmail = async (data: {
     <p style="font-size: 14px; color: #555;">
       KIVこどもオンライン英会話 AaasoBo!<br>
       KIV Online English Program AaasoBo!<br>
-      📧 contact@aaasobo.org
+      📧 ${CONTACT_EMAIL}
     </p>
   </div>
 `,
@@ -399,7 +401,7 @@ export const sendInstructorSameDayRebookEmail = async (data: {
 }) => {
   try {
     const response: CreateEmailResponse = await resend.emails.send({
-      from: "contact@aaasobo.org",
+      from: `${CONTACT_EMAIL}`,
       to: data.instructorEmail,
       subject: "【AaasoBo!】A Class Has Been Booked for Today",
       html: `
@@ -437,7 +439,7 @@ export const sendInstructorSameDayRebookEmail = async (data: {
 
     <p style="font-size: 14px; color: #555;">
       KIV Online English Program AaasoBo!<br>
-      📧 contact@aaasobo.org
+      📧 ${CONTACT_EMAIL}
     </p>
   </div>
 `,

--- a/frontend/src/app/actions/rebooking.ts
+++ b/frontend/src/app/actions/rebooking.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { rebookClass } from "../helper/api/classesApi";
-import { getUserSession } from "../helper/auth/sessionUtils";
 import { revalidateCustomerCalendar } from "./revalidate";
 import { validateSession } from "./validateSession";
 

--- a/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.module.scss
+++ b/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.module.scss
@@ -58,3 +58,31 @@
     min-width: 1.1rem;
   }
 }
+
+.withContactInfo {
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.contacts {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  span {
+    font-size: 13px;
+  }
+
+  &__mail {
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+    margin-bottom: unset !important;
+    font-size: 13.5px !important;
+  }
+
+  &__line {
+    margin-bottom: unset !important;
+    font-size: 13.5px !important;
+  }
+}

--- a/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.tsx
+++ b/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.tsx
@@ -3,6 +3,7 @@ import {
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/solid";
 import styles from "./FormValidationMessage.module.scss";
+import { CONTACT_EMAIL, LINE_QR_CODE_URL } from "@/app/helper/data/contacts";
 
 type MessageProps = {
   type: "error" | "success";
@@ -18,16 +19,49 @@ export default function FormValidationMessage({
   const isError = type === "error";
   const Icon = isError ? ExclamationTriangleIcon : CheckCircleIcon;
 
+  const shouldShowContactInfo =
+    isError &&
+    (message.includes("スタッフまでご連絡") ||
+      message.toLowerCase().includes("contact us"));
+
   return (
     <div
-      className={`${styles.message}  ${isError ? styles["message--error"] : styles["message--success"]} ${className ? styles[className] : ""}`}
+      className={`${styles.message}  ${isError ? styles["message--error"] : styles["message--success"]} ${className && styles[className]} ${shouldShowContactInfo && styles.withContactInfo}`}
     >
       <Icon
         className={`${styles.icon} ${isError ? styles["icon--error"] : styles["icon--success"]}`}
       />
+
       <p className={isError ? styles.errorText : styles.successText}>
         {message}
       </p>
+
+      {shouldShowContactInfo && (
+        <div className={styles.contacts}>
+          <p className={styles.contacts__mail}>
+            <span>mail: </span>
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className={styles.contacts__link}
+              style={{ textDecoration: "underline" }}
+            >
+              {CONTACT_EMAIL}
+            </a>
+          </p>
+          <p className={styles.contacts__line}>
+            <span>LINE: </span>
+            <a
+              href={LINE_QR_CODE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.contacts__link}
+              style={{ textDecoration: "underline" }}
+            >
+              {LINE_QR_CODE_URL}
+            </a>
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/components/features/classDetail/sameDayCancellationNotice/SameDayCancellationNotice.tsx
+++ b/frontend/src/app/components/features/classDetail/sameDayCancellationNotice/SameDayCancellationNotice.tsx
@@ -1,4 +1,4 @@
-import { LINE_QR_CODE_URL } from "@/app/helper/data/contacts";
+import { CONTACT_EMAIL, LINE_QR_CODE_URL } from "@/app/helper/data/contacts";
 import React from "react";
 
 const SameDayCancellationNotice = ({
@@ -9,28 +9,20 @@ const SameDayCancellationNotice = ({
   return language === "ja" ? (
     <p>
       当日（日本時間基準）のクラスをキャンセルされる際は、恐れ入りますが
-      <a
-        href={LINE_QR_CODE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ textDecoration: "none" }}
-      >
-        アーソボLINEまでご連絡ください
+      <a href={LINE_QR_CODE_URL} target="_blank" rel="noopener noreferrer">
+        アーソボLINE
       </a>
-      。なお、当日キャンセルは振替の対象外となりますのでご了承ください。
+      か<a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+      までご連絡ください。なお、当日キャンセルは振替の対象外となりますのでご了承ください。
     </p>
   ) : (
     <p>
       For same-day cancellations (based on Japan time), please contact us via{" "}
-      <a
-        href={LINE_QR_CODE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ textDecoration: "none" }}
-      >
+      <a href={LINE_QR_CODE_URL} target="_blank" rel="noopener noreferrer">
         AaasoBo! LINE
-      </a>
-      . Please note that same-day cancellations are not eligible for rebooking.
+      </a>{" "}
+      or at <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Please note
+      that same-day cancellations are not eligible for rebooking.
     </p>
   );
 };

--- a/frontend/src/app/helper/messages/customerDashboard.ts
+++ b/frontend/src/app/helper/messages/customerDashboard.ts
@@ -1,3 +1,5 @@
+import { CONTACT_EMAIL, LINE_QR_CODE_URL } from "../data/contacts";
+
 export const FAILED_TO_FETCH_REBOOKABLE_CLASSES =
   "We couldn't load your available classes to rebook. Please refresh the page or try again later. / 振替予約可能クラスの読み込みに失敗しました。ページを再読み込みするか、しばらくしてからもう一度お試しください。";
 
@@ -38,13 +40,13 @@ export const SELECTED_CLASSES_CANCELLATION_SUCCESS = {
 };
 
 export const FAILED_TO_CANCEL_INVALID_CLASSES = {
-  ja: "無効なクラスIDが含まれていたため、キャンセルに失敗しました。しばらくしてから再度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "The cancellation failed due to an invalid class ID. Please try again after some time. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: `無効なクラスIDが含まれていたため、キャンセルに失敗しました。しばらくしてから再度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）で連絡ください。`,
+  en: `The cancellation failed due to an invalid class ID. Please try again after some time. If the issue persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const FAILED_TO_CANCEL_CLASSES = {
-  ja: "選択したクラスのキャンセルに失敗しました。お手数ですが、しばらくしてから再度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "Failed to cancel the selected classes. Please try again after a short while. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: `選択したクラスのキャンセルに失敗しました。お手数ですが、しばらくしてから再度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でご連絡ください。`,
+  en: `Failed to cancel the selected classes. Please try again after a short while. If the issue persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const NO_CANCELABLE_CLASSES_MESSAGE = {
@@ -84,8 +86,8 @@ export const NO_CLASS_DETAILS = {
 };
 
 export const CANNOT_CANCEL_ON_OR_AFTER_CLASS_DAY = {
-  ja: "クラス当日以降のキャンセルは承っておりません。当日キャンセルをご希望の方は、contact@aaasobo.org までご連絡ください。",
-  en: "Same-day or later cancellations aren't available. Please contact contact@aaasobo.org if needed.",
+  ja: `クラス当日以降のキャンセルは承っておりません。当日キャンセルをご希望の方は、${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でご連絡ください。`,
+  en: `Same-day or later cancellations aren't available. Please contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}) if needed.`,
 };
 
 export const CANCEL_CLASS_CONFIRM_MESSAGE = {
@@ -99,13 +101,13 @@ export const CLASS_CANCELLATION_SUCCESS = {
 };
 
 export const FAILED_TO_CANCEL_INVALID_CLASS = {
-  ja: "クラスIDが無効だったため、キャンセルに失敗しました。しばらくしてから再度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "The cancellation failed due to an invalid class ID. Please try again after some time. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: `クラスIDが無効だったため、キャンセルに失敗しました。しばらくしてから再度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でご連絡ください。`,
+  en: `The cancellation failed due to an invalid class ID. Please try again after some time. If the issue persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const FAILED_TO_CANCEL_CLASS = {
-  ja: "クラスのキャンセルに失敗しました。お手数ですが、しばらくしてから再度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "Failed to cancel the class. Please try again after a short while. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: `クラスのキャンセルに失敗しました。お手数ですが、しばらくしてから再度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でご連絡ください。`,
+  en: `Failed to cancel the class. Please try again after a short while. If the issue persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const CANCELED_BY_INSTRUCTOR_NOTICE = {
@@ -125,8 +127,8 @@ export const NO_CHANGES_MADE_MESSAGE = {
 };
 
 export const PROFILE_UPDATE_EMAIL_VERIFICATION_FAILED_MESSAGE = {
-  ja: "新しいメールアドレスへ認証リンクを送信できなかったため、プロフィールを更新できませんでした。メールアドレスをご確認のうえ、再度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't update your profile because we were unable to send a verification link to your new email address. Please check your email address and try again. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: "新しいメールアドレスへ認証リンクを送信できなかったため、プロフィールを更新できませんでした。メールアドレスをご確認のうえ、再度お試しください。解決しない場合はスタッフまでご連絡ください。",
+  en: "We couldn't update your profile because we were unable to send a verification link to your new email address. Please check your email address and try again. If the issue persists, contact us.",
 };
 
 export const PROFILE_UPDATED_VERIFICATION_EMAIL_SENT = {
@@ -140,8 +142,8 @@ export const PROFILE_ADD_SUCCESS_MESSAGE = {
 };
 
 export const PROFILE_ADD_FAILED_MESSAGE = {
-  ja: "新しいお子さまのプロフィールを追加できませんでした。時間をおいて、もう一度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't add a new child profile. Please wait a moment and try again. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: "新しいお子さまのプロフィールを追加できませんでした。時間をおいて、もう一度お試しください。解決しない場合はスタッフまでご連絡ください。",
+  en: "We couldn't add a new child profile. Please wait a moment and try again. If the issue persists, contact us.",
 };
 
 export const PROFILE_UPDATE_SUCCESS_MESSAGE = {
@@ -150,8 +152,8 @@ export const PROFILE_UPDATE_SUCCESS_MESSAGE = {
 };
 
 export const PROFILE_UPDATE_FAILED_MESSAGE = {
-  ja: "プロフィールを更新できませんでした。時間をおいて、もう一度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't update the profile. Please wait a moment and try again. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: "プロフィールを更新できませんでした。時間をおいて、もう一度お試しください。解決しない場合はスタッフまでご連絡ください。",
+  en: "We couldn't update the profile. Please wait a moment and try again. If the issue persists, contact us.",
 };
 
 // Rebooking modal
@@ -190,12 +192,12 @@ export const REBOOK_CLASS_RESULT_MESSAGES: Record<string, LocalizedMessage> = {
     en: "Rebooking is available until 3 hours before the class starts. The deadline has passed, so please refresh the page and choose another class.",
   },
   "no subscription": {
-    ja: "ご契約情報が確認できなかったため、振替予約を完了できませんでした。ご不明な点がございましたら、contact@aaasobo.org までお気軽にお問い合わせください。",
-    en: "We couldn't complete the rebooking as your subscription couldn't be verified. If you have any questions, feel free to contact us at contact@aaasobo.org.",
+    ja: `ご契約情報が確認できなかったため、振替予約を完了できませんでした。ご不明な点がございましたら、${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でお気軽にお問い合わせください。`,
+    en: `We couldn't complete the rebooking as your subscription couldn't be verified. If you have any questions, feel free to contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
   },
   "outdated subscription": {
-    ja: "ご契約期間が終了しているため、振替予約できません。ご不明な点がございましたら、contact@aaasobo.org までお気軽にお問い合わせください。",
-    en: "We cannot complete the rebooking because your subscription period has ended. If you have any questions, feel free to contact us at contact@aaasobo.org.",
+    ja: `ご契約期間が終了しているため、振替予約できません。ご不明な点がございましたら、${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でお気軽にお問い合わせください。`,
+    en: `We cannot complete the rebooking because your subscription period has ended. If you have any questions, feel free to contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
   },
   "instructor conflict": {
     ja: "申し訳ございませんが、選択された時間はインストラクターがすでに予約されています。お手数ですが、ページを更新して別の時間かインストラクターをお選びください。",
@@ -206,8 +208,8 @@ export const REBOOK_CLASS_RESULT_MESSAGES: Record<string, LocalizedMessage> = {
     en: "The selected time is no longer available due to a change in the instructor's schedule. Please refresh the page and choose a different time or instructor.",
   },
   default: {
-    ja: "クラスの振替予約中にエラーが発生しました。しばらく時間をおいてから、もう一度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-    en: "An error occurred while rebooking the class. Please wait a moment and try again. If the issue persists, feel free to contact us at contact@aaasobo.org.",
+    ja: `クラスの振替予約中にエラーが発生しました。しばらく時間をおいてから、もう一度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でご連絡ください。`,
+    en: `An error occurred while rebooking the class. Please wait a moment and try again. If the issue persists, feel free to contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
   },
 };
 
@@ -233,8 +235,8 @@ export const PROFILE_DELETE_SUCCESS_MESSAGE = {
 };
 
 export const PROFILE_DELETE_FAILED_MESSAGE = {
-  ja: "プロフィールを削除できませんでした。時間をおいて、もう一度お試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't delete the profile. Please wait a moment and try again. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: `プロフィールを削除できませんでした。時間をおいて、もう一度お試しください。解決しない場合は ${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）で連絡ください。`,
+  en: `We couldn't delete the profile. Please wait a moment and try again. If the issue persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const PROFILE_DELETE_BLOCKED_BY_PAST_CLASS_MESSAGE = {
@@ -264,8 +266,8 @@ export const FREE_TRIAL_ALREADY_REMOVED_MESSAGE = {
 };
 
 export const FREE_TRIAL_REMOVE_ERROR_MESSAGE = {
-  ja: "無料トライアルクラスの削除に失敗しました。もう一度お試しください。解決しない場合は、contact@aaasobo.orgまでお問い合わせください。",
-  en: "Failed to remove the free trial class. Please try again. If the problem persists, contact us at contact@aaasobo.org.",
+  ja: `無料トライアルクラスの削除に失敗しました。もう一度お試しください。解決しない場合は、${CONTACT_EMAIL} かLINE（${LINE_QR_CODE_URL}）でお問い合わせください。`,
+  en: `Failed to remove the free trial class. Please try again. If the problem persists, contact us at ${CONTACT_EMAIL} or LINE(${LINE_QR_CODE_URL}).`,
 };
 
 export const WELCOME_MODAL_TITLE = {

--- a/frontend/src/app/helper/messages/formValidation.ts
+++ b/frontend/src/app/helper/messages/formValidation.ts
@@ -1,9 +1,9 @@
 export const GENERAL_ERROR_MESSAGE =
-  "Something went wrong. Please try again shortly. If the issue persists, contact us at contact@aaasobo.org. We're sorry for the inconvenience.";
+  "Something went wrong. Please try again shortly. If the issue persists, contact us. We're sorry for the inconvenience.";
 
 export const UNEXPECTED_ERROR_MESSAGE = {
-  ja: "エラーが発生しました。しばらくしてから、もう一度お試しください。問題が解決しない場合は、contact@aaasobo.org までご連絡ください。ご不便をおかけして申し訳ありません。",
-  en: "Something went wrong. Please try again after some time. If the issue persists, contact us at contact@aaasobo.org. We're sorry for the inconvenience.",
+  ja: "エラーが発生しました。時間をおいてもう一度お試しください。うまくいかない場合は、スタッフまでご連絡ください。ご迷惑をおかけして申し訳ありません。",
+  en: "Something went wrong. Please try again later. If the issue persists, contact us. We're sorry for the inconvenience.",
 };
 
 // RegisterForm
@@ -36,8 +36,8 @@ export const MULTIPLE_ITEMS_ALREADY_REGISTERED_ERROR = (items: string) => {
 };
 
 export const CONFIRMATION_EMAIL_SEND_FAILURE = {
-  ja: "確認メールの送信に失敗しました。前の画面に戻ってメールアドレスをご確認のうえ、もう一度「アカウント登録」をお試しください。解決しない場合は contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't send the confirmation email. Please check your email address and try again. Contact us at contact@aaasobo.org if the issue continues.",
+  ja: "確認メールの送信に失敗しました。前の画面に戻ってメールアドレスをご確認のうえ、もう一度「アカウント登録」をお試しください。解決しない場合はスタッフまでご連絡ください。",
+  en: "We couldn't send the confirmation email. Please check your email address and try again. If the issue persists, contact us",
 };
 
 export const INSTRUCTOR_REGISTRATION_SUCCESS_MESSAGE =
@@ -102,8 +102,8 @@ export const EMAIL_VERIFICATION_TOKEN_EXPIRED = {
 };
 
 export const EMAIL_VERIFICATION_UNEXPECTED_ERROR = {
-  ja: "認証リクエストを確認できませんでした。しばらくしてから下のリンクからログインし、新しい認証メールをリクエストしてください。問題が解決しない場合は、contact@aaasobo.org までご連絡ください。ご不便をおかけして申し訳ありません。",
-  en: "We couldn't verify your request. Please try logging in using the link below to request a new confirmation link later. If the issue persists, contact us at contact@aaasobo.org. We're sorry for the inconvenience.",
+  ja: "認証リクエストを確認できませんでした。しばらくしてから下のリンクからログインし、新しい認証メールをリクエストしてください。問題が解決しない場合はスタッフまでご連絡ください。ご不便をおかけして申し訳ありません。",
+  en: "We couldn't verify your request. Please try logging in using the link below to request a new confirmation link later. If the issue persists, contact us. We're sorry for the inconvenience.",
 };
 
 // ForgotPasswordForm
@@ -123,8 +123,8 @@ export const PASSWORD_RESET_EMAIL_SENT_MESSAGE = {
 };
 
 export const PASSWORD_RESET_EMAIL_SEND_FAILURE = {
-  ja: "パスワード再設定メールを送信できませんでした。後ほど再度お試しください。問題が解決しない場合は、contact@aaasobo.org までご連絡ください。ご不便をおかけして申し訳ありません。",
-  en: "We couldn't send the password reset email. Please try again later. If the issue persists, contact us at contact@aaasobo.org. We're sorry for the inconvenience.",
+  ja: "パスワード再設定メールを送信できませんでした。後ほど再度お試しください。問題が解決しない場合はスタッフまでご連絡ください。ご不便をおかけして申し訳ありません。",
+  en: "We couldn't send the password reset email. Please try again later. If the issue persists, contact us. We're sorry for the inconvenience.",
 };
 
 // ResetPasswordForm
@@ -134,8 +134,8 @@ export const PASSWORD_RESET_TOKEN_OR_USER_TYPE_ERROR = {
 };
 
 export const PASSWORD_SECURITY_CHECK_FAILED_MESSAGE = {
-  ja: "パスワードの安全性を確認できませんでした。時間をおいて、もう一度お試しください。問題が解決しない場合は、contact@aaasobo.org までご連絡ください。ご不便をおかけして申し訳ありません。",
-  en: "We couldn't check your password's security. Please try again later. If the issue persists, contact us at contact@aaasobo.org. We're sorry for the inconvenience.",
+  ja: "パスワードの安全性を確認できませんでした。時間をおいて、もう一度お試しください。問題が解決しない場合はスタッフまでご連絡ください。ご不便をおかけして申し訳ありません。",
+  en: "We couldn't check your password's security. Please try again later. If the issue persists, contact us. We're sorry for the inconvenience.",
 };
 
 export const PASSWORD_RESET_LINK_EXPIRED = {
@@ -144,8 +144,8 @@ export const PASSWORD_RESET_LINK_EXPIRED = {
 };
 
 export const TOKEN_OR_USER_NOT_FOUND_ERROR = {
-  ja: "パスワード再設定リンクの確認に失敗しました。複数のメールが届いている場合は、最新のものをご確認ください。うまくいかない場合は、contact@aaasobo.org までご連絡ください。",
-  en: "We couldn't verify your password reset link. If you've received multiple reset emails, please use the most recent one. If the issue persists, contact us at contact@aaasobo.org.",
+  ja: "パスワード再設定リンクの確認に失敗しました。複数のメールが届いている場合は、最新のものをご確認ください。うまくいかない場合はスタッフまでご連絡ください。",
+  en: "We couldn't verify your password reset link. If you've received multiple reset emails, please use the most recent one. If the issue persists, contact us.",
 };
 
 export const RESET_TOKEN_VERIFICATION_FAILED = {


### PR DESCRIPTION
### Overview

At the client's request, ensured both the email address and LINE URL are displayed in the contact information.

<img width="1439" height="781" alt="スクリーンショット 2025-07-25 午前6 54 12" src="https://github.com/user-attachments/assets/6fa0c95e-542a-49f7-9e22-844ef5f7e251" />
<img width="1436" height="778" alt="スクリーンショット 2025-07-25 午前7 26 19" src="https://github.com/user-attachments/assets/52b4fb45-40d9-47be-801c-fea1be6233d2" />
