### PR TITLE
fix: add default cases to switch statements in validationUtils

### DIFF
--- a/frontend/src/app/helper/utils/validationUtils.ts
+++ b/frontend/src/app/helper/utils/validationUtils.ts
@@ -94,6 +94,8 @@ export const getLoginPath = (type: UserType): string => {
       return "/instructors/login";
     case "customer":
       return "/customers/login";
+    default:
+      throw new Error(`Unknown user type: ${type}`);
   }
 };
 
@@ -106,5 +108,7 @@ export const getForgotPasswordPath = (type: UserType): string => {
       return "/auth/forgot-password?type=instructor";
     case "customer":
       return "/auth/forgot-password?type=customer";
+    default:
+      throw new Error(`Unknown user type: ${type}`);
   }
 };


### PR DESCRIPTION
Fixes TypeScript compilation error in Vercel build by adding missing default cases to switch statements.

Adds missing default cases to `getLoginPath` and `getForgotPasswordPath` functions to resolve TypeScript compilation error in Vercel build. Both functions now throw descriptive errors for unknown user types.

Fixes #263

Generated with [Claude Code](https://claude.ai/code)