### PR TITLE
fix: resolve TypeScript error in AvailabilityCalendar

### DIFF
--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.tsx
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.tsx
@@ -9,6 +9,7 @@ import {
   batchUpdateInstructorAbsences,
   type AbsenceChange,
 } from "@/app/actions/instructorAbsence";
+import type { InstructorAbsence } from "@shared/schemas/instructors";
 import Calendar from "@/app/components/features/calendar/Calendar";
 import Modal from "@/app/components/elements/modal/Modal";
 import ActionButton from "@/app/components/elements/buttons/actionButton/ActionButton";
@@ -105,7 +106,7 @@ export default function AvailabilityCalendar({
         // Add absences (red) - filter to current view range
         if ("absences" in absencesResponse) {
           const absenceEvents = absencesResponse.absences
-            .filter((absence) => {
+            .filter((absence: InstructorAbsence) => {
               const absenceDate = new Date(absence.absentAt);
               return absenceDate >= info.start && absenceDate < info.end;
             })


### PR DESCRIPTION
## Summary
- Fix TypeScript error "Parameter 'absence' implicitly has an 'any' type" in AvailabilityCalendar component
- Add explicit type annotation using existing InstructorAbsence type from shared schemas
- Resolve Vercel build failure caused by type inference issues

## Test plan
- [x] Verify local TypeScript compilation passes
- [x] Confirm proper type imports from @shared/schemas/instructors
- [ ] Verify Vercel deployment succeeds without TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)