### PR TITLE
feat(backend): migrate instructorAbsence tests to real DB with Testcontainers (#312)

### DIFF
--- a/backend/src/test.bak/README.md
+++ b/backend/src/test.bak/README.md
@@ -23,7 +23,7 @@ Or temporarily remove `**/test.bak/**` from the exclude list in `vitest.config.m
 - [x] customers (migrated to `src/test/customers.test.ts`)
 - [x] instructors (migrated to `src/test/instructors.test.ts`)
 - [x] instructorSchedule (migrated to `src/test/instructors/schedules.test.ts`)
-- [ ] instructorAbsence
+- [x] instructorAbsence (migrated to `src/test/instructors/absences.test.ts`)
 - [ ] children
 - [ ] classes
 - [ ] events

--- a/backend/src/test/instructors.test.ts
+++ b/backend/src/test/instructors.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
-const { faker } = require("@faker-js/faker");
 import { server } from "../server";
-import { prisma } from "./setup";
 import {
   createInstructor,
   createAdmin,
   createCustomer,
   createClass,
-  createInstructorSchedule,
-  createInstructorSlot,
-  createInstructorAbsence,
   generateAuthCookie,
-  generateTestInstructor,
 } from "./testUtils";
 
 describe("GET /instructors/all-profiles", () => {
@@ -77,89 +71,6 @@ describe("GET /instructors/:id", () => {
     expect(response.body.instructor.id).toBe(instructor.id);
     expect(response.body.instructor.name).toBe(instructor.name);
     expect(response.body.instructor.email).toBe(instructor.email);
-  });
-});
-
-describe("GET /instructors/:id/absences", () => {
-  it("succeed returning instructor absences", async () => {
-    const instructor = await createInstructor();
-    const absenceDate = new Date("2024-06-15");
-    await createInstructorAbsence(instructor.id, absenceDate);
-
-    const response = await request(server)
-      .get(`/instructors/${instructor.id}/absences`)
-      .expect(200);
-
-    expect(response.body.data).toHaveLength(1);
-  });
-});
-
-describe("POST /instructors/:id/absences", () => {
-  it("succeed adding instructor absence", async () => {
-    const admin = await createAdmin();
-    const authCookie = await generateAuthCookie(admin.id, "admin");
-    const instructor = await createInstructor();
-    const absenceDate = "2024-07-01T00:00:00.000Z";
-
-    await request(server)
-      .post(`/instructors/${instructor.id}/absences`)
-      .set("Cookie", authCookie)
-      .send({ absentAt: absenceDate })
-      .expect(201);
-
-    // Verify absence was created
-    const absence = await prisma.instructorAbsence.findUnique({
-      where: {
-        instructorId_absentAt: {
-          instructorId: instructor.id,
-          absentAt: new Date(absenceDate),
-        },
-      },
-    });
-    expect(absence).toBeTruthy();
-  });
-
-  it("fail for unauthenticated request", async () => {
-    const instructor = await createInstructor();
-
-    await request(server)
-      .post(`/instructors/${instructor.id}/absences`)
-      .send({ absentAt: "2024-07-01T00:00:00.000Z" })
-      .expect(401);
-  });
-});
-
-describe("DELETE /instructors/:id/absences/:absentAt", () => {
-  it("succeed removing instructor absence", async () => {
-    const admin = await createAdmin();
-    const authCookie = await generateAuthCookie(admin.id, "admin");
-    const instructor = await createInstructor();
-    const absenceDate = new Date("2024-07-01T00:00:00.000Z");
-    await createInstructorAbsence(instructor.id, absenceDate);
-
-    await request(server)
-      .delete(`/instructors/${instructor.id}/absences/2024-07-01T00:00:00.000Z`)
-      .set("Cookie", authCookie)
-      .expect(200);
-
-    // Verify absence was deleted
-    const absence = await prisma.instructorAbsence.findUnique({
-      where: {
-        instructorId_absentAt: {
-          instructorId: instructor.id,
-          absentAt: absenceDate,
-        },
-      },
-    });
-    expect(absence).toBeNull();
-  });
-
-  it("fail for unauthenticated request", async () => {
-    const instructor = await createInstructor();
-
-    await request(server)
-      .delete(`/instructors/${instructor.id}/absences/2024-07-01T00:00:00.000Z`)
-      .expect(401);
   });
 });
 

--- a/backend/src/test/instructors/absences.test.ts
+++ b/backend/src/test/instructors/absences.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { server } from "../../server";
+import { prisma } from "../setup";
+import {
+  createInstructor,
+  createAdmin,
+  createInstructorAbsence,
+  generateAuthCookie,
+} from "../testUtils";
+
+describe("GET /instructors/:id/absences", () => {
+  it("succeed returning instructor absences", async () => {
+    const instructor = await createInstructor();
+    const absenceDate = new Date("2024-06-15");
+    await createInstructorAbsence(instructor.id, absenceDate);
+
+    const response = await request(server)
+      .get(`/instructors/${instructor.id}/absences`)
+      .expect(200);
+
+    expect(response.body.data).toHaveLength(1);
+  });
+});
+
+describe("POST /instructors/:id/absences", () => {
+  it("succeed adding instructor absence", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+    const instructor = await createInstructor();
+    const absenceDate = "2024-07-01T00:00:00.000Z";
+
+    await request(server)
+      .post(`/instructors/${instructor.id}/absences`)
+      .set("Cookie", authCookie)
+      .send({ absentAt: absenceDate })
+      .expect(201);
+
+    // Verify absence was created
+    const absence = await prisma.instructorAbsence.findUnique({
+      where: {
+        instructorId_absentAt: {
+          instructorId: instructor.id,
+          absentAt: new Date(absenceDate),
+        },
+      },
+    });
+    expect(absence).toBeTruthy();
+  });
+
+  it("fail for unauthenticated request", async () => {
+    const instructor = await createInstructor();
+
+    await request(server)
+      .post(`/instructors/${instructor.id}/absences`)
+      .send({ absentAt: "2024-07-01T00:00:00.000Z" })
+      .expect(401);
+  });
+});
+
+describe("DELETE /instructors/:id/absences/:absentAt", () => {
+  it("succeed removing instructor absence", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+    const instructor = await createInstructor();
+    const absenceDate = new Date("2024-07-01T00:00:00.000Z");
+    await createInstructorAbsence(instructor.id, absenceDate);
+
+    await request(server)
+      .delete(`/instructors/${instructor.id}/absences/2024-07-01T00:00:00.000Z`)
+      .set("Cookie", authCookie)
+      .expect(200);
+
+    // Verify absence was deleted
+    const absence = await prisma.instructorAbsence.findUnique({
+      where: {
+        instructorId_absentAt: {
+          instructorId: instructor.id,
+          absentAt: absenceDate,
+        },
+      },
+    });
+    expect(absence).toBeNull();
+  });
+
+  it("fail for unauthenticated request", async () => {
+    const instructor = await createInstructor();
+
+    await request(server)
+      .delete(`/instructors/${instructor.id}/absences/2024-07-01T00:00:00.000Z`)
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
Reorganize instructorAbsence tests by moving them to a dedicated file for better organization and maintainability.

## Changes
- **Created** `src/test/instructors/absences.test.ts`: Dedicated test file with 5 tests
- **Modified** `src/test/instructors.test.ts`: Removed absence tests (moved to separate file)
- **Updated** `src/test.bak/README.md`: Marked instructorAbsence as migrated

## Motivation
Following the established pattern from `schedules.test.ts`, sub-resource endpoint tests should be organized in separate files for better modularity and easier maintenance.

## Test Coverage
All 3 absence endpoints tested (5 total tests):
- GET /instructors/:id/absences
- POST /instructors/:id/absences (with auth test)
- DELETE /instructors/:id/absences/:absentAt (with auth test)

## Test Results
- ✅ 5/5 new tests passing
- ✅ Uses real PostgreSQL database via Testcontainers
- ✅ Follows testing guidelines (happy path + auth + data integrity)
- ✅ All formatting checks pass

## Benefits
- Better test organization (sub-resources in separate files)
- Consistent with schedules.test.ts pattern
- Real database integration testing
- No brittle mocks

## Migration Progress
This completes the migration of instructorAbsence tests. Progress: 6/13 router test files migrated.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)