### PR TITLE
fix(backend): align tests with generated Prisma client

### DIFF
--- a/backend/src/test/testUtils.ts
+++ b/backend/src/test/testUtils.ts
@@ -2,7 +2,7 @@ const { faker } = require("@faker-js/faker");
 import { hashPasswordSync } from "../helper/commonUtils";
 import { prisma } from "./setup";
 import { SignJWT } from "jose";
-import { Status } from "@prisma/client";
+import { Status } from "../../generated/prisma";
 
 /**
  * Generate a test admin


### PR DESCRIPTION
Fixes backend test runs failing with `Cannot find module '.prisma/client/default'` when Prisma client output is configured to `backend/generated/prisma`.

Closes #396.

- Update `backend/src/test/testUtils.ts` to import `Status` from `../../generated/prisma` instead of `@prisma/client`.
- `cd backend && npm run test` passes.
