### PR TITLE
feat: update claude.yml permissions to enable PR creation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write # Required for Claude to push commits and create branches
+      pull-requests: write # Required for Claude to create PRs
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
Updates the Claude GitHub Action permissions to allow Claude to create pull requests when requested by users.

## Changes Made
- Added `contents: write` permission to enable Claude to push commits and create branches
- Added `pull-requests: write` permission to enable Claude to create PRs
- Added explanatory comments for each permission

## Why This Change Is Needed
Currently, Claude can only read and comment on issues/PRs but cannot create new PRs when users request changes. This limitation prevents Claude from following the standard development workflow of creating feature branches and PRs for proposed changes.

## Security Considerations
These permissions are scoped to the Claude GitHub Action and only activate when Claude is explicitly mentioned (@claude) in issues or comments. The write permissions are necessary for Claude to participate in the development workflow while maintaining security through explicit user triggers.

## Test Plan
- [ ] Verify the workflow still runs successfully on new issues/comments
- [ ] Test Claude's ability to create PRs when requested
- [ ] Confirm that permissions are appropriately scoped

Closes #215

🤖 Generated with [Claude Code](https://claude.ai/code)