### PR TITLE
fix: resolve TypeScript error in AdminProfile component

### DIFF
--- a/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.tsx
@@ -73,7 +73,7 @@ function AdminProfile({
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement>,
-    field: keyof Admin,
+    field: keyof Admin & string,
   ) => {
     if (latestAdmin) {
       setLatestAdmin({ ...latestAdmin, [field]: e.target.value });


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error in AdminProfile component
- Issue: `keyof Admin` parameter was incompatible with `clearErrorMessage` function expecting `string`
- Solution: Used intersection type `keyof Admin & string` for type-safe parameter handling

## Details
The error occurred because TypeScript infers `keyof Admin` as `string | number | symbol`, but the `clearErrorMessage` function expects only `string`. Since the Admin interface only has string keys (`id`, `name`, `email`), using the intersection type `keyof Admin & string` ensures type safety without unsafe casting.

## Test plan
- [x] Local build passes (`npm run build`)
- [x] TypeScript compilation successful
- [x] No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.ai/code)