### PR TITLE
feat: implement Zod validation for plans router

### DIFF
--- a/backend/src/controllers/plansController.ts
+++ b/backend/src/controllers/plansController.ts
@@ -1,9 +1,7 @@
 import { Request, Response } from "express";
-import {
-  getAllPlans,
-  getPlanById,
-  getWeeklyClassTimes,
-} from "../services/plansService";
+import { RequestWithParams } from "../middlewares/validationMiddleware";
+import { getAllPlans, getPlanById } from "../services/plansService";
+import type { PlanIdParams } from "@shared/schemas/plans";
 
 // Get all plans' information
 export const getAllPlansController = async (_: Request, res: Response) => {
@@ -23,11 +21,11 @@ function setErrorResponse(res: Response, error: unknown) {
 }
 
 // Get plan by ID
-export const getPlanController = async (req: Request, res: Response) => {
-  const id = parseInt(req.params.id);
-  if (isNaN(id)) {
-    return res.status(400).json({ message: "Invalid ID provided." });
-  }
+export const getPlanController = async (
+  req: RequestWithParams<PlanIdParams>,
+  res: Response,
+) => {
+  const { id } = req.params;
   try {
     const plan = await getPlanById(id);
     if (!plan) {

--- a/backend/src/routes/plansRouter.ts
+++ b/backend/src/routes/plansRouter.ts
@@ -3,10 +3,65 @@ import {
   getAllPlansController,
   getPlanController,
 } from "../../src/controllers/plansController";
+import { registerRoutes } from "../middlewares/validationMiddleware";
+import {
+  PlanIdParams,
+  PlanResponse,
+  PlansListResponse,
+} from "@shared/schemas/plans";
+import { MessageErrorResponse } from "@shared/schemas/common";
 
 export const plansRouter = express.Router();
 
 // http://localhost:4000/plans
 
-plansRouter.get("/", getAllPlansController);
-plansRouter.get("/:id", getPlanController);
+// Route configurations with Zod validation
+const getAllPlansConfig = {
+  method: "get" as const,
+  handler: getAllPlansController,
+  openapi: {
+    summary: "Get all active plans",
+    description: "Retrieves a list of all non-terminated plans",
+    responses: {
+      "200": {
+        description: "List of active plans",
+        schema: PlansListResponse,
+      },
+      "500": {
+        description: "Internal server error",
+        schema: MessageErrorResponse,
+      },
+    },
+  },
+} as const;
+
+const getPlanConfig = {
+  method: "get" as const,
+  handler: getPlanController,
+  paramsSchema: PlanIdParams,
+  openapi: {
+    summary: "Get plan by ID",
+    description: "Retrieves a specific plan by its ID",
+    responses: {
+      "200": {
+        description: "Plan information",
+        schema: PlanResponse,
+      },
+      "400": { description: "Invalid plan ID", schema: MessageErrorResponse },
+      "404": { description: "Plan not found", schema: MessageErrorResponse },
+      "500": {
+        description: "Internal server error",
+        schema: MessageErrorResponse,
+      },
+    },
+  },
+} as const;
+
+const routeConfigs = {
+  "/": [getAllPlansConfig],
+  "/:id": [getPlanConfig],
+} as const;
+
+registerRoutes(plansRouter, routeConfigs);
+
+export { routeConfigs as plansRouterConfig };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,7 +12,7 @@ import {
 import { adminsRouter } from "./routes/adminsRouter";
 import { childrenRouter } from "./routes/childrenRouter";
 import { recurringClassesRouter } from "./routes/recurringClassesRouter";
-import { plansRouter } from "./routes/plansRouter";
+import { plansRouter, plansRouterConfig } from "./routes/plansRouter";
 import { eventsRouter, eventsRouterConfig } from "./routes/eventsRouter";
 import { subscriptionsRouter } from "./routes/subscriptionsRouter";
 import { indexRouter } from "./routes/indexRouter";
@@ -72,6 +72,7 @@ if (process.env.NODE_ENV === "development") {
   registerRoutesFromConfig(globalRegistry, "/classes", classesRouterConfig);
   registerRoutesFromConfig(globalRegistry, "/customers", customersRouterConfig);
   registerRoutesFromConfig(globalRegistry, "/events", eventsRouterConfig);
+  registerRoutesFromConfig(globalRegistry, "/plans", plansRouterConfig);
 
   const openApiSpec = createOpenApiSpec();
   server.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));

--- a/backend/src/test/plans.test.ts
+++ b/backend/src/test/plans.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockPrisma } from "./helper";
+import request from "supertest";
+import { server } from "../server";
+
+vi.mock("../../prisma/prismaClient", () => ({
+  prisma: createMockPrisma(),
+}));
+
+import { prisma } from "../../prisma/prismaClient";
+
+const mockPrisma = prisma as unknown as ReturnType<typeof createMockPrisma>;
+
+describe("Plans Router - Validation Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /plans", () => {
+    it("should return list of all active plans", async () => {
+      const mockPlans = [
+        {
+          id: 1,
+          name: "Basic Plan",
+          weeklyClassTimes: 2,
+          description: "A basic plan with 2 weekly classes",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+          terminationAt: null,
+        },
+        {
+          id: 2,
+          name: "Premium Plan",
+          weeklyClassTimes: 4,
+          description: "A premium plan with 4 weekly classes",
+          createdAt: new Date("2024-01-02"),
+          updatedAt: new Date("2024-01-02"),
+          terminationAt: null,
+        },
+      ];
+
+      mockPrisma.plan.findMany.mockResolvedValue(mockPlans);
+
+      const response = await request(server).get("/plans");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(2);
+      expect(response.body.data[0].id).toBe(1);
+      expect(response.body.data[0].name).toBe("Basic Plan");
+      expect(response.body.data[0].weeklyClassTimes).toBe(2);
+    });
+
+    it("should return empty array when no plans exist", async () => {
+      mockPrisma.plan.findMany.mockResolvedValue([]);
+
+      const response = await request(server).get("/plans");
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([]);
+    });
+
+    it("should return 500 for database errors", async () => {
+      mockPrisma.plan.findMany.mockRejectedValue(
+        new Error("Database connection failed"),
+      );
+
+      const response = await request(server).get("/plans");
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("GET /plans/:id", () => {
+    it("should return plan for valid ID", async () => {
+      const mockPlan = {
+        id: 1,
+        name: "Basic Plan",
+        weeklyClassTimes: 2,
+        description: "A basic plan with 2 weekly classes",
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+        terminationAt: null,
+      };
+
+      mockPrisma.plan.findUnique.mockResolvedValue(mockPlan);
+
+      const response = await request(server).get("/plans/1");
+
+      expect(response.status).toBe(200);
+      expect(response.body.plan).toEqual({
+        id: 1,
+        name: "Basic Plan",
+        weeklyClassTimes: 2,
+        description: "A basic plan with 2 weekly classes",
+      });
+    });
+
+    it("should return 400 for invalid plan ID", async () => {
+      const response = await request(server).get("/plans/invalid");
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Invalid parameters");
+    });
+
+    it("should return 400 for non-numeric plan ID", async () => {
+      const response = await request(server).get("/plans/abc123");
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Invalid parameters");
+    });
+
+    it("should return 404 for non-existent plan ID", async () => {
+      mockPrisma.plan.findUnique.mockResolvedValue(null);
+
+      const response = await request(server).get("/plans/999");
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe("Plan not found.");
+    });
+
+    it("should return 500 for database errors", async () => {
+      mockPrisma.plan.findUnique.mockRejectedValue(
+        new Error("Database connection failed"),
+      );
+
+      const response = await request(server).get("/plans/1");
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe("Database connection failed");
+    });
+  });
+});

--- a/frontend/src/app/helper/api/plansApi.ts
+++ b/frontend/src/app/helper/api/plansApi.ts
@@ -4,6 +4,7 @@ import {
   GENERAL_ERROR_MESSAGE,
   CONTENT_REGISTRATION_SUCCESS_MESSAGE,
 } from "../messages/formValidation";
+import type { PlanResponse, PlansListResponse } from "@shared/schemas/plans";
 
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
@@ -13,13 +14,13 @@ const BASE_URL = `${BACKEND_ORIGIN}/plans`;
 export type Response<T> = T | { message: string };
 
 // GET all plans data
-export const getAllPlans = async () => {
+export const getAllPlans = async (): Promise<PlansListResponse["data"]> => {
   try {
     const response = await fetch(`${BASE_URL}`);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const { data } = await response.json();
+    const { data }: PlansListResponse = await response.json();
     return data;
   } catch (error) {
     console.error("Failed to fetch plans:", error);
@@ -30,9 +31,9 @@ export const getAllPlans = async () => {
 // Get plan by ID
 export const getPlanById = async (
   id: number,
-): Promise<Response<{ plan: Plan }>> => {
+): Promise<Response<PlanResponse>> => {
   const apiUrl = `${BASE_URL}/${id}`;
-  const data: Response<{ plan: Plan }> = await fetch(apiUrl, {
+  const data: Response<PlanResponse> = await fetch(apiUrl, {
     cache: "no-store",
   }).then((res) => res.json());
 

--- a/shared/schemas/plans.ts
+++ b/shared/schemas/plans.ts
@@ -22,9 +22,9 @@ export const PlansListResponse = z.object({
       name: z.string().describe("Plan name"),
       weeklyClassTimes: z.number().describe("Number of weekly class times"),
       description: z.string().describe("Plan description"),
-      createdAt: z.coerce.date().describe("Creation timestamp"),
-      updatedAt: z.coerce.date().describe("Last update timestamp"),
-      terminationAt: z.coerce.date().nullable().describe("Termination timestamp"),
+      createdAt: z.string().datetime().describe("Creation timestamp"),
+      updatedAt: z.string().datetime().describe("Last update timestamp"),
+      terminationAt: z.string().datetime().nullable().describe("Termination timestamp"),
     }),
   ),
 });

--- a/shared/schemas/plans.ts
+++ b/shared/schemas/plans.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+// Parameter schemas
+export const PlanIdParams = z.object({
+  id: z.string().regex(/^\d+$/, "Must be a valid number").transform(Number),
+});
+
+// Response schemas
+export const PlanResponse = z.object({
+  plan: z.object({
+    id: z.number().describe("Plan ID"),
+    name: z.string().describe("Plan name"),
+    weeklyClassTimes: z.number().describe("Number of weekly class times"),
+    description: z.string().describe("Plan description"),
+  }),
+});
+
+export const PlansListResponse = z.object({
+  data: z.array(
+    z.object({
+      id: z.number().describe("Plan ID"),
+      name: z.string().describe("Plan name"),
+      weeklyClassTimes: z.number().describe("Number of weekly class times"),
+      description: z.string().describe("Plan description"),
+      createdAt: z.coerce.date().describe("Creation timestamp"),
+      updatedAt: z.coerce.date().describe("Last update timestamp"),
+      terminationAt: z.coerce.date().nullable().describe("Termination timestamp"),
+    }),
+  ),
+});
+
+// Inferred TypeScript types
+export type PlanIdParams = z.infer<typeof PlanIdParams>;
+
+// Response types
+export type PlanResponse = z.infer<typeof PlanResponse>;
+export type PlansListResponse = z.infer<typeof PlansListResponse>;


### PR DESCRIPTION
## Summary
Implements Zod validation for the plansRouter following the established pattern from eventsRouter.

## Changes
- **Create Zod schemas** in `shared/schemas/plans.ts`
  - `PlanIdParams` for route parameter validation
  - `PlanResponse` for single plan responses  
  - `PlansListResponse` for list responses with date coercion
- **Update plansRouter.ts** with validation middleware and OpenAPI documentation
- **Update plansController.ts** with proper `RequestWithParams` types
- **Remove manual validation** code (`isNaN` checks) from controller
- **Add integration tests** (8 test cases covering valid/invalid inputs and error scenarios)
- **Update frontend** `plansApi.ts` with shared schema types for full-stack type safety
- **Register router** in OpenAPI registry (server.ts)

## Testing
- ✅ All 131 tests passing (including 8 new plans tests)
- ✅ `npm run format` - Code formatted successfully
- ✅ `npm run build` - TypeScript compilation successful
- ✅ Smoke tested endpoints with curl

## Related
Continues Zod validation implementation. Related PRs: #274 (customers), #275/#276 (events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)