### PR TITLE
feat: implement Zod validation for subscriptions router

### DIFF
--- a/backend/src/controllers/subscriptionsController.ts
+++ b/backend/src/controllers/subscriptionsController.ts
@@ -1,13 +1,14 @@
 import { Response } from "express";
-import { RequestWithId } from "../middlewares/parseId.middleware";
+import { RequestWithParams } from "../middlewares/validationMiddleware";
+import type { SubscriptionIdParams } from "@shared/schemas/subscriptions";
 import { getSubscriptionById } from "../services/subscriptionsService";
 
 export const getSubscriptionByIdController = async (
-  req: RequestWithId,
+  req: RequestWithParams<SubscriptionIdParams>,
   res: Response,
 ) => {
   try {
-    const subscription = await getSubscriptionById(req.id);
+    const subscription = await getSubscriptionById(req.params.id);
 
     if (!subscription) {
       return res.status(404).json({ error: "Subscription not found." });

--- a/backend/src/routes/subscriptionsRouter.ts
+++ b/backend/src/routes/subscriptionsRouter.ts
@@ -1,14 +1,45 @@
 import express from "express";
-import {
-  parseId,
-  RequestWithId,
-} from "../../src/middlewares/parseId.middleware";
+import { registerRoutes } from "../../src/middlewares/validationMiddleware";
 import { getSubscriptionByIdController } from "../../src/controllers/subscriptionsController";
+import {
+  SubscriptionIdParams,
+  SubscriptionResponse,
+} from "@shared/schemas/subscriptions";
+import { ErrorResponse } from "@shared/schemas/common";
+import { RouteConfig } from "../openapi/routerRegistry";
 
 export const subscriptionsRouter = express.Router();
 
 // http://localhost:4000/subscriptions
 
-subscriptionsRouter.get("/:id", parseId, (req, res) =>
-  getSubscriptionByIdController(req as RequestWithId, res),
-);
+const getSubscriptionByIdConfig = {
+  method: "get" as const,
+  handler: getSubscriptionByIdController,
+  paramsSchema: SubscriptionIdParams,
+  openapi: {
+    summary: "Get subscription by ID",
+    description: "Retrieve a single subscription by its ID",
+    responses: {
+      "200": {
+        description: "Subscription retrieved successfully",
+        schema: SubscriptionResponse,
+      },
+      "404": {
+        description: "Subscription not found",
+        schema: ErrorResponse,
+      },
+      "400": {
+        description: "Invalid subscription ID",
+        schema: ErrorResponse,
+      },
+    },
+  },
+};
+
+export const validatedRouteConfigs: Record<string, readonly RouteConfig[]> = {
+  "/:id": [getSubscriptionByIdConfig],
+};
+
+registerRoutes(subscriptionsRouter, validatedRouteConfigs);
+
+export { validatedRouteConfigs as subscriptionsRouterConfig };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,7 +17,10 @@ import {
 } from "./routes/recurringClassesRouter";
 import { plansRouter, plansRouterConfig } from "./routes/plansRouter";
 import { eventsRouter, eventsRouterConfig } from "./routes/eventsRouter";
-import { subscriptionsRouter } from "./routes/subscriptionsRouter";
+import {
+  subscriptionsRouter,
+  subscriptionsRouterConfig,
+} from "./routes/subscriptionsRouter";
 import { indexRouter } from "./routes/indexRouter";
 import { usersRouter, usersRouterConfig } from "./routes/usersRouter";
 import { instructorsRouterConfig } from "./routes/instructorsRouter";
@@ -80,6 +83,11 @@ if (process.env.NODE_ENV === "development") {
     globalRegistry,
     "/recurring-classes",
     recurringClassesRouterConfig,
+  );
+  registerRoutesFromConfig(
+    globalRegistry,
+    "/subscriptions",
+    subscriptionsRouterConfig,
   );
 
   const openApiSpec = createOpenApiSpec();

--- a/backend/src/test/helper.ts
+++ b/backend/src/test/helper.ts
@@ -75,6 +75,7 @@ export const createMockPrisma = () => {
     subscription: {
       findFirst: vi.fn(),
       findMany: vi.fn(),
+      findUnique: vi.fn(),
       create: vi.fn(),
     },
     plan: {

--- a/backend/src/test/subscriptions.test.ts
+++ b/backend/src/test/subscriptions.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockPrisma } from "./helper";
+
+vi.mock("../../prisma/prismaClient", () => ({
+  prisma: createMockPrisma(),
+}));
+
+import { prisma } from "../../prisma/prismaClient";
+import request from "supertest";
+import { server } from "../server";
+
+const mockPrisma = prisma as unknown as ReturnType<typeof createMockPrisma>;
+
+describe("Subscriptions Router - Zod Validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /subscriptions/:id", () => {
+    it("should return subscription with valid ID", async () => {
+      const mockSubscription = {
+        id: 1,
+        planId: 1,
+        customerId: 1,
+        startAt: new Date("2024-01-01T00:00:00.000Z"),
+        endAt: null,
+        plan: {
+          id: 1,
+          name: "Basic Plan",
+          weeklyClassTimes: 2,
+          description: "Basic English conversation plan",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+          terminationAt: null,
+        },
+        customer: {
+          id: 1,
+          name: "Test Customer",
+          email: "customer@example.com",
+          prefecture: "Tokyo",
+          emailVerified: new Date("2024-01-01T00:00:00.000Z"),
+          hasSeenWelcome: true,
+        },
+      };
+
+      mockPrisma.subscription.findUnique = vi
+        .fn()
+        .mockResolvedValue(mockSubscription);
+
+      const response = await request(server)
+        .get("/subscriptions/1")
+        .expect(200);
+
+      expect(response.body).toEqual({
+        id: 1,
+        planId: 1,
+        customerId: 1,
+        startAt: "2024-01-01T00:00:00.000Z",
+        endAt: null,
+        plan: {
+          id: 1,
+          name: "Basic Plan",
+          weeklyClassTimes: 2,
+          description: "Basic English conversation plan",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          terminationAt: null,
+        },
+        customer: {
+          id: 1,
+          name: "Test Customer",
+          email: "customer@example.com",
+          prefecture: "Tokyo",
+          emailVerified: "2024-01-01T00:00:00.000Z",
+          hasSeenWelcome: true,
+        },
+      });
+    });
+
+    it("should return 400 for invalid subscription ID", async () => {
+      const response = await request(server)
+        .get("/subscriptions/invalid")
+        .expect(400);
+
+      expect(response.body.message).toBe("Invalid parameters");
+    });
+
+    it("should return 404 for non-existent subscription", async () => {
+      mockPrisma.subscription.findUnique = vi.fn().mockResolvedValue(null);
+
+      const response = await request(server)
+        .get("/subscriptions/999")
+        .expect(404);
+
+      expect(response.body.error).toBe("Subscription not found.");
+    });
+  });
+});

--- a/frontend/src/app/helper/api/subscriptionsApi.ts
+++ b/frontend/src/app/helper/api/subscriptionsApi.ts
@@ -1,8 +1,17 @@
+import type {
+  SubscriptionsResponse,
+  RegisterSubscriptionRequest,
+  NewSubscriptionResponse,
+} from "@shared/schemas/customers";
+import type { SubscriptionResponse } from "@shared/schemas/subscriptions";
+
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 
 // GET subscriptions by a customer id
-export const getSubscriptionsByCustomerId = async (customerId: number) => {
+export const getSubscriptionsByCustomerId = async (
+  customerId: number,
+): Promise<SubscriptionsResponse> => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/customers/${customerId}/subscriptions`,
@@ -22,8 +31,8 @@ export const getSubscriptionsByCustomerId = async (customerId: number) => {
 // Register a subscription
 export const registerSubscription = async (
   customerId: number,
-  subscriptionData: RegisterSubscription,
-) => {
+  subscriptionData: RegisterSubscriptionRequest,
+): Promise<NewSubscriptionResponse> => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/customers/${customerId}/subscription`,
@@ -38,7 +47,7 @@ export const registerSubscription = async (
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return;
+    return await response.json();
   } catch (error) {
     console.error("Failed to register a subscription:", error);
     throw error;
@@ -46,7 +55,9 @@ export const registerSubscription = async (
 };
 
 // GET subscription by a subscription id
-export const getSubscriptionById = async (subscriptionId: number) => {
+export const getSubscriptionById = async (
+  subscriptionId: number,
+): Promise<SubscriptionResponse> => {
   try {
     const response = await fetch(
       `${BACKEND_ORIGIN}/subscriptions/${subscriptionId}`,

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -118,7 +118,7 @@ type Subscription = {
   planId: number;
   customerId: number;
   startAt: string;
-  endAt: string;
+  endAt: string | null;
   plan: Plan;
 };
 

--- a/shared/schemas/subscriptions.ts
+++ b/shared/schemas/subscriptions.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+// Parameter schemas
+export const SubscriptionIdParams = z.object({
+  id: z
+    .string()
+    .regex(/^\d+$/, "Must be a valid number")
+    .transform(Number),
+});
+
+// Response schemas
+export const SubscriptionResponse = z.object({
+  id: z.number().describe("Subscription ID"),
+  planId: z.number().describe("Plan ID"),
+  customerId: z.number().describe("Customer ID"),
+  startAt: z.string().datetime().describe("Subscription start date"),
+  endAt: z.string().datetime().nullable().describe("Subscription end date"),
+  plan: z.object({
+    id: z.number().describe("Plan ID"),
+    name: z.string().describe("Plan name"),
+    weeklyClassTimes: z.number().describe("Weekly class times"),
+    description: z.string().describe("Plan description"),
+    createdAt: z.string().datetime().describe("Plan creation date"),
+    updatedAt: z.string().datetime().describe("Plan last update date"),
+    terminationAt: z
+      .string()
+      .datetime()
+      .nullable()
+      .describe("Plan termination date"),
+  }).describe("Associated plan details"),
+  customer: z.object({
+    id: z.number().describe("Customer ID"),
+    name: z.string().describe("Customer name"),
+    email: z.string().email().describe("Customer email"),
+    prefecture: z.string().describe("Customer prefecture"),
+    emailVerified: z
+      .string()
+      .datetime()
+      .nullable()
+      .describe("Email verification date"),
+    hasSeenWelcome: z
+      .boolean()
+      .describe("Whether customer has seen welcome message"),
+  }).describe("Associated customer details"),
+});
+
+// Inferred TypeScript types
+export type SubscriptionIdParams = z.infer<typeof SubscriptionIdParams>;
+export type SubscriptionResponse = z.infer<typeof SubscriptionResponse>;


### PR DESCRIPTION
## Summary
Implements Zod validation for the subscriptions router following the established pattern.

## Changes
- ✅ Created Zod schemas in `/shared/schemas/subscriptions.ts`
- ✅ Updated `subscriptionsRouter.ts` to use validation middleware
- ✅ Updated `subscriptionsController.ts` with proper `RequestWithParams` types
- ✅ Added integration tests for subscriptions endpoints (3 tests)
- ✅ Registered subscriptionsRouter in OpenAPI registry
- ✅ Updated frontend `subscriptionsApi.ts` with shared schema types
- ✅ Fixed type definition for `Subscription.endAt` (was `string`, now `string | null`)

## Test Plan
- ✅ All backend tests passing (150/150)
- ✅ Backend build successful
- ✅ Frontend build successful
- ✅ Code formatted

## Remaining Work
After this PR is merged, only `jobsRouter` remains for Zod validation implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)