### PR TITLE
Fix lint:unused failure from unused customAlert export

### DIFF
--- a/frontend/src/app/helper/utils/alertUtils.ts
+++ b/frontend/src/app/helper/utils/alertUtils.ts
@@ -1,27 +1,5 @@
 import Swal from "sweetalert2";
 
-export const customAlert: (settings: AlertOptions) => Promise<boolean> = (
-  settings: AlertOptions,
-) => {
-  const result = Swal.fire({
-    title: settings.title,
-    text: settings.text,
-    icon: settings.icon,
-    confirmButtonText: settings.confirmButtonText,
-    cancelButtonText: settings.cancelButtonText,
-    showCancelButton: settings.showCancelButton,
-    showConfirmButton: settings.showConfirmButton,
-    position: settings.position || "center",
-  }).then((result) => {
-    if (result.isConfirmed) {
-      return true;
-    } else {
-      return false;
-    }
-  });
-  return result;
-};
-
 export const confirmAlert: (text: string) => Promise<boolean> = (
   text: string,
 ) => {


### PR DESCRIPTION
## Summary
- remove the unused `customAlert` helper export from `frontend/src/app/helper/utils/alertUtils.ts`
- rerun `npm run lint:unused` to ensure the lint check passes

## Testing
- npm run lint:unused