### PR TITLE
Fix Vercel build by installing shared dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "prisma:init": "npx prisma migrate reset && npx ts-node ./src/seed/dummy.ts",
     "test": "vitest run",
     "build": "prisma generate && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
-    "vercel:build": "prisma generate && tsc && tsc-alias && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
+    "vercel:build": "cd ../shared && npm install && cd ../backend && prisma generate && tsc && tsc-alias && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
     "lint:unused": "knip"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- Install shared package dependencies during `vercel:build` to resolve TypeScript compilation errors

## Problem
Vercel build was failing with "Cannot find module 'zod'" errors when compiling TypeScript code that imports from `../shared` directory. This happened because Vercel only installs dependencies for the `backend` directory and doesn't automatically install dependencies for sibling directories.

## Solution
Modified `vercel:build` script to:
1. Navigate to `../shared` directory
2. Run `npm install` to install shared dependencies (including `zod`)
3. Return to `../backend` directory
4. Continue with the rest of the build process

## Changes
- Updated `backend/package.json` `vercel:build` script to include shared dependency installation

## Testing
- ✅ Tests pass
- ✅ `vercel:build` runs successfully locally
- ✅ TypeScript compilation completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)