### PR TITLE
Fix Vercel deployment by removing outputDirectory configuration

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
   "buildCommand": "npm run vercel:build",
-  "outputDirectory": "dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/backend/api/app" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/dist/backend/api/app" }]
 }


### PR DESCRIPTION
## Summary
- Remove `outputDirectory` configuration from vercel.json
- Update `destination` path to `/dist/backend/api/app`

## Problem
After setting `outputDirectory: "dist"` in the previous PR, Vercel deployments were failing with `DEPLOYMENT_NOT_FOUND` error. Users couldn't log in and all API requests returned 404.

The issue was that `outputDirectory` changes Vercel's root directory, but serverless functions in the `api/` directory need to be at the root level, not inside `dist/`.

## Solution
- Removed `outputDirectory` setting (defaults to project root `.`)
- Changed `destination` from `/backend/api/app` to `/dist/backend/api/app`

This allows:
- Vercel to find the serverless function at `dist/backend/api/app.js`
- Compiled code to resolve `../../../shared` paths correctly (both `dist/backend` and `dist/shared` are preserved)

## Testing
- ✅ Build succeeds
- ✅ All tests pass
- Needs verification: Deployment should work on Vercel

## Related
- Follow-up to PR #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)