### PR TITLE
Fix Vercel functions runtime specification

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "npm run vercel:build",
   "functions": {
     "dist/backend/api/app.js": {
-      "runtime": "@vercel/node"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
Fix Vercel build error by correcting the functions runtime specification from `@vercel/node` to `nodejs20.x`

## Issue
Build was failing with error:
```
Function Runtimes must have a valid version, for example `now-php@1.0.0`
```

## Changes
- Updated `vercel.json` to use `nodejs20.x` instead of `@vercel/node` in functions configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)