### PR TITLE
feat: add workflows: write permission to claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write # Required for Claude to push commits and create branches
       pull-requests: write # Required for Claude to create PRs
+      workflows: write # Required for Claude to modify workflow files
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
Adds the `workflows: write` permission to the Claude GitHub Action configuration to enable Claude to modify workflow files when requested by users.

## Changes Made
- Added `workflows: write` permission to the permissions block
- Added explanatory comment for the new permission

## Why This Change Is Needed
Claude needs this permission to:
- Update existing workflow files (.github/workflows/*)
- Create new workflow files when requested
- Modify CI/CD configurations as part of development tasks

## Security Considerations
This permission follows the same security model as other write permissions:
- Scoped to the Claude GitHub Action
- Only activates when Claude is explicitly mentioned (@claude) in issues or comments
- Maintains the existing trigger-based access control

## Current Permissions After This Change
- contents: write (for pushing commits and creating branches)
- pull-requests: write (for creating PRs)
- workflows: write (for modifying workflow files) ← NEW
- issues: read
- id-token: write
- actions: read (for reading CI results on PRs)

Closes #217

🤖 Generated with [Claude Code](https://claude.ai/code)