### PR TITLE
Implement Zod-based OpenAPI Integration for Users Router

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.1.0",
         "@panva/hkdf": "^1.2.1",
         "@prisma/client": "^5.19.1",
         "@vercel/blob": "^1.1.1",
@@ -23,7 +24,9 @@
         "multer": "^2.0.1",
         "resend": "^4.1.2",
         "rrule": "^2.8.1",
-        "uuid": "^11.0.5"
+        "swagger-ui-express": "^5.0.1",
+        "uuid": "^11.0.5",
+        "zod": "^4.1.0"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.4",
@@ -35,6 +38,7 @@
         "@types/multer": "^1.4.13",
         "@types/node": "^20.14.6",
         "@types/supertest": "^6.0.3",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "nodemon": "^3.1.0",
         "prettier": "^3.3.2",
@@ -47,6 +51,18 @@
       },
       "engines": {
         "node": "20.x"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.1.0.tgz",
+      "integrity": "sha512-tQFxVs05J/6QXXqIzj6rTRk3nj1HFs4pe+uThwE95jL5II2JfpVXkK+CqkO7aT0Do5AYqO6LDrKpleLUFXgY+g==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1034,6 +1050,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -1300,6 +1323,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -3575,6 +3609,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4390,6 +4433,30 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
+      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -4744,18 +4811,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
-      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
     "node_modules/vite-node/node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4808,15 +4863,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.0.3",
@@ -5320,6 +5366,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -5328,6 +5386,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.0.tgz",
+      "integrity": "sha512-UWxluYj2IDX9MHRXTMbB/2eeWrAMmmMSESM+MfT9MQw8U1qo9q5ASW08anoJh6AJ7pkt099fLdNFmfI+4aChHg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4811,6 +4811,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/vite-node/node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4863,6 +4875,15 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vite-node/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "@types/multer": "^1.4.13",
     "@types/node": "^20.14.6",
     "@types/supertest": "^6.0.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "nodemon": "^3.1.0",
     "prettier": "^3.3.2",
@@ -39,6 +40,7 @@
     "vitest-mock-extended": "^3.1.0"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.1.0",
     "@panva/hkdf": "^1.2.1",
     "@prisma/client": "^5.19.1",
     "@vercel/blob": "^1.1.1",
@@ -53,6 +55,8 @@
     "multer": "^2.0.1",
     "resend": "^4.1.2",
     "rrule": "^2.8.1",
-    "uuid": "^11.0.5"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.0.5",
+    "zod": "^4.1.0"
   }
 }

--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -1,5 +1,6 @@
-import { Request, Response } from "express";
+import { Response } from "express";
 import bcrypt from "bcrypt";
+import { ValidatedRequest } from "../middlewares/validationMiddleware";
 import {
   getAdminByEmail,
   updateAdminPassword,
@@ -28,6 +29,12 @@ import {
 } from "../services/passwordResetTokensService";
 import { hashPassword } from "../helper/commonUtils";
 import { Customer } from "@prisma/client";
+import {
+  AuthenticateRequest,
+  SendPasswordResetRequest,
+  VerifyResetTokenRequest,
+  UpdatePasswordRequest,
+} from "../schemas/usersSchema";
 
 const getUserByEmail = async (userType: UserType, email: string) => {
   switch (userType) {
@@ -41,14 +48,10 @@ const getUserByEmail = async (userType: UserType, email: string) => {
 };
 
 export const authenticateUserController = async (
-  req: Request,
+  req: ValidatedRequest<AuthenticateRequest>,
   res: Response,
 ) => {
   const { email, password, userType } = req.body;
-
-  if (!email || !password || !userType) {
-    return res.sendStatus(400);
-  }
 
   // Normalize email
   const normalizedEmail = email.trim().toLowerCase();
@@ -103,14 +106,10 @@ export const authenticateUserController = async (
 };
 
 export const sendUserResetEmailController = async (
-  req: Request,
+  req: ValidatedRequest<SendPasswordResetRequest>,
   res: Response,
 ) => {
   const { email, userType } = req.body;
-
-  if (!email || !userType) {
-    return res.sendStatus(400);
-  }
 
   const normalizedEmail = email.trim().toLowerCase();
 
@@ -149,12 +148,11 @@ export const sendUserResetEmailController = async (
   }
 };
 
-export const updatePasswordController = async (req: Request, res: Response) => {
+export const updatePasswordController = async (
+  req: ValidatedRequest<UpdatePasswordRequest>,
+  res: Response,
+) => {
   const { token, userType, password } = req.body;
-
-  if (!token || !userType || !password) {
-    return res.sendStatus(400);
-  }
 
   try {
     const existingToken = await getPasswordResetTokenByToken(token);
@@ -202,14 +200,10 @@ export const updatePasswordController = async (req: Request, res: Response) => {
 };
 
 export const verifyResetTokenController = async (
-  req: Request,
+  req: ValidatedRequest<VerifyResetTokenRequest>,
   res: Response,
 ) => {
   const { token, userType } = req.body;
-
-  if (!token || !userType) {
-    return res.sendStatus(400);
-  }
 
   try {
     const existingToken = await getPasswordResetTokenByToken(token);

--- a/backend/src/openapi/routerRegistry.ts
+++ b/backend/src/openapi/routerRegistry.ts
@@ -1,0 +1,68 @@
+import {
+  OpenAPIRegistry,
+  ResponseConfig,
+} from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { RequestHandler } from "express";
+
+export type RouteConfig = {
+  method: "get" | "post" | "put" | "patch" | "delete";
+  requestSchema?: z.ZodSchema;
+  handler: RequestHandler;
+  openapi: {
+    summary: string;
+    description: string;
+    responses: Record<string, { description: string; schema?: z.ZodSchema }>;
+  };
+};
+
+/**
+ * Register routes from config into OpenAPI registry with base path
+ */
+export const registerRoutesFromConfig = (
+  registry: OpenAPIRegistry,
+  basePath: string,
+  routeConfigs: Record<string, RouteConfig>,
+) => {
+  Object.entries(routeConfigs).forEach(([path, config]) => {
+    const fullPath = basePath + path;
+
+    // Build responses
+    const responses: Record<string, ResponseConfig> = {};
+    Object.entries(config.openapi.responses).forEach(
+      ([status, responseConfig]) => {
+        responses[status] = {
+          description: responseConfig.description,
+        };
+
+        if (responseConfig.schema) {
+          responses[status].content = {
+            "application/json": {
+              schema: responseConfig.schema,
+            },
+          };
+        }
+      },
+    );
+
+    // Register path
+    registry.registerPath({
+      method: config.method,
+      path: fullPath,
+      summary: config.openapi.summary,
+      description: config.openapi.description,
+      request: config.requestSchema
+        ? {
+            body: {
+              content: {
+                "application/json": {
+                  schema: config.requestSchema,
+                },
+              },
+            },
+          }
+        : undefined,
+      responses,
+    });
+  });
+};

--- a/backend/src/openapi/spec.ts
+++ b/backend/src/openapi/spec.ts
@@ -1,0 +1,28 @@
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV3,
+} from "@asteasolutions/zod-to-openapi";
+
+// Global OpenAPI registry
+export const globalRegistry = new OpenAPIRegistry();
+
+// OpenAPI specification generator
+export const createOpenApiSpec = () => {
+  const generator = new OpenApiGeneratorV3(globalRegistry.definitions);
+
+  return generator.generateDocument({
+    openapi: "3.0.0",
+    info: {
+      version: "1.0.0",
+      title: "AaasoBo! Management System API",
+      description:
+        "API documentation for AaasoBo! online English conversation service management system",
+    },
+    servers: [
+      {
+        url: "http://localhost:4000",
+        description: "Local development server",
+      },
+    ],
+  });
+};

--- a/backend/src/routes/usersRouter.ts
+++ b/backend/src/routes/usersRouter.ts
@@ -5,12 +5,109 @@ import {
   updatePasswordController,
   verifyResetTokenController,
 } from "../controllers/usersController";
+import { z } from "zod";
+import { registerRoutes } from "../middlewares/validationMiddleware";
+import { ErrorResponse } from "../schemas/commonSchemas";
+import {
+  authenticateSchema,
+  sendPasswordResetSchema,
+  verifyResetTokenSchema,
+  updatePasswordSchema,
+} from "../schemas/usersSchema";
 
-export const usersRouter = express.Router();
+const authenticateConfig = {
+  method: "post" as const,
+  requestSchema: authenticateSchema,
+  handler: authenticateUserController,
+  openapi: {
+    summary: "Authenticate user",
+    description: "Authenticate user credentials",
+    responses: {
+      200: {
+        description: "Authentication successful",
+        schema: z.object({
+          id: z.number().int().positive().describe("User ID"),
+        }),
+      },
+      400: {
+        description: "Bad request - validation failed",
+        schema: ErrorResponse,
+      },
+      401: { description: "Unauthorized - invalid credentials" },
+      403: { description: "Forbidden - email not verified (customers only)" },
+      503: {
+        description: "Service unavailable - failed to send verification email",
+      },
+    },
+  },
+} as const;
+
+const sendPasswordResetConfig = {
+  method: "post" as const,
+  requestSchema: sendPasswordResetSchema,
+  handler: sendUserResetEmailController,
+  openapi: {
+    summary: "Send password reset email",
+    description: "Send password reset email",
+    responses: {
+      201: { description: "Password reset email sent successfully" },
+      400: {
+        description: "Bad request - validation failed",
+        schema: ErrorResponse,
+      },
+      404: { description: "User not found" },
+      503: { description: "Service unavailable - failed to send email" },
+    },
+  },
+} as const;
+
+const verifyResetTokenConfig = {
+  method: "post" as const,
+  requestSchema: verifyResetTokenSchema,
+  handler: verifyResetTokenController,
+  openapi: {
+    summary: "Verify password reset token",
+    description: "Verify password reset token",
+    responses: {
+      200: { description: "Token is valid" },
+      400: {
+        description: "Bad request - validation failed",
+        schema: ErrorResponse,
+      },
+      404: { description: "Token not found or user not found" },
+      410: { description: "Token expired" },
+    },
+  },
+} as const;
+
+const updatePasswordConfig = {
+  method: "patch" as const,
+  requestSchema: updatePasswordSchema,
+  handler: updatePasswordController,
+  openapi: {
+    summary: "Update password",
+    description: "Update user password using reset token",
+    responses: {
+      201: { description: "Password updated successfully" },
+      400: {
+        description: "Bad request - validation failed",
+        schema: ErrorResponse,
+      },
+      404: { description: "Token not found or user not found" },
+      410: { description: "Token expired" },
+    },
+  },
+} as const;
 
 // http://localhost:4000/users
+const routeConfigs = {
+  "/authenticate": authenticateConfig,
+  "/send-password-reset": sendPasswordResetConfig,
+  "/verify-reset-token": verifyResetTokenConfig,
+  "/update-password": updatePasswordConfig,
+} as const;
 
-usersRouter.post("/authenticate", authenticateUserController);
-usersRouter.post("/send-password-reset", sendUserResetEmailController);
-usersRouter.post("/verify-reset-token", verifyResetTokenController);
-usersRouter.patch("/update-password", updatePasswordController);
+export const usersRouter = express.Router();
+registerRoutes(usersRouter, routeConfigs);
+
+export { routeConfigs as usersRouterConfig };

--- a/backend/src/schemas/commonSchemas.ts
+++ b/backend/src/schemas/commonSchemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+// Common user type enum used across multiple routers
+export const UserType = z
+  .enum(["admin", "customer", "instructor"])
+  .describe("Type of user account");
+
+// Standard error response used across all API endpoints
+export const ErrorResponse = z.object({
+  error: z.string().describe("Error message"),
+});

--- a/backend/src/schemas/usersSchema.ts
+++ b/backend/src/schemas/usersSchema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { UserType } from "./commonSchemas";
+
+export const authenticateSchema = z.object({
+  email: z.email(),
+  password: z.string().min(1).describe("User's password"),
+  userType: UserType,
+});
+
+export const sendPasswordResetSchema = z.object({
+  email: z.email(),
+  userType: UserType,
+});
+
+export const verifyResetTokenSchema = z.object({
+  token: z.string().min(1).describe("Password reset token"),
+  userType: UserType,
+});
+
+export const updatePasswordSchema = z.object({
+  token: z.string().min(1).describe("Password reset token"),
+  userType: UserType,
+  password: z.string().min(1).describe("New password"),
+});
+
+export type AuthenticateRequest = z.infer<typeof authenticateSchema>;
+export type SendPasswordResetRequest = z.infer<typeof sendPasswordResetSchema>;
+export type VerifyResetTokenRequest = z.infer<typeof verifyResetTokenSchema>;
+export type UpdatePasswordRequest = z.infer<typeof updatePasswordSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import swaggerUi from "swagger-ui-express";
 import "dotenv/config";
 import { instructorsRouter } from "./routes/instructorsRouter";
 import { classesRouter } from "./routes/classesRouter";
@@ -12,8 +13,10 @@ import { plansRouter } from "./routes/plansRouter";
 import { eventsRouter } from "./routes/eventsRouter";
 import { subscriptionsRouter } from "./routes/subscriptionsRouter";
 import { indexRouter } from "./routes/indexRouter";
-import { usersRouter } from "./routes/usersRouter";
+import { usersRouter, usersRouterConfig } from "./routes/usersRouter";
 import { jobsRouter } from "./routes/jobsRouter";
+import { globalRegistry, createOpenApiSpec } from "./openapi/spec";
+import { registerRoutesFromConfig } from "./openapi/routerRegistry";
 
 export const server = express();
 
@@ -48,3 +51,15 @@ server.use("/events", eventsRouter);
 server.use("/subscriptions", subscriptionsRouter);
 server.use("/users", usersRouter);
 server.use("/jobs", jobsRouter);
+
+// OpenAPI Documentation (only in development)
+if (process.env.NODE_ENV === "development") {
+  registerRoutesFromConfig(globalRegistry, "/users", usersRouterConfig);
+
+  const openApiSpec = createOpenApiSpec();
+  server.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));
+  server.get("/api-docs.json", (req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.send(openApiSpec);
+  });
+}


### PR DESCRIPTION
Resolves #228

# Implement Zod-based OpenAPI Integration for Users Router

This PR introduces Zod-based request validation and automatic OpenAPI documentation generation for the `/users` router as a starter.

## What and Why

**Zod**
- Zod is a schema validation library that validates data at runtime and generates types automatically
- We use it to have a single source of truth for validation, typing, and documentation instead of managing them separately

**OpenAPI**
- OpenAPI is a specification for describing REST APIs that generates interactive documentation
- We use it to provide auto-generated Swagger UI and enable type-safe client SDK generation for the frontend

## How to Define Routes with Zod

See the new pattern in [`src/routes/usersRouter.ts`](backend/src/routes/usersRouter.ts) - define Zod schemas, create route configs with OpenAPI metadata, then register with `registerRoutes()`.

## Key Benefits

- **Type Safety**: Controllers receive validated, properly typed data via `ValidatedRequest<T>`
- **Single Source of Truth**: One Zod schema handles validation, typing, and documentation  
- **Living Documentation**: Auto-generated Swagger UI at `/api-docs` (development only)

## Development Access

Add this line to `backend/.env` to enable the Swagger UI documents:

```sh
NODE_ENV="development"
```

- **Swagger UI**: http://localhost:4000/api-docs
- **OpenAPI Spec**: http://localhost:4000/api-docs.json (I'm planning to use this later)

## Next Steps

- Frontend integration to use Zod schemas for type-safe API communication
- Expand this pattern to the remaining 11 routers for complete API coverage