### PR TITLE
Replace @shared path alias with relative imports

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 # Keep environment variables out of version control
 .env
 .vercel

--- a/backend/api/app.ts
+++ b/backend/api/app.ts
@@ -3,13 +3,6 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-// For local development
-if (process.env.NODE_ENV === "development") {
-  const PORT = process.env.PORT || 3000;
-  server.listen(PORT, () => {
-    console.log(`[Server]: http://localhost:${PORT}`);
-  });
-}
+const PORT = process.env.PORT;
 
-// For Vercel serverless deployment
-export default server;
+server.listen(PORT, () => console.log(`[Server]: http://localhost:${PORT}`));

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,8 +41,6 @@
         "prisma": "^5.19.1",
         "supertest": "^7.1.3",
         "ts-node": "^10.9.2",
-        "tsc-alias": "^1.8.16",
-        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.4.5",
         "vite": "^7.1.5",
         "vite-tsconfig-paths": "^5.1.4",
@@ -1928,16 +1926,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2451,19 +2439,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -3060,19 +3035,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3103,27 +3065,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globrex": {
@@ -3290,16 +3231,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/ignore-by-default": {
@@ -3562,19 +3493,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/knip": {
@@ -3859,20 +3777,6 @@
       },
       "engines": {
         "node": ">= 10.16.0"
-      }
-    },
-    "node_modules/mylas": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
-      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/raouldeheer"
       }
     },
     "node_modules/nanoid": {
@@ -4172,16 +4076,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4224,19 +4118,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/plimit-lit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
-      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "queue-lit": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/postcss": {
@@ -4338,16 +4219,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue-lit": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
-      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/queue-microtask": {
@@ -4456,16 +4327,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/retry": {
@@ -4747,16 +4608,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
@@ -4866,16 +4717,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5217,38 +5058,6 @@
         }
       }
     },
-    "node_modules/tsc-alias": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
-      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "get-tsconfig": "^4.10.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "bin": {
-        "tsc-alias": "dist/bin/index.js"
-      },
-      "engines": {
-        "node": ">=16.20.2"
-      }
-    },
-    "node_modules/tsc-alias/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -5268,21 +5077,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,11 +6,10 @@
     "format": "npx prettier --write . && npx prisma format",
     "format-check": "npx prettier --check .",
     "db:start": "docker run --name summer-postgres -p 5432:5432 -e POSTGRES_PASSWORD=summer -d postgres",
-    "dev": "nodemon --exec ts-node -r tsconfig-paths/register ./api/app.ts",
+    "dev": "nodemon --exec ts-node ./api/app.ts",
     "prisma:init": "npx prisma migrate reset && npx ts-node ./src/seed/dummy.ts",
     "test": "vitest run",
-    "build": "prisma generate && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
-    "vercel:build": "cd ../shared && npm install && cd ../backend && prisma generate && tsc && tsc-alias && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
+    "build": "cd ../shared && npm install && cd ../backend && prisma generate && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
     "lint:unused": "knip"
   },
   "engines": {
@@ -37,8 +36,6 @@
     "prisma": "^5.19.1",
     "supertest": "^7.1.3",
     "ts-node": "^10.9.2",
-    "tsc-alias": "^1.8.16",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.4.5",
     "vite": "^7.1.5",
     "vite-tsconfig-paths": "^5.1.4",

--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -52,7 +52,7 @@ import type {
   UpdatePlanRequest,
   RegisterEventRequest,
   UpdateEventRequest,
-} from "@shared/schemas/admins";
+} from "../../../shared/schemas/admins";
 
 // Register Admin
 export const registerAdminController = async (

--- a/backend/src/controllers/childrenController.ts
+++ b/backend/src/controllers/childrenController.ts
@@ -24,7 +24,7 @@ import type {
   GetChildrenQuery,
   RegisterChildRequest,
   UpdateChildRequest,
-} from "@shared/schemas/children";
+} from "../../../shared/schemas/children";
 
 export const getChildrenController = async (
   req: RequestWithQuery<GetChildrenQuery>,

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -30,7 +30,7 @@ import type {
   CancelClassesRequest,
   UpdateAttendanceRequest,
   UpdateClassStatusRequest,
-} from "@shared/schemas/classes";
+} from "../../../shared/schemas/classes";
 import { prisma } from "../../prisma/prismaClient";
 import {
   getValidRecurringClasses,

--- a/backend/src/controllers/customersController.ts
+++ b/backend/src/controllers/customersController.ts
@@ -43,7 +43,7 @@ import type {
   VerifyEmailRequest,
   CheckEmailConflictsRequest,
   DeclineFreeTrialRequest,
-} from "@shared/schemas/customers";
+} from "../../../shared/schemas/customers";
 
 export const registerCustomerController = async (
   req: RequestWithBody<RegisterCustomerRequest>,

--- a/backend/src/controllers/eventsController.ts
+++ b/backend/src/controllers/eventsController.ts
@@ -1,7 +1,7 @@
 import { Response } from "express";
 import { getEventById } from "../services/eventsService";
 import { RequestWithParams } from "../middlewares/validationMiddleware";
-import type { EventIdParams } from "@shared/schemas/events";
+import type { EventIdParams } from "../../../shared/schemas/events";
 
 function setErrorResponse(res: Response, error: unknown) {
   return res

--- a/backend/src/controllers/instructorAbsenceController.ts
+++ b/backend/src/controllers/instructorAbsenceController.ts
@@ -12,7 +12,7 @@ import {
   InstructorIdParams,
   CreateAbsenceRequest,
   InstructorAbsenceParams,
-} from "@shared/schemas/instructors";
+} from "../../../shared/schemas/instructors";
 
 export const getInstructorAbsencesController = async (
   req: RequestWithParams<InstructorIdParams>,

--- a/backend/src/controllers/instructorScheduleController.ts
+++ b/backend/src/controllers/instructorScheduleController.ts
@@ -22,7 +22,7 @@ import {
   CreateSlotRequest,
   InstructorScheduleParams,
   ActiveScheduleQuery,
-} from "@shared/schemas/instructors";
+} from "../../../shared/schemas/instructors";
 
 export const getInstructorSchedulesController = async (
   req: RequestWithParams<InstructorIdParams>,

--- a/backend/src/controllers/instructorsController.ts
+++ b/backend/src/controllers/instructorsController.ts
@@ -4,7 +4,7 @@ import {
   InstructorIdParams,
   ClassIdParams,
   InstructorClassParams,
-} from "@shared/schemas/instructors";
+} from "../../../shared/schemas/instructors";
 import { validateUserImageUrl } from "../helper/commonUtils";
 import {
   getInstructorById,

--- a/backend/src/controllers/plansController.ts
+++ b/backend/src/controllers/plansController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { RequestWithParams } from "../middlewares/validationMiddleware";
 import { getAllPlans, getPlanById } from "../services/plansService";
-import type { PlanIdParams } from "@shared/schemas/plans";
+import type { PlanIdParams } from "../../../shared/schemas/plans";
 
 // Get all plans' information
 export const getAllPlansController = async (_: Request, res: Response) => {

--- a/backend/src/controllers/recurringClassesController.ts
+++ b/backend/src/controllers/recurringClassesController.ts
@@ -18,7 +18,7 @@ import type {
   GetRecurringClassesByInstructorQuery,
   CreateRecurringClassRequest,
   UpdateRecurringClassRequest,
-} from "@shared/schemas/recurringClasses";
+} from "../../../shared/schemas/recurringClasses";
 
 function handleRegularClassError(error: unknown, res: Response): Response {
   const err =

--- a/backend/src/controllers/schedulesController.ts
+++ b/backend/src/controllers/schedulesController.ts
@@ -10,7 +10,7 @@ import {
   convertToISOString,
 } from "../helper/dateUtils";
 import { RequestWithBody } from "../middlewares/validationMiddleware";
-import type { UpdateSundayColorRequest } from "@shared/schemas/jobs";
+import type { UpdateSundayColorRequest } from "../../../shared/schemas/jobs";
 
 // Admin dashboard for displaying all schedules
 export const getAllSchedulesController = async (_: Request, res: Response) => {

--- a/backend/src/controllers/subscriptionsController.ts
+++ b/backend/src/controllers/subscriptionsController.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import { RequestWithParams } from "../middlewares/validationMiddleware";
-import type { SubscriptionIdParams } from "@shared/schemas/subscriptions";
+import type { SubscriptionIdParams } from "../../../shared/schemas/subscriptions";
 import { getSubscriptionById } from "../services/subscriptionsService";
 
 export const getSubscriptionByIdController = async (

--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -34,7 +34,7 @@ import {
   SendPasswordResetRequest,
   VerifyResetTokenRequest,
   UpdatePasswordRequest,
-} from "@shared/schemas/users";
+} from "../../../shared/schemas/users";
 
 const getUserByEmail = async (userType: UserType, email: string) => {
   switch (userType) {

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -25,7 +25,10 @@ import {
   updateBusinessScheduleController,
 } from "../../src/controllers/schedulesController";
 import { registerRoutes } from "../middlewares/validationMiddleware";
-import { MessageErrorResponse, ErrorResponse } from "@shared/schemas/common";
+import {
+  MessageErrorResponse,
+  ErrorResponse,
+} from "../../../shared/schemas/common";
 import {
   AdminIdParams,
   InstructorIdParams,
@@ -58,7 +61,7 @@ import {
   ValidationErrorResponse,
   ConflictErrorResponse,
   InstructorUpdateErrorResponse,
-} from "@shared/schemas/admins";
+} from "../../../shared/schemas/admins";
 
 import { verifyAuthentication } from "../middlewares/auth.middleware";
 import upload from "../middlewares/upload.middleware";

--- a/backend/src/routes/childrenRouter.ts
+++ b/backend/src/routes/childrenRouter.ts
@@ -7,7 +7,7 @@ import {
   getChildByIdController,
 } from "../../src/controllers/childrenController";
 import { registerRoutes } from "../middlewares/validationMiddleware";
-import { MessageErrorResponse } from "@shared/schemas/common";
+import { MessageErrorResponse } from "../../../shared/schemas/common";
 import {
   ChildIdParams,
   GetChildrenQuery,
@@ -18,7 +18,7 @@ import {
   UpdateChildResponse,
   DeleteChildResponse,
   DeleteChildConflictResponse,
-} from "@shared/schemas/children";
+} from "../../../shared/schemas/children";
 
 // Route configurations
 const getChildrenConfig = {

--- a/backend/src/routes/classesRouter.ts
+++ b/backend/src/routes/classesRouter.ts
@@ -31,7 +31,7 @@ import {
   DeleteClassResponse,
   RebookClassErrorResponse,
   ValidationErrorResponse,
-} from "@shared/schemas/classes";
+} from "../../../shared/schemas/classes";
 
 export const classesRouter = express.Router();
 

--- a/backend/src/routes/customersRouter.ts
+++ b/backend/src/routes/customersRouter.ts
@@ -32,8 +32,8 @@ import {
   UpcomingClassesResponse,
   CustomerClassesResponse,
   ChildProfilesResponse,
-} from "@shared/schemas/customers";
-import { ErrorResponse } from "@shared/schemas/common";
+} from "../../../shared/schemas/customers";
+import { ErrorResponse } from "../../../shared/schemas/common";
 
 export const customersRouter = express.Router();
 

--- a/backend/src/routes/eventsRouter.ts
+++ b/backend/src/routes/eventsRouter.ts
@@ -1,8 +1,8 @@
 import express from "express";
 import { getEventController } from "../controllers/eventsController";
 import { registerRoutes } from "../middlewares/validationMiddleware";
-import { EventIdParams, EventResponse } from "@shared/schemas/events";
-import { MessageErrorResponse } from "@shared/schemas/common";
+import { EventIdParams, EventResponse } from "../../../shared/schemas/events";
+import { MessageErrorResponse } from "../../../shared/schemas/common";
 
 export const eventsRouter = express.Router();
 

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -10,7 +10,10 @@ import {
   getSameDateClassesController,
 } from "../../src/controllers/instructorsController";
 import { registerRoutes } from "../middlewares/validationMiddleware";
-import { MessageErrorResponse, ErrorResponse } from "@shared/schemas/common";
+import {
+  MessageErrorResponse,
+  ErrorResponse,
+} from "../../../shared/schemas/common";
 import {
   InstructorProfilesResponse,
   AllInstructorProfilesResponse,
@@ -36,7 +39,7 @@ import {
   CreateAbsenceResponse,
   DeleteAbsenceResponse,
   PostTerminationScheduleResponse,
-} from "@shared/schemas/instructors";
+} from "../../../shared/schemas/instructors";
 import {
   type RequestWithId,
   parseId,

--- a/backend/src/routes/jobsRouter.ts
+++ b/backend/src/routes/jobsRouter.ts
@@ -16,8 +16,8 @@ import {
   UpdateSundayColorResponse,
   MaskInstructorsResponse,
   DeleteOldClassesResponse,
-} from "@shared/schemas/jobs";
-import { MessageErrorResponse } from "@shared/schemas/common";
+} from "../../../shared/schemas/jobs";
+import { MessageErrorResponse } from "../../../shared/schemas/common";
 
 export const jobsRouter = express.Router();
 

--- a/backend/src/routes/plansRouter.ts
+++ b/backend/src/routes/plansRouter.ts
@@ -8,8 +8,8 @@ import {
   PlanIdParams,
   PlanResponse,
   PlansListResponse,
-} from "@shared/schemas/plans";
-import { MessageErrorResponse } from "@shared/schemas/common";
+} from "../../../shared/schemas/plans";
+import { MessageErrorResponse } from "../../../shared/schemas/common";
 
 export const plansRouter = express.Router();
 

--- a/backend/src/routes/recurringClassesRouter.ts
+++ b/backend/src/routes/recurringClassesRouter.ts
@@ -13,8 +13,8 @@ import {
   GetRecurringClassesByInstructorQuery,
   CreateRecurringClassRequest,
   UpdateRecurringClassRequest,
-} from "@shared/schemas/recurringClasses";
-import { MessageErrorResponse } from "@shared/schemas/common";
+} from "../../../shared/schemas/recurringClasses";
+import { MessageErrorResponse } from "../../../shared/schemas/common";
 
 export const recurringClassesRouter = express.Router();
 

--- a/backend/src/routes/subscriptionsRouter.ts
+++ b/backend/src/routes/subscriptionsRouter.ts
@@ -4,8 +4,8 @@ import { getSubscriptionByIdController } from "../../src/controllers/subscriptio
 import {
   SubscriptionIdParams,
   SubscriptionResponse,
-} from "@shared/schemas/subscriptions";
-import { ErrorResponse } from "@shared/schemas/common";
+} from "../../../shared/schemas/subscriptions";
+import { ErrorResponse } from "../../../shared/schemas/common";
 import { RouteConfig } from "../openapi/routerRegistry";
 
 export const subscriptionsRouter = express.Router();

--- a/backend/src/routes/usersRouter.ts
+++ b/backend/src/routes/usersRouter.ts
@@ -7,13 +7,13 @@ import {
 } from "../controllers/usersController";
 import { z } from "zod";
 import { registerRoutes } from "../middlewares/validationMiddleware";
-import { ErrorResponse } from "@shared/schemas/common";
+import { ErrorResponse } from "../../../shared/schemas/common";
 import {
   authenticateSchema,
   sendPasswordResetSchema,
   verifyResetTokenSchema,
   updatePasswordSchema,
-} from "@shared/schemas/users";
+} from "../../../shared/schemas/users";
 
 const authenticateConfig = {
   method: "post" as const,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./dist",
-    "paths": {
-      "@shared/*": ["../shared/*"]
-    }
-  }
+  "extends": "@tsconfig/node20/tsconfig.json"
 }

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,10 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": "npm run vercel:build",
-  "functions": {
-    "dist/backend/api/app.js": {
-      "runtime": "nodejs20.x"
-    }
-  }
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/app" }]
 }


### PR DESCRIPTION
## Summary
- Replace all @shared/* imports with ../../../shared/* relative paths (24 files)
- Remove tsc-alias and tsconfig-paths dependencies (no longer needed)
- Simplify build process by removing TypeScript path alias configuration
- Revert vercel.json to original simple configuration
- Unify vercel:build into build script

## Motivation
The @shared path alias required tsc-alias and tsconfig-paths to work in Vercel, adding unnecessary complexity to the build process. By using relative paths instead, we eliminate these dependencies and make deployments more straightforward and reliable.

## Changes Made

### Dependencies
- Removed `tsc-alias` and `tsconfig-paths` from devDependencies
- Cleaned up 16 related packages from package-lock.json

### Configuration
- **tsconfig.json**: Removed `baseUrl` and `paths` configuration
- **vercel.json**: Reverted to original simple rewrites configuration
- **package.json**: 
  - Removed `vercel:build` script, unified into `build`
  - Simplified `dev` script (removed `-r tsconfig-paths/register`)
  - `build` now installs shared dependencies before building

### Code Changes
- Updated 24 files (routes and controllers) to use relative imports
- Changed `@shared/schemas/*` → `../../../shared/schemas/*`

### Reverted Unnecessary Changes
- **api/app.ts**: Reverted to simple version (Vercel handles listen() correctly)
- **.gitignore**: Removed `dist` entry (not using tsc compilation)

## Test Results
✅ Format: Clean  
✅ Tests: 162 passed  
✅ Dev server: Starts successfully  
✅ Build: Completes successfully  

## Trade-offs
- **Pros**: Simpler build, fewer dependencies, more reliable deployment
- **Cons**: Slightly longer import paths (../../../shared vs @shared)

This approach prioritizes deployment reliability over import path brevity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)