### PR TITLE
Improve class status edit feature

### DIFF
--- a/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classItem/ClassItemForAdmin.tsx
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classItem/ClassItemForAdmin.tsx
@@ -41,7 +41,12 @@ const ClassItemForAdmin = ({
     "rebooked",
     "completed",
   ];
-  const bookedStatuses: ClassStatus[] = ["booked", "rebooked"];
+  const bookedStatuses: ClassStatus[] = [
+    "booked",
+    "rebooked",
+    "completed",
+    "canceledByInstructor",
+  ];
 
   const classDateTime = new Date(classItem.dateTime);
   const classStartTime = formatTime24Hour(classDateTime);

--- a/frontend/src/app/helper/utils/classItemHandlers.ts
+++ b/frontend/src/app/helper/utils/classItemHandlers.ts
@@ -90,7 +90,7 @@ export const handleClassStatusUpdate = async ({
 
   if (isAdminAuthenticated && selectedStatus) {
     const confirmed = window.confirm(
-      `Are you sure you want to change the class status to "${selectedStatus}"?`,
+      "Are you sure you want to change the class status?",
     );
     if (!confirmed) return;
   }

--- a/frontend/src/app/helper/utils/classItemHandlers.ts
+++ b/frontend/src/app/helper/utils/classItemHandlers.ts
@@ -90,7 +90,7 @@ export const handleClassStatusUpdate = async ({
 
   if (isAdminAuthenticated && selectedStatus) {
     const confirmed = window.confirm(
-      "Are you sure you want to change the class status?",
+      `Are you sure you want to change the class status to "${selectedStatus}"?`,
     );
     if (!confirmed) return;
   }

--- a/frontend/src/app/helper/utils/classItemHandlers.ts
+++ b/frontend/src/app/helper/utils/classItemHandlers.ts
@@ -90,7 +90,7 @@ export const handleClassStatusUpdate = async ({
 
   if (isAdminAuthenticated && selectedStatus) {
     const confirmed = window.confirm(
-      "Are you sure you want to change the class status? This change cannot be undone.",
+      "Are you sure you want to change the class status?",
     );
     if (!confirmed) return;
   }


### PR DESCRIPTION
### Overview
- Make class status editable even after being set to "Completed" or "Canceled by instructor" in admin dashboard. 
   Note: This update is based on the client's requirement 

###
Class status is editable even when the status is "Completed"
<img width="800" height="756" alt="Screenshot 2025-08-10 at 22 49 12" src="https://github.com/user-attachments/assets/59482214-c239-4449-baab-9a5e7d2b94b6" />
↓
Enable updating the status to either "Completed" or "Canceled by Instructor"
<img width="800" height="758" alt="Screenshot 2025-08-10 at 22 49 33" src="https://github.com/user-attachments/assets/4480d3e7-4e99-4760-9ed9-d7938f96f902" />
↓
Complete to update the status
<img width="800" height="754" alt="Screenshot 2025-08-10 at 22 49 49" src="https://github.com/user-attachments/assets/84468a9c-e8de-429f-927d-f36368240013" />
