### PR TITLE
refactor: make instructor availabilities unavailable on holidays

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1932,7 +1932,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
-      "license": "MIT",
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -1718,7 +1718,7 @@ async function insertEvents() {
         color: "#FAD7CD",
       },
       {
-        name: "お休み振替対象日 / Rebookable Day",
+        name: "お休み振替対象日 / No Class (Rebookable)",
         color: "#FF0000",
       },
       {

--- a/backend/src/services/instructorsAvailabilitiesService.ts
+++ b/backend/src/services/instructorsAvailabilitiesService.ts
@@ -15,7 +15,7 @@ type InstructorAvailability = {
  * Only includes slots where:
  * - The instructor is not marked as unavailable
  * - There are no existing classes that are booked or rebooked at those times
- * - Excludes any instructor availability falling on dates marked as events named "AaasoBo! Holiday".
+ * - Excludes any instructor availability falling on dates marked as events named "お休み / No Class" and "お休み振替対象日 / No Class (Rebookable)".
  *   This exclusion is based on matching the date (ignoring time) between InstructorAvailability.dateTime and Schedule.date.
  */
 export const getCalendarAvailabilities = async (instructorId: number) => {
@@ -41,7 +41,7 @@ export const getCalendarAvailabilities = async (instructorId: number) => {
         SELECT 1 FROM "Schedule" s
         JOIN "Event" e ON e."id" = s."eventId"
         WHERE ia."dateTime"::date = s."date"
-          AND e."name" = 'AaasoBo! Holiday'
+          AND e."name" IN ('お休み / No Class', 'お休み振替対象日 / No Class (Rebookable)')
       )
   `;
 
@@ -65,7 +65,7 @@ export const getCalendarAvailabilities = async (instructorId: number) => {
  * Only includes slots where:
  * - The instructor is not marked as unavailable
  * - There are no existing classes that are booked or rebooked at those times
- * - Excludes any instructor availability falling on dates marked as events named "お休み / No Class".
+ * - Excludes any instructor availability falling on dates marked as events named "お休み / No Class" and "お休み振替対象日 / No Class (Rebookable)".
  *   This exclusion is based on matching the date (ignoring time) between InstructorAvailability.dateTime and Schedule.date.
  */
 export const getInstructorAvailabilities = async (
@@ -95,7 +95,7 @@ export const getInstructorAvailabilities = async (
       SELECT 1 FROM "Schedule" s
       JOIN "Event" e ON e."id" = s."eventId"
       WHERE ia."dateTime"::date = s."date"
-        AND e."name" = 'お休み / No Class'
+        AND e."name" IN ('お休み / No Class', 'お休み振替対象日 / No Class (Rebookable)')
     )
   `;
 


### PR DESCRIPTION
### Overview

1. Translated "お休み振替対象日" as "No Class (Rebookable)"
2. Updated logic to exclude instructor availabilities on both "お休み / No Class" and "お休み振替対象日 / No Class (Rebookable)" days