### PR TITLE
CI(backend): run API tests on GitHub Actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,5 +1,8 @@
 name: general
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -8,6 +11,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            shared/package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
       - run: npm ci
         working-directory: ./shared
       - run: npm run format-check
@@ -27,4 +35,39 @@ jobs:
       - run: npm run format-check
         working-directory: ./backend
       - run: npm run lint:unused
+        working-directory: ./backend
+
+  backend_test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: summer
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:summer@localhost:5432/postgres?schema=public
+      POSTGRES_PRISMA_URL: postgresql://postgres:summer@localhost:5432/postgres?schema=public
+      FRONTEND_ORIGIN: http://localhost:3000
+      RESEND_API_KEY: re_test_dummy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+        working-directory: ./backend
+      - run: npx prisma generate
+        working-directory: ./backend
+      - run: npm run test
         working-directory: ./backend


### PR DESCRIPTION
Implements #388.

- Adds a `backend_test` job with a Postgres service and runs Vitest API tests
- Uses `TEST_DATABASE_URL`/`POSTGRES_PRISMA_URL` to avoid Testcontainers in CI
- Enables npm cache and workflow concurrency
