### PR TITLE
Fix TypeScript type narrowing and Vercel deployment configuration

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -631,6 +631,11 @@ export const updatePlanController = async (
     }
 
     // When updating (not deleting), validation ensures both name and description are present
+    if (!body.name || !body.description) {
+      return res
+        .status(400)
+        .json({ message: "Name and description are required for update" });
+    }
     const { name, description } = body;
     const updatedPlan = await updatePlan(planId, name, description);
     return res.status(200).json({

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "buildCommand": "npm run vercel:build",
-  "outputDirectory": "dist/backend",
-  "rewrites": [{ "source": "/(.*)", "destination": "/api/app" }]
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/backend/api/app" }]
 }


### PR DESCRIPTION
## Summary
- Fix TypeScript type narrowing error in `updatePlanController`
- Fix Vercel deployment configuration to include shared directory

## Problems
1. **TypeScript Error**: Property 'name' and 'description' do not exist on union type without proper type narrowing
2. **Runtime Error**: Vercel deployment failed at runtime because `dist/shared` was outside `outputDirectory: "dist/backend"`

## Solutions

### 1. TypeScript Type Narrowing
Added explicit type guard to narrow the `UpdatePlanRequest` union type:
```typescript
if (!body.name || !body.description) {
  return res.status(400).json({ 
    message: "Name and description are required for update" 
  });
}
```

### 2. Vercel Configuration
- Changed `outputDirectory` from `"dist/backend"` to `"dist"`  
- Updated `destination` from `"/api/app"` to `"/backend/api/app"`

This ensures both `dist/backend` and `dist/shared` are included in the deployment, allowing compiled code to correctly resolve `../../../shared` paths.

## Changes
- `backend/src/controllers/adminsController.ts`: Add type guard
- `backend/vercel.json`: Update outputDirectory and destination path

## Testing
- ✅ TypeScript compilation succeeds without errors
- ✅ All tests pass
- ✅ `vercel:build` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)