### PR TITLE
Fix dummy seed script failing due to auto-increment sequence issues

### DIFF
--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -2072,8 +2072,11 @@ async function getPlan(name: "3,180 yen/month" | "7,980 yen/month") {
 }
 
 async function deleteAll(table: Uncapitalize<Prisma.ModelName>) {
-  // @ts-ignore
-  await prisma[table].deleteMany({});
+  // Use raw SQL TRUNCATE to reset auto-increment sequences
+  const tableName = table.charAt(0).toUpperCase() + table.slice(1);
+  await prisma.$executeRawUnsafe(
+    `TRUNCATE TABLE "${tableName}" RESTART IDENTITY CASCADE`,
+  );
 }
 
 async function main() {
@@ -2129,4 +2132,11 @@ async function main() {
   }
 }
 
-main();
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
Fixes #308

The dummy seed script was failing because `deleteMany()` doesn't reset PostgreSQL's auto-increment sequences, causing foreign key constraint failures for hardcoded IDs.

## Changes
- Replace `deleteMany()` with `TRUNCATE TABLE RESTART IDENTITY CASCADE`
- Add proper error handling with `.catch()` and `.finally()`
- Add Prisma disconnect on completion

## Technical Details
**Before:** Using `deleteMany()`
```typescript
await prisma.event.deleteMany({});
// Sequence continues from last ID, e.g., 5, 6, 7, 8
// Hardcoded eventId: 2 in schedules fails (event 2 doesn't exist)
```

**After:** Using `TRUNCATE`
```typescript
await prisma.$executeRawUnsafe('TRUNCATE TABLE "Event" RESTART IDENTITY CASCADE');
// Sequence resets to 1, 2, 3, 4
// eventId: 2 works correctly
```

## Test Plan
```bash
npx ts-node ./src/seed/dummy.ts
```
Should complete successfully without foreign key errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)