### PR TITLE
chore(backend): stop ignoring prisma runtime utils

### DIFF
--- a/backend/knip.json
+++ b/backend/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": ["generated/**", "prisma.config.ts"],
-  "ignoreDependencies": ["@prisma/client", "@prisma/client-runtime-utils"],
+  "ignoreDependencies": ["@prisma/client"],
   "prisma": {
     "config": ["package.json"]
   }


### PR DESCRIPTION
Closes #386.

Removes `@prisma/client-runtime-utils` from `backend/knip.json` `ignoreDependencies` so Knip reports it normally.
