### PR TITLE
fix: remove invalid workflows: write permission from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,6 @@ jobs:
     permissions:
       contents: write # Required for Claude to push commits and create branches
       pull-requests: write # Required for Claude to create PRs
-      workflows: write # Required for Claude to modify workflow files
       issues: write # Required for Claude to manage issues (labels, descriptions, status)
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
Removes the invalid `workflows: write` permission from the Claude GitHub Action configuration that was causing a workflow validation error.

## Problem
The workflow was failing with this error:
```
Invalid workflow file: .github/workflows/claude.yml#L1
(Line: 24, Col: 7): Unexpected value 'workflows'
```

## Solution
- Removed the invalid `workflows: write` permission from line 24
- Claude can still modify workflow files using the existing `contents: write` permission
- All other permissions remain intact and functional

## Why This Works
GitHub Actions workflow files are regular repository files, so `contents: write` permission is sufficient for Claude to:
- Create branches
- Edit workflow files (like any other file)
- Commit changes
- Create PRs with the changes

No special `workflows` permission is needed - it doesn't exist in the GitHub Actions permission model.

## Remaining Permissions
After this fix, Claude retains all necessary permissions:
- ✅ `contents: write` (push commits, create branches, edit all files including workflows)
- ✅ `pull-requests: write` (create PRs)
- ✅ `issues: write` (manage issues)
- ✅ `id-token: write`
- ✅ `actions: read` (read CI results)

## Next Steps
Once merged, the workflow should function correctly and Claude will be able to create PRs when mentioned in issues.

🤖 Generated with [Claude Code](https://claude.ai/code)