### PR TITLE
feat: update claude.yml to use issues: write permission

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write # Required for Claude to push commits and create branches
       pull-requests: write # Required for Claude to create PRs
       workflows: write # Required for Claude to modify workflow files
-      issues: read
+      issues: write # Required for Claude to manage issues (labels, descriptions, status)
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
Updates the Claude GitHub Action to use `issues: write` permission instead of `issues: read` to enable Claude to manage issues beyond just reading them.

## Changes Made
- Changed `issues: read` to `issues: write` in the permissions block
- Updated the comment to reflect the expanded issue management capabilities

## Why This Change Is Needed
Claude needs this permission to:
- Add and modify issue labels based on analysis
- Update issue descriptions with additional context
- Close/reopen issues when tasks are completed
- Perform comprehensive issue management tasks when requested by users

## Security Considerations
This permission follows the same security model as other write permissions:
- Scoped to the Claude GitHub Action
- Only activates when Claude is explicitly mentioned (@claude) in issues or comments
- Maintains the existing trigger-based access control

## Complete Permissions After This Change
- contents: write (for pushing commits and creating branches)
- pull-requests: write (for creating PRs)
- workflows: write (for modifying workflow files)
- issues: write (for managing issues) ← UPDATED
- id-token: write
- actions: read (for reading CI results on PRs)

## Use Cases
With this permission, Claude can now:
- Automatically label issues based on content analysis
- Update issue descriptions with structured information
- Close issues when related PRs are merged
- Manage issue lifecycle as part of development workflows

Closes #219

🤖 Generated with [Claude Code](https://claude.ai/code)