### PR TITLE
Upgrade Next.js to 16.1.1 + React 19

### DIFF
--- a/backend/src/routes/plansRouter.ts
+++ b/backend/src/routes/plansRouter.ts
@@ -20,7 +20,7 @@ export const plansRouter = express.Router();
 // Route configurations with Zod validation
 const getAllPlansConfig = {
   method: "get" as const,
-  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  middleware: [verifyAuthentication(AUTH_ROLES.AC)] as RequestHandler[],
   handler: getAllPlansController,
   openapi: {
     summary: "Get all active plans",
@@ -40,7 +40,7 @@ const getAllPlansConfig = {
 
 const getPlanConfig = {
   method: "get" as const,
-  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  middleware: [verifyAuthentication(AUTH_ROLES.AC)] as RequestHandler[],
   handler: getPlanController,
   paramsSchema: PlanIdParams,
   openapi: {

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "eslint-config-next/core-web-vitals";
+
+export default config;

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "node_modules/knip/schema.json",
+  "entry": [
+    "src/proxy.ts",
+    "src/app/**/page.tsx",
+    "src/app/**/layout.tsx",
+    "src/app/**/route.ts",
+    "src/app/**/loading.tsx",
+    "src/app/**/error.tsx"
+  ]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,23 +21,22 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "jose": "^6.0.11",
-        "next": "14.2.4",
-        "next-auth": "^5.0.0-beta.25",
-        "react": "^18",
-        "react-dom": "^18",
+        "next": "16.1.1",
+        "next-auth": "^5.0.0-beta.30",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "react-toastify": "^10.0.5",
         "sweetalert2": "^11.26.3",
         "zod": "^4.1.0",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
-        "@types/next-auth": "^3.15.0",
         "@types/node": "^20",
-        "@types/react": "^18",
-        "@types/react-dom": "^18",
+        "@types/react": "^19.2.8",
+        "@types/react-dom": "^19.2.3",
         "@types/zxcvbn": "^4.4.5",
-        "eslint": "^8",
-        "eslint-config-next": "14.2.4",
+        "eslint": "^9.39.2",
+        "eslint-config-next": "16.1.1",
         "knip": "^5.64.1",
         "prettier": "^3.3.2",
         "sass": "^1.77.6",
@@ -48,9 +47,9 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.40.0.tgz",
-      "integrity": "sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -86,6 +85,279 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
+      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
+      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.6"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/generator": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.6",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
@@ -105,10 +377,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-      "dev": true,
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -127,9 +398,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,47 +417,115 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@fullcalendar/core": {
@@ -270,20 +609,28 @@
         "react": ">= 16 || ^19.0.0-rc"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -300,59 +647,534 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -369,25 +1191,55 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.4.tgz",
-      "integrity": "sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.1.tgz",
+      "integrity": "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.4.tgz",
-      "integrity": "sha512-svSFxW9f3xDaZA3idQmlFw7SusOuWTpDTAeBlO3AEPDltrraV+lqs7mAc6A27YdnpQVVIA3sODqUAAHdWhVWsA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.1.tgz",
+      "integrity": "sha512-Ovb/6TuLKbE1UiPcg0p39Ke3puyTCIKN9hGbNItmpQsp+WX3qrjO3WaMVSi6JHr9X1NrmthqIguVHodMJbh/dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "10.3.10"
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.4.tgz",
-      "integrity": "sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
+      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
       "cpu": [
         "arm64"
       ],
@@ -401,9 +1253,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
-      "integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
+      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
       "cpu": [
         "x64"
       ],
@@ -417,9 +1269,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
-      "integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
+      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
       "cpu": [
         "arm64"
       ],
@@ -433,9 +1285,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
-      "integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
+      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
       "cpu": [
         "arm64"
       ],
@@ -449,9 +1301,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
-      "integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
+      "integrity": "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==",
       "cpu": [
         "x64"
       ],
@@ -465,9 +1317,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
-      "integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz",
+      "integrity": "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==",
       "cpu": [
         "x64"
       ],
@@ -481,9 +1333,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
-      "integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
+      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
       "cpu": [
         "arm64"
       ],
@@ -496,26 +1348,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
-      "integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.4.tgz",
-      "integrity": "sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
+      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
       "cpu": [
         "x64"
       ],
@@ -1177,17 +2013,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1195,27 +2020,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
-      "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -1262,23 +2073,26 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/next-auth": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@types/next-auth/-/next-auth-3.15.0.tgz",
-      "integrity": "sha512-ZVfejlu81YiIRX1m0iKAfvZ3nK7K9EyZWhNARNKsFop8kNAgEvMnlKpTpwN59xkK2OhyWLagPuiDAVBYSO9jSA==",
-      "deprecated": "This is a stub types definition. next-auth provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "next-auth": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.19.17",
@@ -1290,32 +2104,24 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/zxcvbn": {
@@ -1325,61 +2131,160 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
+      "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.53.0",
+        "@typescript-eslint/type-utils": "8.53.0",
+        "@typescript-eslint/utils": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.53.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
+      "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/scope-manager": "8.53.0",
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
+      "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.53.0",
+        "@typescript-eslint/types": "^8.53.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
+      "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
+      "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
+      "integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0",
+        "@typescript-eslint/utils": "8.53.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
+      "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1387,32 +2292,31 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
+      "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.53.0",
+        "@typescript-eslint/tsconfig-utils": "8.53.0",
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/visitor-keys": "8.53.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -1426,9 +2330,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1441,30 +2345,60 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
+      "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.53.0",
+        "@typescript-eslint/types": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
+      "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.53.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -1775,16 +2709,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1856,16 +2780,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -2048,6 +2962,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2072,15 +2995,38 @@
         "node": ">=8"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "streamsearch": "^1.1.0"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
       },
       "engines": {
-        "node": ">=10.16.0"
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/call-bind": {
@@ -2144,9 +3090,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001745",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
-      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
       "funding": [
         {
           "type": "opencollective",
@@ -2238,6 +3184,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2254,9 +3207,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2406,32 +3359,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2447,12 +3374,12 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2638,6 +3565,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2652,87 +3589,103 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.4.tgz",
-      "integrity": "sha512-Qr0wMgG9m6m4uYy2jrYJmyuNlYZzPRQq5Kvb9IDlYwn+7yq6W6sfMNFgb+9guM1KYwuIo6TIaiFhZJ6SnQ/Efw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.1.tgz",
+      "integrity": "sha512-55nTpVWm3qeuxoQKLOjQVciKZJUphKrNM0fCcQHAIOGl6VFXgaqeMfv0aKJhs7QtcnlAPhNVqsqRfRjeKBPIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.4",
-        "@rushstack/eslint-patch": "^1.3.3",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+        "@next/eslint-plugin-next": "16.1.1",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0",
+        "eslint": ">=9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -2951,16 +3904,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0-canary-7118f5dd7-20230705",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
-      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -3005,9 +3965,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3015,7 +3975,7 @@
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3034,19 +3994,45 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3170,16 +4156,16 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -3213,18 +4199,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -3250,23 +4235,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/formatly": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
@@ -3282,13 +4250,6 @@
       "engines": {
         "node": ">=18.3.0"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3329,6 +4290,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3401,29 +4372,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3437,43 +4385,14 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3496,27 +4415,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3529,19 +4427,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3637,6 +4522,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3680,25 +4582,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3886,16 +4769,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -3979,16 +4852,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -4168,25 +5031,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4210,12 +5054,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4223,6 +5068,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -4414,6 +5272,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4423,11 +5282,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4484,16 +5346,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/moment": {
@@ -4568,41 +5420,41 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.4.tgz",
-      "integrity": "sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
+      "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.4",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
+        "@next/env": "16.1.1",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.6"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.4",
-        "@next/swc-darwin-x64": "14.2.4",
-        "@next/swc-linux-arm64-gnu": "14.2.4",
-        "@next/swc-linux-arm64-musl": "14.2.4",
-        "@next/swc-linux-x64-gnu": "14.2.4",
-        "@next/swc-linux-x64-musl": "14.2.4",
-        "@next/swc-win32-arm64-msvc": "14.2.4",
-        "@next/swc-win32-ia32-msvc": "14.2.4",
-        "@next/swc-win32-x64-msvc": "14.2.4"
+        "@next/swc-darwin-arm64": "16.1.1",
+        "@next/swc-darwin-x64": "16.1.1",
+        "@next/swc-linux-arm64-gnu": "16.1.1",
+        "@next/swc-linux-arm64-musl": "16.1.1",
+        "@next/swc-linux-x64-gnu": "16.1.1",
+        "@next/swc-linux-x64-musl": "16.1.1",
+        "@next/swc-win32-arm64-msvc": "16.1.1",
+        "@next/swc-win32-x64-msvc": "16.1.1",
+        "sharp": "^0.34.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -4612,25 +5464,28 @@
         "@playwright/test": {
           "optional": true
         },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
         "sass": {
           "optional": true
         }
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.29.tgz",
-      "integrity": "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A==",
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.40.0"
+        "@auth/core": "0.41.0"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "next": "^14.0.0-0 || ^15.0.0-0",
-        "nodemailer": "^6.6.5",
-        "react": "^18.2.0 || ^19.0.0-0"
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -4652,10 +5507,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/oauth4webapi": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
-      "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
+      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -4784,16 +5646,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4916,16 +5768,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4942,33 +5784,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5116,28 +5931,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-is": {
@@ -5270,45 +6081,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5410,19 +6182,16 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5478,6 +6247,61 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shebang-command": {
@@ -5579,29 +6403,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
@@ -5643,84 +6444,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -5836,33 +6559,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5887,9 +6583,9 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -5898,7 +6594,7 @@
         "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -5944,13 +6640,6 @@
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"
       }
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -6014,16 +6703,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6056,19 +6745,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6163,6 +6839,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
+      "integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.53.0",
+        "@typescript-eslint/parser": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0",
+        "@typescript-eslint/utils": "8.53.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6222,6 +6922,37 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -6359,111 +7090,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
@@ -6487,6 +7117,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zxcvbn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,11 +8,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "lint:unused": "knip"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20.9"
   },
   "dependencies": {
     "@date-fns/tz": "^1.4.1",
@@ -28,23 +28,22 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "jose": "^6.0.11",
-    "next": "14.2.4",
-    "next-auth": "^5.0.0-beta.25",
-    "react": "^18",
-    "react-dom": "^18",
+    "next": "16.1.1",
+    "next-auth": "^5.0.0-beta.30",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "react-toastify": "^10.0.5",
     "sweetalert2": "^11.26.3",
     "zod": "^4.1.0",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@types/next-auth": "^3.15.0",
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^19.2.8",
+    "@types/react-dom": "^19.2.3",
     "@types/zxcvbn": "^4.4.5",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.4",
+    "eslint": "^9.39.2",
+    "eslint-config-next": "16.1.1",
     "knip": "^5.64.1",
     "prettier": "^3.3.2",
     "sass": "^1.77.6",

--- a/frontend/src/app/actions/cancelSelectedClasses.ts
+++ b/frontend/src/app/actions/cancelSelectedClasses.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { cancelClass, cancelClasses } from "../helper/api/classesApi";
 import { getUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 
 export const cancelSelectedClasses = async (
   classesToCancel: number[],

--- a/frontend/src/app/actions/deleteContent.ts
+++ b/frontend/src/app/actions/deleteContent.ts
@@ -8,7 +8,7 @@ import {
   revalidatePlanList,
   revalidateSubscriptionList,
 } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 import { deleteSubscription } from "../helper/api/subscriptionsApi";
 
 export async function deleteEventAction(

--- a/frontend/src/app/actions/deleteUser.ts
+++ b/frontend/src/app/actions/deleteUser.ts
@@ -9,7 +9,7 @@ import {
   revalidateClassList,
   revalidateSubscriptionList,
 } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 import { getUserSession } from "../helper/auth/sessionUtils";
 import { LOGIN_REQUIRED_MESSAGE } from "../helper/messages/customerDashboard";
 import { deleteChild } from "../helper/api/childrenApi";

--- a/frontend/src/app/actions/instructorAbsence.ts
+++ b/frontend/src/app/actions/instructorAbsence.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 import { revalidatePath } from "next/cache";
 import {
   addInstructorAbsence,

--- a/frontend/src/app/actions/rebooking.ts
+++ b/frontend/src/app/actions/rebooking.ts
@@ -3,7 +3,7 @@
 import { rebookClass } from "../helper/api/classesApi";
 import { revalidateCustomerCalendar } from "./revalidate";
 import { validateSession } from "./validateSession";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 
 export async function rebookClassWithValidation({
   customerId,

--- a/frontend/src/app/actions/registerContent.ts
+++ b/frontend/src/app/actions/registerContent.ts
@@ -6,7 +6,7 @@ import { GENERAL_ERROR_MESSAGE } from "../helper/messages/formValidation";
 import { extractRegisterValidationErrors } from "../helper/utils/validationErrorUtils";
 import { planRegisterSchema, eventRegisterSchema } from "../schemas/authSchema";
 import { revalidatePlanList, revalidateEventList } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 
 export async function registerContent(
   prevState: RegisterFormState | undefined,

--- a/frontend/src/app/actions/registerUser.ts
+++ b/frontend/src/app/actions/registerUser.ts
@@ -10,7 +10,7 @@ import {
   adminRegisterSchema,
 } from "../schemas/authSchema";
 import { revalidateInstructorList, revalidateAdminList } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 
 export async function registerUser(
   prevState: RegisterFormState | undefined,

--- a/frontend/src/app/actions/resetPassword.ts
+++ b/frontend/src/app/actions/resetPassword.ts
@@ -7,7 +7,7 @@ import {
   resetPasswordFormSchema,
   resetPasswordFormSchemaJa,
 } from "../schemas/authSchema";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 
 export async function resetPassword(
   prevState: StringMessages | undefined,

--- a/frontend/src/app/actions/revalidate.ts
+++ b/frontend/src/app/actions/revalidate.ts
@@ -19,37 +19,37 @@ export async function revalidateCustomerCalendar(
 }
 
 export async function revalidateSystemStatus() {
-  revalidateTag("system-status");
+  revalidateTag("system-status", "default");
 }
 
 export async function revalidateAdminList() {
-  revalidateTag("admin-list");
+  revalidateTag("admin-list", "default");
 }
 
 export async function revalidateCustomerList() {
-  revalidateTag("customer-list");
+  revalidateTag("customer-list", "default");
 }
 
 export async function revalidateInstructorList() {
-  revalidateTag("instructor-list");
+  revalidateTag("instructor-list", "default");
 }
 
 export async function revalidatePlanList() {
-  revalidateTag("plan-list");
+  revalidateTag("plan-list", "default");
 }
 
 export async function revalidateEventList() {
-  revalidateTag("event-list");
+  revalidateTag("event-list", "default");
 }
 
 export async function revalidateBusinessSchedule() {
-  revalidateTag("business-schedule");
+  revalidateTag("business-schedule", "default");
 }
 
 export async function revalidateClassList() {
-  revalidateTag("class-list");
+  revalidateTag("class-list", "default");
 }
 
 export async function revalidateSubscriptionList() {
-  revalidateTag("subscription-list");
+  revalidateTag("subscription-list", "default");
 }

--- a/frontend/src/app/actions/updateContent.ts
+++ b/frontend/src/app/actions/updateContent.ts
@@ -18,7 +18,7 @@ import {
   revalidatePlanList,
   revalidateSubscriptionList,
 } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 import { validateSession } from "./validateSession";
 import {
   generateClasses,
@@ -285,7 +285,7 @@ export async function generateClassesAction(
     const cookie = await getCookie();
 
     // Update the business schedule
-    await generateClasses(year, month, cookie);
+    await generateClasses(Number(year), month, cookie);
 
     revalidateClassList();
 

--- a/frontend/src/app/actions/updateUser.ts
+++ b/frontend/src/app/actions/updateUser.ts
@@ -13,7 +13,7 @@ import {
   instructorIconUpdateSchema,
 } from "../schemas/authSchema";
 import { revalidateAdminList, revalidateInstructorList } from "./revalidate";
-import { getCookie } from "../../middleware";
+import { getCookie } from "../../proxy";
 import {
   childProfileSchema,
   customerProfileSchema,

--- a/frontend/src/app/admins/[id]/admin-list/[adminId]/page.tsx
+++ b/frontend/src/app/admins/[id]/admin-list/[adminId]/page.tsx
@@ -1,7 +1,10 @@
 import AdminDashboardForAdmin from "@/app/components/admins-dashboard/AdminDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({ params }: { params: { id: string; adminId: string } }) {
+async function Page(props: {
+  params: Promise<{ id: string; adminId: string }>;
+}) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType = await authenticateUserSession("admin", params.id);
 

--- a/frontend/src/app/admins/[id]/admin-list/page.tsx
+++ b/frontend/src/app/admins/[id]/admin-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllAdmins } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/business-calendar/page.tsx
+++ b/frontend/src/app/admins/[id]/business-calendar/page.tsx
@@ -5,9 +5,10 @@ import {
 import { businessCalendarValidRange } from "@/app/helper/utils/calendarUtils";
 import BusinessCalendarClient from "@/app/components/admins-dashboard/BusinessCalendarClient";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-const Page = async ({ params }: { params: { id: string } }) => {
+const Page = async (props: { params: Promise<{ id: string }> }) => {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   const userSessionType: UserType = await authenticateUserSession(

--- a/frontend/src/app/admins/[id]/calendar/[instructorId]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/admins/[id]/calendar/[instructorId]/class-schedule/[classId]/page.tsx
@@ -1,13 +1,12 @@
 import ClassDetails from "@/app/components/instructors-dashboard/class-schedule/classDetails/ClassDetails";
 import { getSameDateClasses } from "@/app/helper/api/instructorsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../../../../middleware";
+import { getCookie } from "../../../../../../../proxy";
 
-const Page = async ({
-  params,
-}: {
-  params: { id: string; instructorId: string; classId: string };
+const Page = async (props: {
+  params: Promise<{ id: string; instructorId: string; classId: string }>;
 }) => {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType = await authenticateUserSession("admin", params.id);
   const adminId = parseInt(params.id);

--- a/frontend/src/app/admins/[id]/calendar/page.tsx
+++ b/frontend/src/app/admins/[id]/calendar/page.tsx
@@ -1,7 +1,8 @@
 import InstructorCalendarForAdmin from "@/app/components/admins-dashboard/InstructorCalendarForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-const Page = async ({ params }: { params: { id: string } }) => {
+const Page = async (props: { params: Promise<{ id: string }> }) => {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/child-list/page.tsx
+++ b/frontend/src/app/admins/[id]/child-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllChildren } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/class-list/[classId]/page.tsx
+++ b/frontend/src/app/admins/[id]/class-list/[classId]/page.tsx
@@ -4,13 +4,12 @@ import {
   getInstructorIdByClassId,
 } from "@/app/helper/api/instructorsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../../middleware";
+import { getCookie } from "../../../../../proxy";
 
-const Page = async ({
-  params,
-}: {
-  params: { id: string; classId: string };
+const Page = async (props: {
+  params: Promise<{ id: string; classId: string }>;
 }) => {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType = await authenticateUserSession("admin", params.id);
   const adminId = parseInt(params.id);

--- a/frontend/src/app/admins/[id]/class-list/page.tsx
+++ b/frontend/src/app/admins/[id]/class-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllClasses } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 ``;
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/customer-list/[customerId]/page.tsx
+++ b/frontend/src/app/admins/[id]/customer-list/[customerId]/page.tsx
@@ -1,11 +1,10 @@
 import CustomerDashboardForAdmin from "@/app/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({
-  params,
-}: {
-  params: { id: string; customerId: string };
+async function Page(props: {
+  params: Promise<{ id: string; customerId: string }>;
 }) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/customer-list/page.tsx
+++ b/frontend/src/app/admins/[id]/customer-list/page.tsx
@@ -4,9 +4,10 @@ import {
   getAllPastCustomers,
 } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/event-list/[eventId]/page.tsx
+++ b/frontend/src/app/admins/[id]/event-list/[eventId]/page.tsx
@@ -1,7 +1,10 @@
 import EventDashboardForAdmin from "@/app/components/admins-dashboard/events-dashboard/EventDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({ params }: { params: { id: string; eventId: string } }) {
+async function Page(props: {
+  params: Promise<{ id: string; eventId: string }>;
+}) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/event-list/page.tsx
+++ b/frontend/src/app/admins/[id]/event-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllEvents } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/instructor-list/[instructorId]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/admins/[id]/instructor-list/[instructorId]/class-schedule/[classId]/page.tsx
@@ -1,13 +1,12 @@
 import ClassDetails from "@/app/components/instructors-dashboard/class-schedule/classDetails/ClassDetails";
 import { getSameDateClasses } from "@/app/helper/api/instructorsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../../../../middleware";
+import { getCookie } from "../../../../../../../proxy";
 
-const Page = async ({
-  params,
-}: {
-  params: { id: string; instructorId: string; classId: string };
+const Page = async (props: {
+  params: Promise<{ id: string; instructorId: string; classId: string }>;
 }) => {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType = await authenticateUserSession("admin", params.id);
   const adminId = parseInt(params.id);

--- a/frontend/src/app/admins/[id]/instructor-list/[instructorId]/page.tsx
+++ b/frontend/src/app/admins/[id]/instructor-list/[instructorId]/page.tsx
@@ -1,11 +1,10 @@
 import InstructorDashboardForAdmin from "@/app/components/admins-dashboard/instructors-dashboard/InstructorDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({
-  params,
-}: {
-  params: { id: string; instructorId: string };
+async function Page(props: {
+  params: Promise<{ id: string; instructorId: string }>;
 }) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/instructor-list/page.tsx
+++ b/frontend/src/app/admins/[id]/instructor-list/page.tsx
@@ -4,9 +4,10 @@ import {
   getAllPastInstructors,
 } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/layout.tsx
+++ b/frontend/src/app/admins/[id]/layout.tsx
@@ -2,13 +2,11 @@ import styles from "./layout.module.scss";
 import SideNav from "@/app/components/layouts/sideNav/SideNav";
 import { getUserSession } from "@/app/helper/auth/sessionUtils";
 
-export default async function Layout({
-  children,
-  params,
-}: {
+export default async function Layout(props: {
   children: React.ReactNode;
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const params = await props.params;
   // Get the admin id from the URL parameters
   let adminId = parseInt(params.id);
   if (isNaN(adminId)) {
@@ -27,7 +25,7 @@ export default async function Layout({
       <div className={styles.sidebar}>
         <SideNav userId={adminId} userType="admin" />
       </div>
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content}>{props.children}</div>
     </div>
   );
 }

--- a/frontend/src/app/admins/[id]/plan-list/[planId]/page.tsx
+++ b/frontend/src/app/admins/[id]/plan-list/[planId]/page.tsx
@@ -1,7 +1,10 @@
 import PlanDashboardForAdmin from "@/app/components/admins-dashboard/plans-dashboard/PlanDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({ params }: { params: { id: string; planId: string } }) {
+async function Page(props: {
+  params: Promise<{ id: string; planId: string }>;
+}) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/plan-list/page.tsx
+++ b/frontend/src/app/admins/[id]/plan-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllPlans } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/[id]/subscription-list/[subscriptionId]/page.tsx
+++ b/frontend/src/app/admins/[id]/subscription-list/[subscriptionId]/page.tsx
@@ -1,7 +1,10 @@
 import PlanDashboardForAdmin from "@/app/components/admins-dashboard/plans-dashboard/PlanDashboardForAdmin";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-async function Page({ params }: { params: { id: string; planId: string } }) {
+async function Page(props: {
+  params: Promise<{ id: string; planId: string }>;
+}) {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "admin",

--- a/frontend/src/app/admins/[id]/subscription-list/page.tsx
+++ b/frontend/src/app/admins/[id]/subscription-list/page.tsx
@@ -1,9 +1,10 @@
 import ListTable from "@/app/components/admins-dashboard/ListTable";
 import { getAllSubscriptions } from "@/app/helper/api/adminsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   const adminId = params.id;
   await authenticateUserSession("admin", adminId);

--- a/frontend/src/app/admins/login/page.module.scss
+++ b/frontend/src/app/admins/login/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/api/proxy/route.ts
+++ b/frontend/src/app/api/proxy/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { getCookie } from "../../../middleware";
+import { getCookie } from "../../../proxy";
 
 export async function GET(req: NextRequest) {
   // Get information from request headers

--- a/frontend/src/app/auth/forgot-password/page.module.scss
+++ b/frontend/src/app/auth/forgot-password/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/auth/new-verification/[token]/page.module.scss
+++ b/frontend/src/app/auth/new-verification/[token]/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/auth/new-verification/[token]/page.tsx
+++ b/frontend/src/app/auth/new-verification/[token]/page.tsx
@@ -5,11 +5,10 @@ import { Suspense } from "react";
 import Loading from "@/app/components/elements/loading/Loading";
 import { verifyCustomerEmail } from "@/app/helper/api/customersApi";
 
-export default async function EmailVerificationPage({
-  params,
-}: {
-  params: { token: string };
+export default async function EmailVerificationPage(props: {
+  params: Promise<{ token: string }>;
 }) {
+  const params = await props.params;
   const token = params.token;
 
   const resultMessage = await verifyCustomerEmail(token);

--- a/frontend/src/app/auth/reset-password/page.module.scss
+++ b/frontend/src/app/auth/reset-password/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -5,11 +5,10 @@ import Loading from "@/app/components/elements/loading/Loading";
 import ResetPasswordForm from "@/app/components/features/resetPasswordForm/ResetPasswordForm";
 import { verifyResetToken } from "@/app/helper/api/usersApi";
 
-export default async function ResetPasswordPage({
-  searchParams,
-}: {
-  searchParams: { token: string; type: UserType };
+export default async function ResetPasswordPage(props: {
+  searchParams: Promise<{ token: string; type: UserType }>;
 }) {
+  const searchParams = await props.searchParams;
   const token = searchParams.token;
   const userType = searchParams.type;
 

--- a/frontend/src/app/components/admins-dashboard/AdminDashboardForAdmin.tsx
+++ b/frontend/src/app/components/admins-dashboard/AdminDashboardForAdmin.tsx
@@ -1,6 +1,6 @@
 import AdminTabs from "@/app/components/admins-dashboard/AdminDashboardClient";
 import { getAdminById } from "@/app/helper/api/adminsApi";
-import { getCookie } from "../../../middleware";
+import { getCookie } from "../../../proxy";
 
 export default async function AdminDashboardForAdmin({
   userId,

--- a/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/AdminProfile.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .container {
   padding: 30px;

--- a/frontend/src/app/components/admins-dashboard/BusinessCalendarClient.module.scss
+++ b/frontend/src/app/components/admins-dashboard/BusinessCalendarClient.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .calendarContainer {
   transform-origin: top;

--- a/frontend/src/app/components/admins-dashboard/BusinessCalendarModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/BusinessCalendarModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .modalContent {
   display: flex;

--- a/frontend/src/app/components/admins-dashboard/EditSubscriptionModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/EditSubscriptionModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .progressiveFlow {
   padding: 0;

--- a/frontend/src/app/components/admins-dashboard/GenerateClassesForm.tsx
+++ b/frontend/src/app/components/admins-dashboard/GenerateClassesForm.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useActionState, useMemo, useState } from "react";
 import ActionButton from "../elements/buttons/actionButton/ActionButton";
 import Modal from "../elements/modal/Modal";
 import GenerateClassesModal from "./GenerateClassesModal";
-import { useFormState } from "react-dom";
 import { generateClassesAction } from "@/app/actions/updateContent";
 
 function GenerateClassesForm() {
@@ -13,21 +12,17 @@ function GenerateClassesForm() {
     successMessage: "",
   };
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [generateClassesResultState, formAction] = useFormState(
+  const [generateClassesResultState, formAction] = useActionState(
     generateClassesAction,
     initialFormState,
   );
-  const [localState, setLocalState] = useState<{
-    errorMessage: string;
-    successMessage: string;
-  }>(initialFormState);
-
-  useEffect(() => {
-    setLocalState({
+  const localState = useMemo(
+    () => ({
       errorMessage: generateClassesResultState.errorMessage ?? "",
       successMessage: generateClassesResultState.successMessage ?? "",
-    });
-  }, [generateClassesResultState]);
+    }),
+    [generateClassesResultState],
+  );
 
   return (
     <>
@@ -40,7 +35,6 @@ function GenerateClassesForm() {
         isOpen={isModalOpen}
         onClose={() => {
           setIsModalOpen(false);
-          setLocalState(initialFormState);
         }}
         className="businessCalendarModal"
       >

--- a/frontend/src/app/components/admins-dashboard/GenerateClassesModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/GenerateClassesModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .modalContent {
   display: flex;

--- a/frontend/src/app/components/admins-dashboard/GenerateClassesModal.tsx
+++ b/frontend/src/app/components/admins-dashboard/GenerateClassesModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useMemo, useState } from "react";
 import styles from "./GenerateClassesModal.module.scss";
 import ActionButton from "../elements/buttons/actionButton/ActionButton";
 import { CalendarDaysIcon } from "@heroicons/react/24/outline";
@@ -14,10 +14,9 @@ type GenerateClassesModalProps = {
 function GenerateClassesModal({ error, success }: GenerateClassesModalProps) {
   const defaultValue = "Select Month";
   const [selectedMonth, setSelectedMonth] = useState(defaultValue);
-  const [selectableMonths, setSelectableMonths] = useState<string[]>([]);
   const isSelectMonth = selectedMonth === "" || selectedMonth === defaultValue;
 
-  useEffect(() => {
+  const selectableMonths = useMemo(() => {
     const now = new Date();
     const months = [];
 
@@ -30,7 +29,7 @@ function GenerateClassesModal({ error, success }: GenerateClassesModalProps) {
       months.push(value);
     }
 
-    setSelectableMonths(months);
+    return months;
   }, []);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/app/components/admins-dashboard/InstructorSearch.module.scss
+++ b/frontend/src/app/components/admins-dashboard/InstructorSearch.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 $border_radius: 0.375rem;
 

--- a/frontend/src/app/components/admins-dashboard/ListPageRegistrationModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/ListPageRegistrationModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .modalContent {
   display: flex;

--- a/frontend/src/app/components/admins-dashboard/ListPageViewPastModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/ListPageViewPastModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .modalContent {
   display: flex;

--- a/frontend/src/app/components/admins-dashboard/ListTable.module.scss
+++ b/frontend/src/app/components/admins-dashboard/ListTable.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 $border_radius: 0.5rem;
 $font_size: 0.9rem;

--- a/frontend/src/app/components/admins-dashboard/TabFunction.module.scss
+++ b/frontend/src/app/components/admins-dashboard/TabFunction.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 $active-color: #ffffff;
 $inactive-color: #888888;

--- a/frontend/src/app/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardClient.tsx
+++ b/frontend/src/app/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import TabFunction from "@/app/components/admins-dashboard/TabFunction";
 import CustomerProfile from "@/app/components/customers-dashboard/profile/CustomerProfile";
 import ChildrenProfiles from "@/app/components/customers-dashboard/children-profiles/ChildrenProfiles";
@@ -22,39 +23,43 @@ function CustomerDashboardClient({
   customerProfile: CustomerProfile;
   childProfiles: Child[];
 }) {
-  // Get the previous list page from local storage to set the breadcrumb.
-  const previousListPage = localStorage.getItem("previousListPage");
-  let breadcrumb: string[] = [];
-  switch (previousListPage) {
-    case "class-list":
-      breadcrumb = [
-        "Class List",
-        `/admins/${adminId}/class-list`,
-        `Customer Page (${customerProfile.name})`,
-      ];
-      break;
-    case "customer-list":
-      breadcrumb = [
-        "Customer List",
-        `/admins/${adminId}/customer-list`,
-        `Customer Page (${customerProfile.name})`,
-      ];
-      break;
-    case "child-list":
-      breadcrumb = [
-        "Child List",
-        `/admins/${adminId}/child-list`,
-        `Customer Page (${customerProfile.name})`,
-      ];
-      break;
-    case "subscription-list":
-      breadcrumb = [
-        "Subscription List",
-        `/admins/${adminId}/subscription-list`,
-        `Customer Page (${customerProfile.name})`,
-      ];
-      break;
-  }
+  const [previousListPage] = useState<string | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return localStorage.getItem("previousListPage");
+  });
+
+  const breadcrumb = useMemo(() => {
+    switch (previousListPage) {
+      case "class-list":
+        return [
+          "Class List",
+          `/admins/${adminId}/class-list`,
+          `Customer Page (${customerProfile.name})`,
+        ];
+      case "customer-list":
+        return [
+          "Customer List",
+          `/admins/${adminId}/customer-list`,
+          `Customer Page (${customerProfile.name})`,
+        ];
+      case "child-list":
+        return [
+          "Child List",
+          `/admins/${adminId}/child-list`,
+          `Customer Page (${customerProfile.name})`,
+        ];
+      case "subscription-list":
+        return [
+          "Subscription List",
+          `/admins/${adminId}/subscription-list`,
+          `Customer Page (${customerProfile.name})`,
+        ];
+      default:
+        return [];
+    }
+  }, [adminId, customerProfile.name, previousListPage]);
 
   // Get the active tab name to set the active tab in the TabFunction component.
   const activeTabName = "activeCustomerTab";

--- a/frontend/src/app/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardForAdmin.tsx
+++ b/frontend/src/app/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardForAdmin.tsx
@@ -4,7 +4,7 @@ import {
   getChildProfiles,
   getCustomerById,
 } from "@/app/helper/api/customersApi";
-import { getCookie } from "../../../../../middleware";
+import { getCookie } from "../../../../../proxy";
 
 export default async function CustomerDashboardForAdmin({
   adminId,

--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventDashboardForAdmin.tsx
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventDashboardForAdmin.tsx
@@ -1,6 +1,6 @@
 import EventTabs from "@/app/components/admins-dashboard/events-dashboard/EventDashboardClient";
 import { getEventById } from "@/app/helper/api/eventsApi";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
 export default async function EventDashboardForAdmin({
   userId,

--- a/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/events-dashboard/EventProfile.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .container {
   padding: 30px;

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
@@ -6,6 +6,8 @@ import { useTabSelect } from "@/app/hooks/useTabSelect";
 import InstructorSchedule from "./instructor-schedule/InstructorSchedule";
 import AvailabilityCalendar from "./instructor-schedule/AvailabilityCalendar";
 import Loading from "@/app/components/elements/loading/Loading";
+import type { InstructorSchedule as InstructorScheduleType } from "@shared/schemas/instructors";
+import type { InstructorScheduleWithSlots } from "@/app/helper/api/instructorsApi";
 
 export default function InstructorTabs({
   adminId,
@@ -13,6 +15,9 @@ export default function InstructorTabs({
   instructor,
   token,
   userSessionType,
+  initialSchedules,
+  initialSelectedScheduleId,
+  initialSelectedSchedule,
   classScheduleComponent,
 }: {
   adminId: number;
@@ -20,6 +25,9 @@ export default function InstructorTabs({
   instructor: Instructor | string;
   token: string;
   userSessionType: UserType;
+  initialSchedules: InstructorScheduleType[];
+  initialSelectedScheduleId: number | null;
+  initialSelectedSchedule: InstructorScheduleWithSlots | null;
   classScheduleComponent: React.ReactNode;
 }) {
   const nickname = typeof instructor !== "string" ? instructor.nickname : null;
@@ -71,7 +79,14 @@ export default function InstructorTabs({
     },
     {
       label: "Instructor's Schedule",
-      content: <InstructorSchedule instructorId={instructorId} />,
+      content: (
+        <InstructorSchedule
+          instructorId={instructorId}
+          initialSchedules={initialSchedules}
+          initialSelectedScheduleId={initialSelectedScheduleId}
+          initialSelectedSchedule={initialSelectedSchedule}
+        />
+      ),
     },
   ];
 

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.module.scss
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.module.scss
@@ -1,5 +1,5 @@
-@import "../../../../variables.module.scss";
-@import "./CalendarVariables.module.scss";
+@use "../../../../variables.module.scss" as *;
+@use "./CalendarVariables.module.scss" as calendar;
 
 .content {
   max-width: 800px;
@@ -8,7 +8,7 @@
 
 .header {
   padding: 20px 24px;
-  border-bottom: 1px solid $border-light;
+  border-bottom: 1px solid calendar.$border-light;
 
   h2 {
     margin: 0;
@@ -30,13 +30,13 @@
     flex-direction: column;
     gap: 8px;
     font-weight: 500;
-    color: $text-primary;
+    color: calendar.$text-primary;
   }
 }
 
 .dateInput {
   padding: 10px 12px;
-  border: 2px solid $border-gray;
+  border: 2px solid calendar.$border-gray;
   border-radius: 6px;
   font-size: 16px;
   max-width: 200px;
@@ -52,12 +52,12 @@
   margin-bottom: 24px;
 
   p {
-    color: $text-primary;
+    color: calendar.$text-primary;
     font-weight: 500;
 
     &:nth-of-type(2) {
       margin-bottom: 16px;
-      color: $text-secondary;
+      color: calendar.$text-secondary;
       font-weight: 400;
       font-size: 14px;
     }
@@ -69,9 +69,9 @@
   gap: 20px;
   margin-bottom: 16px;
   padding: 12px;
-  background-color: $bg-light;
+  background-color: calendar.$bg-light;
   border-radius: 8px;
-  border: 1px solid $border-light;
+  border: 1px solid calendar.$border-light;
   flex-wrap: wrap;
 }
 
@@ -80,20 +80,20 @@
   align-items: center;
   gap: 8px;
   font-size: 14px;
-  color: $text-secondary;
+  color: calendar.$text-secondary;
 }
 
 .legendDot {
   width: 20px;
   height: 16px;
   border-radius: 3px;
-  border: 1px solid $border-light;
-  background-color: $calendar-white;
+  border: 1px solid calendar.$border-light;
+  background-color: calendar.$calendar-white;
   position: relative;
 
   &.unchanged {
-    background-color: $calendar-white;
-    border: 1px solid $border-gray;
+    background-color: calendar.$calendar-white;
+    border: 1px solid calendar.$border-gray;
 
     &::after {
       content: "";
@@ -103,14 +103,14 @@
       transform: translate(-50%, -50%);
       width: 8px;
       height: 8px;
-      background-color: $legend-gray;
+      background-color: calendar.$legend-gray;
       border-radius: 50%;
     }
   }
 
   &.added {
-    background-color: $legend-green-bg;
-    border: 1px solid $border-gray;
+    background-color: calendar.$legend-green-bg;
+    border: 1px solid calendar.$border-gray;
 
     &::after {
       content: "";
@@ -120,14 +120,14 @@
       transform: translate(-50%, -50%);
       width: 8px;
       height: 8px;
-      background-color: $legend-green;
+      background-color: calendar.$legend-green;
       border-radius: 50%;
     }
   }
 
   &.removed {
-    background-color: $legend-red-bg;
-    border: 1px solid $border-gray;
+    background-color: calendar.$legend-red-bg;
+    border: 1px solid calendar.$border-gray;
 
     &::after {
       content: "\00d7"; // Unicode for X mark
@@ -136,31 +136,31 @@
       left: 50%;
       transform: translate(-50%, -50%);
       font-size: 12px;
-      color: $legend-red;
+      color: calendar.$legend-red;
       font-weight: bold;
     }
   }
 
   &.disabled {
-    background-color: $bg-gray;
-    border: 1px solid $border-light;
+    background-color: calendar.$bg-gray;
+    border: 1px solid calendar.$border-light;
     opacity: 0.6;
 
     background-image: repeating-linear-gradient(
       45deg,
-      $bg-gray,
-      $bg-gray 2px,
-      $border-light 2px,
-      $border-light 4px
+      calendar.$bg-gray,
+      calendar.$bg-gray 2px,
+      calendar.$border-light 2px,
+      calendar.$border-light 4px
     );
   }
 }
 
 .calendarContainer {
-  border: 1px solid $border-light;
+  border: 1px solid calendar.$border-light;
   border-radius: 8px;
   overflow: hidden;
-  background-color: $calendar-white;
+  background-color: calendar.$calendar-white;
 }
 
 .footer {
@@ -168,23 +168,23 @@
   justify-content: flex-end;
   gap: 12px;
   padding: 20px 24px;
-  border-top: 1px solid $border-light;
-  background-color: $bg-light;
+  border-top: 1px solid calendar.$border-light;
+  background-color: calendar.$bg-light;
 }
 
 .cancelButton {
   padding: 10px 20px;
-  border: 2px solid $border-gray;
-  background-color: $calendar-white;
-  color: $text-secondary;
+  border: 2px solid calendar.$border-gray;
+  background-color: calendar.$calendar-white;
+  color: calendar.$text-secondary;
   border-radius: 6px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
 
   &:hover {
-    border-color: $text-muted;
-    color: $text-primary;
+    border-color: calendar.$text-muted;
+    color: calendar.$text-primary;
   }
 }
 
@@ -192,7 +192,7 @@
   padding: 10px 20px;
   border: 2px solid $blue_primary;
   background-color: $blue_primary;
-  color: $calendar-white;
+  color: calendar.$calendar-white;
   border-radius: 6px;
   font-weight: 500;
   cursor: pointer;

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.tsx
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Modal from "@/app/components/elements/modal/Modal";
 import EditableScheduleCalendar from "./EditableScheduleCalendar";
 import { InstructorSlot } from "@/app/helper/api/instructorsApi";
@@ -21,9 +21,6 @@ export default function AddScheduleModal({
   onSubmit,
   initialSlots = [],
 }: AddScheduleModalProps) {
-  const [effectiveFrom, setEffectiveFrom] = useState("");
-  const [editedSlots, setEditedSlots] = useState<Set<string>>(new Set());
-
   const slotsToKeys = (slots: InstructorSlot[]): Set<string> => {
     return new Set(
       slots.map((slot) => {
@@ -44,14 +41,14 @@ export default function AddScheduleModal({
     });
   };
 
-  useEffect(() => {
-    if (isOpen) {
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      setEffectiveFrom(tomorrow.toISOString().split("T")[0]);
-      setEditedSlots(slotsToKeys(initialSlots));
-    }
-  }, [isOpen, initialSlots]);
+  const [effectiveFrom, setEffectiveFrom] = useState(() => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().split("T")[0];
+  });
+  const [editedSlots, setEditedSlots] = useState<Set<string>>(() =>
+    slotsToKeys(initialSlots),
+  );
 
   const toggleSlot = (weekday: number, time: string) => {
     const key = slotToKey(weekday, time);

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/EditableScheduleCalendar.module.scss
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/EditableScheduleCalendar.module.scss
@@ -1,22 +1,23 @@
-@import "../../../../variables.module.scss";
-@import "./CalendarVariables.module.scss";
+@use "sass:color";
+@use "../../../../variables.module.scss" as *;
+@use "./CalendarVariables.module.scss" as calendar;
 
 .root {
   display: flex;
-  border: 1px solid $calendar-border;
-  background-color: $calendar-white;
+  border: 1px solid calendar.$calendar-border;
+  background-color: calendar.$calendar-white;
   font-family: "Arial", sans-serif;
   user-select: none;
 }
 
 .timeColumn {
-  border-right: 1px solid $calendar-border;
-  background-color: $calendar-header-bg;
+  border-right: 1px solid calendar.$calendar-border;
+  background-color: calendar.$calendar-header-bg;
 }
 
 .column {
   flex: 1;
-  border-right: 1px solid $calendar-border;
+  border-right: 1px solid calendar.$calendar-border;
 
   &:last-child {
     border-right: none;
@@ -29,9 +30,9 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  color: $calendar-header-text;
-  border-bottom: 1px solid $calendar-border;
-  background-color: $calendar-header-bg;
+  color: calendar.$calendar-header-text;
+  border-bottom: 1px solid calendar.$calendar-border;
+  background-color: calendar.$calendar-header-bg;
   margin: 0;
 }
 
@@ -40,7 +41,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-bottom: 1px solid $calendar-border-light;
+  border-bottom: 1px solid calendar.$calendar-border-light;
   padding: 0 8px;
   width: 60px;
 
@@ -51,7 +52,7 @@
 
 %cellBase {
   height: 30px;
-  border-bottom: 1px solid $calendar-border-light;
+  border-bottom: 1px solid calendar.$calendar-border-light;
   transition: all 0.15s ease;
   position: relative;
 
@@ -70,7 +71,7 @@
   @extend %cellBase;
 
   &:hover {
-    background-color: lighten($blue_primary_hover, 40%);
+    background-color: color.adjust($blue_primary_hover, $lightness: 40%);
     border: 1px solid $blue-primary;
   }
 }
@@ -94,13 +95,13 @@
   }
 
   &:hover {
-    background-color: lighten($gray-background-hover, 20%);
+    background-color: color.adjust($gray-background-hover, $lightness: 20%);
   }
 }
 
 .addedCell {
   @extend %cellBase;
-  background-color: lighten($green-success, 20%);
+  background-color: color.adjust($green-success, $lightness: 20%);
   border: 1px solid $gray-background;
   position: relative;
 
@@ -123,7 +124,7 @@
 
 .removedCell {
   @extend %cellBase;
-  background-color: lighten($red-alert, 30%);
+  background-color: color.adjust($red-alert, $lightness: 30%);
   border: 1px solid $gray-background;
   position: relative;
 
@@ -139,7 +140,7 @@
   }
 
   &:hover {
-    background-color: lighten($red-alert, 25%);
+    background-color: color.adjust($red-alert, $lightness: 25%);
   }
 }
 

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/InstructorSchedule.module.scss
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/InstructorSchedule.module.scss
@@ -1,5 +1,5 @@
-@import "../../../../variables.module.scss";
-@import "./CalendarVariables.module.scss";
+@use "../../../../variables.module.scss" as *;
+@use "./CalendarVariables.module.scss" as calendar;
 
 .dateInput {
   padding-bottom: 1rem;
@@ -17,13 +17,13 @@
   flex-direction: column;
   gap: 8px;
   font-weight: 500;
-  color: $text-primary;
+  color: calendar.$text-primary;
 }
 
 .addButton {
   padding: 0.5rem 1rem;
   background-color: $blue_primary;
-  color: $calendar-white;
+  color: calendar.$calendar-white;
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -38,7 +38,7 @@
 .input {
   margin-left: 0.5rem;
   padding: 8px 12px;
-  border: 2px solid $border-gray;
+  border: 2px solid calendar.$border-gray;
   border-radius: 6px;
   font-size: 16px;
 
@@ -56,13 +56,13 @@
 .scheduleInfo {
   margin: 1rem 0;
   padding: 1rem;
-  background-color: $bg-light;
+  background-color: calendar.$bg-light;
   border-radius: 4px;
-  border: 1px solid $border-light;
+  border: 1px solid calendar.$border-light;
 
   p {
     margin: 0;
-    color: $text-primary;
+    color: calendar.$text-primary;
   }
 }
 
@@ -71,7 +71,7 @@
   text-align: center;
 
   p {
-    color: $text-secondary;
+    color: calendar.$text-secondary;
     font-style: italic;
   }
 }

--- a/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleCalendar.module.scss
+++ b/frontend/src/app/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleCalendar.module.scss
@@ -1,13 +1,14 @@
-@import "../../../../variables.module.scss";
-@import "./CalendarVariables.module.scss";
+@use "sass:color";
+@use "../../../../variables.module.scss" as *;
+@use "./CalendarVariables.module.scss" as calendar;
 
 // Import shared calendar styles
-@import "./EditableScheduleCalendar.module.scss";
+@use "./EditableScheduleCalendar.module.scss" as *;
 
 // Read-only scheduled cell specific to ScheduleCalendar
 %cellBaseReadOnly {
   height: 30px;
-  border-bottom: 1px solid $calendar-border-light;
+  border-bottom: 1px solid calendar.$calendar-border-light;
   position: relative;
   cursor: default;
 
@@ -22,7 +23,7 @@
   // Override any inherited hover effects
   &:hover {
     background-color: transparent !important;
-    border-bottom: 1px solid $calendar-border-light !important;
+    border-bottom: 1px solid calendar.$calendar-border-light !important;
     border-top: none !important;
     border-left: none !important;
     border-right: none !important;
@@ -33,7 +34,7 @@
 
 .scheduledCell {
   @extend %cellBaseReadOnly;
-  background-color: lighten($blue_primary, 45%);
+  background-color: color.adjust($blue_primary, $lightness: 45%);
   border: 1px solid $gray-background;
   position: relative;
 

--- a/frontend/src/app/components/admins-dashboard/plans-dashboard/PlanDashboardForAdmin.tsx
+++ b/frontend/src/app/components/admins-dashboard/plans-dashboard/PlanDashboardForAdmin.tsx
@@ -1,6 +1,6 @@
 import PlanTabs from "@/app/components/admins-dashboard/plans-dashboard/PlanDashboardClient";
 import { getPlanById } from "@/app/helper/api/plansApi";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
 export default async function PlanDashboardForAdmin({
   userId,

--- a/frontend/src/app/components/admins-dashboard/plans-dashboard/PlanProfile.module.scss
+++ b/frontend/src/app/components/admins-dashboard/plans-dashboard/PlanProfile.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .container {
   padding: 30px;

--- a/frontend/src/app/components/customers-dashboard/children-profiles/AddChildForm.tsx
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/AddChildForm.tsx
@@ -10,7 +10,7 @@ import styles from "./AddChildForm.module.scss";
 
 const AddChildForm = ({
   language,
-  action,
+  onSubmit,
   customerId,
   localMessages,
   userSessionType,
@@ -18,7 +18,7 @@ const AddChildForm = ({
   clearErrorMessage,
 }: AddChildFormProps) => {
   return (
-    <form className={styles.addChildForm} action={action}>
+    <form className={styles.addChildForm} onSubmit={onSubmit}>
       {/* Child Name */}
       <InputField
         name="name"

--- a/frontend/src/app/components/customers-dashboard/children-profiles/ChildrenProfiles.module.scss
+++ b/frontend/src/app/components/customers-dashboard/children-profiles/ChildrenProfiles.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .children {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/classes/ClassCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/ClassCalendar.tsx
@@ -8,7 +8,7 @@ import {
   getAllBusinessSchedules,
   getAllEvents,
 } from "@/app/helper/api/adminsApi";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
 export default async function ClassCalendar({
   customerId,

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../variables.module.scss";
+@use "../../../../../variables.module.scss" as *;
 
 .container {
   padding: 1rem;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
@@ -9,7 +9,7 @@ import type { AvailableSlot } from "@shared/schemas/instructors";
 import Calendar from "@/app/components/features/calendar/Calendar";
 import { EventSourceFuncArg, EventClickArg } from "@fullcalendar/core";
 import styles from "./AllInstructorAvailabilityCalendar.module.scss";
-import variables from "@/app/variables.module.scss";
+import { greenSuccess } from "@/app/styles/colors";
 
 interface CalendarEvent {
   id: string;
@@ -58,7 +58,7 @@ const createCalendarEvent = (
     start,
     end,
     title,
-    color: variables.greenSuccess,
+    color: greenSuccess,
     textColor: "#FFF",
     extendedProps: {
       type: "available" as const,

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ChildCheckbox.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ChildCheckbox.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .childCheckbox {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/DateTimeSelection.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/DateTimeSelection.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .dateTimeSelection {
   padding: 1.5rem;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .container {
   padding: 1rem;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.tsx
@@ -5,7 +5,7 @@ import { getInstructorAvailableSlots } from "@/app/helper/api/instructorsApi";
 import Calendar from "@/app/components/features/calendar/Calendar";
 import { EventSourceFuncArg, EventClickArg } from "@fullcalendar/core";
 import styles from "./InstructorAvailabilityCalendar.module.scss";
-import variables from "@/app/variables.module.scss";
+import { greenSuccess } from "@/app/styles/colors";
 
 interface CalendarEvent {
   id: string;
@@ -54,7 +54,7 @@ const createAvailableSlotEvent = (
     start,
     end,
     title: language === "ja" ? "予約可能" : "Available",
-    color: variables.greenSuccess,
+    color: greenSuccess,
     textColor: "#FFF",
     extendedProps: {
       type: "available" as const,

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorItem.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorItem.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .instructorItem {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorItem.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorItem.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import styles from "./InstructorItem.module.scss";
-import variables from "@/app/variables.module.scss";
+import { textLight } from "@/app/styles/colors";
 
 interface InstructorItemProps {
   instructor: InstructorRebookingProfile;
@@ -52,7 +52,7 @@ export default function InstructorItem({
                   width="50"
                   height="50"
                   viewBox="0 0 24 24"
-                  fill={variables.textLight}
+                  fill={textLight}
                 >
                   <path d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z" />
                 </svg>

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorSelection.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/InstructorSelection.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .instructorSelection {
   padding: 2rem;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ModeSelection.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ModeSelection.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .modeSelection {
   padding: 1rem;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.module.scss
@@ -1,4 +1,4 @@
-@import "@/app/variables.module.scss";
+@use "@/app/variables.module.scss" as *;
 
 .progressiveFlow {
   padding: 0;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/CancelClassesActions.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/CancelClassesActions.tsx
@@ -1,6 +1,6 @@
 import CancelClassesModalController from "./cancelClassesModalController/CancelClassesModalController";
 import { getUpcomingClasses } from "@/app/helper/api/customersApi";
-import { getCookie } from "../../../../../../middleware";
+import { getCookie } from "../../../../../../proxy";
 
 export default async function CancelClassesActions({
   customerId,

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/CancelClassesModal.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/CancelClassesModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../../variables.module.scss";
+@use "../../../../../../../variables.module.scss" as *;
 
 .modalWrapper {
   width: 600px;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/upcomingClasses/UpcomingClasses.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/upcomingClasses/UpcomingClasses.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../../../variables.module.scss";
+@use "../../../../../../../../variables.module.scss" as *;
 
 .upcomingClass {
   transition: background-color 0.3s ease;

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/upcomingClasses/UpcomingClasses.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/cancelClassesActions/cancelClassesModalController/cancelClassesModal/upcomingClasses/UpcomingClasses.tsx
@@ -6,7 +6,7 @@ import {
 import styles from "./UpcomingClasses.module.scss";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import Image from "next/image";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 
 export default function UpcomingClasses({
@@ -15,6 +15,7 @@ export default function UpcomingClasses({
   setSelectedClasses,
   isCancelingModalOpen,
 }: UpcomingClassesProps) {
+  const cacheBust = useId();
   const { language } = useLanguage();
   useEffect(() => {
     if (!isCancelingModalOpen) setSelectedClasses([]);
@@ -87,7 +88,7 @@ export default function UpcomingClasses({
 
             <div className={`${styles.item} ${styles["item--instructor"]}`}>
               <Image
-                src={`${eachClass.instructor.icon}?t=${Date.now()}`}
+                src={`${eachClass.instructor.icon}?t=${cacheBust}`}
                 alt={eachClass.instructor.nickname}
                 width={40}
                 height={40}

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/RebookingActions.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/RebookingActions.tsx
@@ -5,7 +5,7 @@ import {
 import RebookingModalController from "./rebookingModalController/RebookingModalController";
 import RebookingForm from "./rebookingForm/RebookingForm";
 import { getInstructorProfiles } from "@/app/helper/api/instructorsApi";
-import { getCookie } from "../../../../../../middleware";
+import { getCookie } from "../../../../../../proxy";
 
 export default async function RebookingActions({
   userSessionType,

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookableClassList/RebookableClassList.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookableClassList/RebookableClassList.tsx
@@ -23,8 +23,7 @@ import { errorAlert } from "@/app/helper/utils/alertUtils";
 export default function RebookableClassList({
   customerId,
   rebookableClasses,
-  setClassToRebook,
-  setRebookingStep,
+  onRebookableClassSelect,
   language,
   userSessionType,
   childProfiles,
@@ -52,6 +51,11 @@ export default function RebookableClassList({
           ? FREE_TRIAL_BOOKING_TOO_LATE_NOTICE[language]
           : REBOOKING_TOO_LATE_NOTICE[language],
       );
+    }
+
+    if (!isFreeTrial) {
+      onRebookableClassSelect(id);
+      return;
     }
 
     // Use booking modal for the new flow

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/confirmRebooking/ConfirmRebooking.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/confirmRebooking/ConfirmRebooking.tsx
@@ -6,7 +6,7 @@ import {
   formatTimeWithAddedMinutes,
   formatYearDateTime,
 } from "@/app/helper/utils/dateUtils";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   CONFIRM_BOOKING_WITH_CONFLICT_MESSAGE,
   DOUBLE_BOOKING_CONFIRMATION_MESSAGE,
@@ -42,18 +42,13 @@ export default function ConfirmRebooking({
   userSessionType,
   language,
 }: ConfirmRebookingProps) {
-  const [selectedChildrenIds, setSelectedChildrenIds] = useState<number[] | []>(
-    [],
+  const [selectedChildrenIds, setSelectedChildrenIds] = useState<number[]>(() =>
+    childProfiles.map((child) => child.id),
   );
   const [isLoading, setIsLoading] = useState(false);
 
   const previousRebookingStep =
     rebookingOption === "instructor" ? "selectDateTime" : "selectInstructor";
-
-  useEffect(() => {
-    const initialIds = childProfiles.map((child) => child.id);
-    setSelectedChildrenIds(initialIds);
-  }, [childProfiles]);
 
   const handleChildChange = (changedChildId: number) => {
     setSelectedChildrenIds((prev: number[]) => {

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableClassesList/RebookableClassesList.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableClassesList/RebookableClassesList.tsx
@@ -12,8 +12,7 @@ import RebookableClassList from "../../rebookableClassList/RebookableClassList";
 export default function RebookableClassesList({
   customerId,
   rebookableClasses,
-  setClassToRebook,
-  setRebookingStep,
+  onRebookableClassSelect,
   language,
   userSessionType,
   childProfiles,
@@ -63,8 +62,7 @@ export default function RebookableClassesList({
             <RebookableClassList
               customerId={customerId}
               rebookableClasses={rebookableClasses}
-              setClassToRebook={setClassToRebook}
-              setRebookingStep={setRebookingStep}
+              onRebookableClassSelect={onRebookableClassSelect}
               language={language}
               userSessionType={userSessionType}
               childProfiles={childProfiles}

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableInstructorsList/RebookableInstructorsList.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableInstructorsList/RebookableInstructorsList.tsx
@@ -30,12 +30,16 @@ export default function RebookableInstructorsList({
 
   const rebookableInstructorIds = useMemo(() => {
     if (rebookingOption === "instructor") {
-      return [...new Set(instructorAvailabilities.map((a) => a.instructorId))];
+      return [
+        ...new Set(
+          instructorAvailabilities.flatMap((a) => a.availableInstructors),
+        ),
+      ];
     }
     if (rebookingOption === "dateTime") {
       return instructorAvailabilities
         .filter((a) => a.dateTime === dateTimeToRebook)
-        .map((a) => a.instructorId);
+        .flatMap((a) => a.availableInstructors);
     }
     return [];
   }, [rebookingOption, instructorAvailabilities, dateTimeToRebook]);

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableTimeSlots/RebookableTimeSlots.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookableTimeSlots/RebookableTimeSlots.tsx
@@ -28,7 +28,7 @@ export default function RebookableTimeSlots({
   const rebookableTimeSlots = useMemo(() => {
     if (rebookingOption === "instructor") {
       return instructorAvailabilities
-        .filter((a) => a.instructorId === instructorToRebook.id)
+        .filter((a) => a.availableInstructors.includes(instructorToRebook.id))
         .map((a) => a.dateTime)
         .sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
     } else if (rebookingOption === "dateTime") {

--- a/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookingCompleteMessage/RebookingCompleteMessage.module.scss
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/rebookingActions/rebookingForm/rebookingCompleteMessage/RebookingCompleteMessage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../../variables.module.scss";
+@use "../../../../../../../variables.module.scss" as *;
 
 .rebookingComplete {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -27,6 +27,7 @@ export default function CustomerCalendar({
 }: CustomerCalendarProps) {
   const [isClassDetailModalOpen, setIsClassDetailModalOpen] = useState(false);
   const [classDetail, setClassDetail] = useState<CustomerClass | null>(null);
+  const cacheBust = useId();
   const { language } = useLanguage();
 
   const handleEventClick = (clickInfo: EventClickArg) => {
@@ -39,7 +40,10 @@ export default function CustomerCalendar({
   };
 
   const validRange = () => getValidRange(createdAt, 3);
-  const renderCustomerEventContent = createRenderEventContent("customer");
+  const renderCustomerEventContent = createRenderEventContent(
+    "customer",
+    cacheBust,
+  );
 
   const handleModalClose = () => {
     setClassDetail(null);

--- a/frontend/src/app/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
+++ b/frontend/src/app/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .modalContent {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/profile/CustomerProfile.module.scss
+++ b/frontend/src/app/components/customers-dashboard/profile/CustomerProfile.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .profileCard {
   display: flex;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/AddSubscription.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/AddSubscription.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 $border_radius: 0.5rem;
 $font_size: 0.9rem;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/CurrentSubscription.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/CurrentSubscription.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .outsideContainer {
   padding-bottom: 1rem;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClass.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClass.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .container {
   background-color: $gray-background;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .table {
   width: 100%;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassModal.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/EditRegularClassModal.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .progressiveFlow {
   padding: 0;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/InstructorSchedule.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/InstructorSchedule.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .scheduleContainer {
   width: 100%;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RecurringClassEntry.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .body {
   background-color: white;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassCard.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassCard.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .card {
   background: white;

--- a/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.module.scss
+++ b/frontend/src/app/components/customers-dashboard/regular-classes/RegularClassesTable.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .cardGrid {
   display: grid;

--- a/frontend/src/app/components/elements/StatusSwitcher/StatusSwitcher.module.scss
+++ b/frontend/src/app/components/elements/StatusSwitcher/StatusSwitcher.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .userStatus {
   &__text {

--- a/frontend/src/app/components/elements/StatusSwitcher/StatusSwitcher.tsx
+++ b/frontend/src/app/components/elements/StatusSwitcher/StatusSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import styles from "./StatusSwitcher.module.scss";
-import { useState, useEffect } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import { getLongMonth, nDaysLater } from "@/app/helper/utils/dateUtils";
 import InputField from "@/app/components/elements/inputField/InputField";
@@ -27,37 +27,25 @@ const StatusSwitcher = ({
 }) => {
   const [status, setStatus] = useState<string>(currentStatus);
   const [updatedLeavingDate, setUpdatedLeavingDate] = useState<string | null>(
-    leavingDate ? leavingDate : null,
+    leavingDate ?? null,
   );
-  const [dateInfo, setDateInfo] = useState<{
-    month: number;
-    date: number;
-    year: number;
-    isPast: boolean;
-  }>({
-    month: 0,
-    date: 0,
-    year: 0,
-    isPast: false,
-  });
   const capitalizeFirst = (str: string): string => {
     if (!str) return str;
     return str.charAt(0).toUpperCase() + str.slice(1);
   };
   const { language } = useLanguage();
 
-  useEffect(() => {
-    setUpdatedLeavingDate(leavingDate ? leavingDate : null);
-
-    // Set date info
-    if (leavingDate) {
-      const targetDate = new Date(leavingDate);
-      const month = targetDate.getMonth();
-      const date = targetDate.getDate();
-      const year = targetDate.getFullYear();
-      const isPast = targetDate < new Date();
-      setDateInfo({ month, date, year, isPast });
+  const dateInfo = useMemo(() => {
+    if (!leavingDate) {
+      return null;
     }
+    const targetDate = new Date(leavingDate);
+    return {
+      month: targetDate.getMonth(),
+      date: targetDate.getDate(),
+      year: targetDate.getFullYear(),
+      isPast: targetDate < new Date(),
+    };
   }, [leavingDate]);
 
   useEffect(() => {
@@ -126,16 +114,18 @@ const StatusSwitcher = ({
         </>
       ) : (
         <>
-          {leavingDate && !isNaN(new Date(leavingDate).getTime()) && (
-            <div className={styles.userLeaving}>
-              <ExclamationTriangleIcon className={styles.userLeaving__icon} />
-              <p className={styles.userLeaving__text}>
-                {language === "en"
-                  ? `${dateInfo.isPast ? "Left" : "Leaving"} on ${getLongMonth(new Date(leavingDate))} ${dateInfo.date}, ${dateInfo.year} (Japan Time)`
-                  : `${dateInfo.year}年${dateInfo.month + 1}月${dateInfo.date}日${dateInfo.isPast ? "退会済み" : "退会予定"} (日本時間)`}
-              </p>
-            </div>
-          )}
+          {leavingDate &&
+            dateInfo &&
+            !isNaN(new Date(leavingDate).getTime()) && (
+              <div className={styles.userLeaving}>
+                <ExclamationTriangleIcon className={styles.userLeaving__icon} />
+                <p className={styles.userLeaving__text}>
+                  {language === "en"
+                    ? `${dateInfo.isPast ? "Left" : "Leaving"} on ${getLongMonth(new Date(leavingDate))} ${dateInfo.date}, ${dateInfo.year} (Japan Time)`
+                    : `${dateInfo.year}年${dateInfo.month + 1}月${dateInfo.date}日${dateInfo.isPast ? "退会済み" : "退会予定"} (日本時間)`}
+                </p>
+              </div>
+            )}
         </>
       )}
     </>

--- a/frontend/src/app/components/elements/breadcrumb/Breadcrumb.module.scss
+++ b/frontend/src/app/components/elements/breadcrumb/Breadcrumb.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .breadcrumb {
   margin-bottom: 1rem;

--- a/frontend/src/app/components/elements/buttons/actionButton/ActionButton.module.scss
+++ b/frontend/src/app/components/elements/buttons/actionButton/ActionButton.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .btnComponent {
   display: inline-block;

--- a/frontend/src/app/components/elements/buttons/redirectButton/RedirectButton.module.scss
+++ b/frontend/src/app/components/elements/buttons/redirectButton/RedirectButton.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .btnComponent {
   display: inline-block;

--- a/frontend/src/app/components/elements/checkboxInput/CheckboxInput.module.scss
+++ b/frontend/src/app/components/elements/checkboxInput/CheckboxInput.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .label {
   display: flex;

--- a/frontend/src/app/components/elements/errorPage/ErrorPage.module.scss
+++ b/frontend/src/app/components/elements/errorPage/ErrorPage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .errorContainer {
   display: flex;

--- a/frontend/src/app/components/elements/externalLink/ExternalLink.module.scss
+++ b/frontend/src/app/components/elements/externalLink/ExternalLink.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .externalLink {
   font-size: 0.9rem;

--- a/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.module.scss
+++ b/frontend/src/app/components/elements/formValidationMessage/FormValidationMessage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .message {
   width: 100%;

--- a/frontend/src/app/components/elements/infoBanner/InfoBanner.module.scss
+++ b/frontend/src/app/components/elements/infoBanner/InfoBanner.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .infoBanner {
   margin-top: 1rem;

--- a/frontend/src/app/components/elements/languageSwitcher/LanguageSwitcher.module.scss
+++ b/frontend/src/app/components/elements/languageSwitcher/LanguageSwitcher.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .languageSwitcher {
   display: flex;

--- a/frontend/src/app/components/elements/maintenancePage/MaintenancePage.module.scss
+++ b/frontend/src/app/components/elements/maintenancePage/MaintenancePage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .maintenanceContainer {
   display: flex;

--- a/frontend/src/app/components/elements/stepIndicator/StepIndicator.module.scss
+++ b/frontend/src/app/components/elements/stepIndicator/StepIndicator.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .stepIndicator {
   display: flex;

--- a/frontend/src/app/components/elements/table/Table.module.scss
+++ b/frontend/src/app/components/elements/table/Table.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .table {
   display: flex;

--- a/frontend/src/app/components/elements/textAreaInput/TextAreaInput.module.scss
+++ b/frontend/src/app/components/elements/textAreaInput/TextAreaInput.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .field {
   margin-bottom: 1rem;

--- a/frontend/src/app/components/elements/textInput/TextInput.module.scss
+++ b/frontend/src/app/components/elements/textInput/TextInput.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .inputWrapper {
   margin-bottom: 1rem;

--- a/frontend/src/app/components/features/calendarView/CalendarView.module.scss
+++ b/frontend/src/app/components/features/calendarView/CalendarView.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 // --- Header Part -----------------
 .headerToolbar {

--- a/frontend/src/app/components/features/classDetail/ClassDetail.module.scss
+++ b/frontend/src/app/components/features/classDetail/ClassDetail.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .classCard {
   padding: 0 25px 15px 25px;

--- a/frontend/src/app/components/features/classDetail/classInstructor/ClassInstructor.module.scss
+++ b/frontend/src/app/components/features/classDetail/classInstructor/ClassInstructor.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .instructor {
   display: flex;

--- a/frontend/src/app/components/features/classDetail/classInstructor/ClassInstructor.tsx
+++ b/frontend/src/app/components/features/classDetail/classInstructor/ClassInstructor.tsx
@@ -1,5 +1,6 @@
 import styles from "./ClassInstructor.module.scss";
 import Image from "next/image";
+import { useId } from "react";
 
 const ClassInstructor = ({
   classStatus,
@@ -16,10 +17,11 @@ const ClassInstructor = ({
   width?: number;
   onClick?: () => void;
 }) => {
+  const cacheBust = useId();
   return (
     <div className={`${styles.instructor} ${className && styles[className]}`}>
       <Image
-        src={`${instructorIcon}?t=${Date.now()}`}
+        src={`${instructorIcon}?t=${cacheBust}`}
         alt={instructorNickname}
         width={width}
         height={width}

--- a/frontend/src/app/components/features/classDetail/classNotification/ClassNotification.module.scss
+++ b/frontend/src/app/components/features/classDetail/classNotification/ClassNotification.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .notification {
   display: flex;

--- a/frontend/src/app/components/features/classDetail/classStatus/ClassStatus.module.scss
+++ b/frontend/src/app/components/features/classDetail/classStatus/ClassStatus.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .classStatus {
   display: flex;

--- a/frontend/src/app/components/features/forgotPasswordForm/ForgotPasswordForm.module.scss
+++ b/frontend/src/app/components/features/forgotPasswordForm/ForgotPasswordForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .form {
   width: 100%;

--- a/frontend/src/app/components/features/forgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/app/components/features/forgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import React from "react";
+import React, { useActionState } from "react";
 import styles from "./ForgotPasswordForm.module.scss";
-import { useFormState } from "react-dom";
 import TextInput from "../../elements/textInput/TextInput";
 import { EnvelopeIcon } from "@heroicons/react/24/outline";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
-import { useFormMessages } from "@/app/hooks/useFormMessages";
 import Link from "next/link";
 import { sendResetEmail } from "@/app/actions/sendResetEmail";
 import { useSearchParams } from "next/navigation";
@@ -18,8 +16,7 @@ export default function ForgotPasswordForm({
 }: {
   language: LanguageType;
 }) {
-  const [resultState, formAction] = useFormState(sendResetEmail, undefined);
-  const { localMessages, clearErrorMessage } = useFormMessages(resultState);
+  const [resultState, formAction] = useActionState(sendResetEmail, undefined);
 
   const searchParams = useSearchParams();
   const userType = searchParams.get("type") as UserType;
@@ -36,7 +33,6 @@ export default function ForgotPasswordForm({
         placeholder={language === "ja" ? "メール" : "e-mail"}
         icon={<EnvelopeIcon className={styles.icon} />}
         required={true}
-        onChange={() => clearErrorMessage("message")}
       />
 
       {/* Hidden input to send necessary data with form submission. */}
@@ -52,16 +48,16 @@ export default function ForgotPasswordForm({
       </div>
 
       <div className={styles.messageWrapper}>
-        {localMessages.errorMessage && (
+        {resultState?.errorMessage && (
           <FormValidationMessage
             type="error"
-            message={localMessages.errorMessage}
+            message={resultState.errorMessage}
           />
         )}
-        {localMessages.successMessage && (
+        {resultState?.successMessage && (
           <FormValidationMessage
             type="success"
-            message={localMessages.successMessage}
+            message={resultState.successMessage}
           />
         )}
       </div>

--- a/frontend/src/app/components/features/loginForm/LoginForm.module.scss
+++ b/frontend/src/app/components/features/loginForm/LoginForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .buttonWrapper {
   display: flex;

--- a/frontend/src/app/components/features/loginForm/LoginForm.tsx
+++ b/frontend/src/app/components/features/loginForm/LoginForm.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useActionState, useState } from "react";
 import styles from "./LoginForm.module.scss";
 import { authenticate } from "@/app/actions/authActions";
-import { useFormState } from "react-dom";
 import TextInput from "../../elements/textInput/TextInput";
 import { EnvelopeIcon, LockClosedIcon } from "@heroicons/react/24/outline";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
-import { useFormMessages } from "@/app/hooks/useFormMessages";
 import Link from "next/link";
 import FormValidationMessage from "../../elements/formValidationMessage/FormValidationMessage";
 
@@ -18,9 +16,8 @@ export default function LoginForm({
   userType: UserType;
   language: LanguageType;
 }) {
-  const [errorState, formAction] = useFormState(authenticate, undefined);
+  const [errorState, formAction] = useActionState(authenticate, undefined);
   const [showPassword, setShowPassword] = useState(false);
-  const { localMessages, clearErrorMessage } = useFormMessages(errorState);
 
   return (
     <form action={formAction} className={styles.form}>
@@ -31,7 +28,6 @@ export default function LoginForm({
         placeholder={language === "ja" ? "メール" : "e-mail"}
         icon={<EnvelopeIcon className={styles.icon} />}
         required={true}
-        onChange={() => clearErrorMessage("message")}
       />
 
       <TextInput
@@ -43,7 +39,6 @@ export default function LoginForm({
         required={true}
         showPassword={showPassword}
         onTogglePasswordVisibility={() => setShowPassword((prev) => !prev)}
-        onChange={() => clearErrorMessage("message")}
         language={language}
       />
 
@@ -67,10 +62,10 @@ export default function LoginForm({
       </div>
 
       <div className={styles.errorWrapper}>
-        {localMessages.errorMessage && (
+        {errorState?.errorMessage && (
           <FormValidationMessage
             type="error"
-            message={localMessages.errorMessage}
+            message={errorState.errorMessage}
           />
         )}
       </div>

--- a/frontend/src/app/components/features/registerForm/RegisterForm.module.scss
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .buttonWrapper {
   display: flex;

--- a/frontend/src/app/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/app/components/features/registerForm/RegisterForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useActionState, useRef, useState } from "react";
 import { useInput } from "@/app/hooks/useInput";
 import styles from "./RegisterForm.module.scss";
 import {
@@ -24,7 +24,6 @@ import {
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
 import TextInput from "../../elements/textInput/TextInput";
 import PasswordStrengthMeter from "../../elements/passwordStrengthMeter/PasswordStrengthMeter";
-import { useFormState } from "react-dom";
 import { registerUser } from "@/app/actions/registerUser";
 import { registerContent } from "@/app/actions/registerContent";
 import { useFormMessages } from "@/app/hooks/useFormMessages";
@@ -46,7 +45,7 @@ const RegisterForm = ({
   // Handle the action based on userType and categoryType
   const actionHandler =
     userType === "admin" && categoryType ? registerContent : registerUser;
-  const [registerResultState, formAction] = useFormState(
+  const [registerResultState, formAction] = useActionState(
     actionHandler,
     undefined,
   );
@@ -54,14 +53,18 @@ const RegisterForm = ({
   const [password, onPasswordChange] = useInput();
   const [showPassword, setShowPassword] = useState(false);
   const [colorValue, setColorValue] = useState(defaultColor);
-  const { localMessages, clearErrorMessage } =
+  const { localMessages, clearErrorMessage, resetMessages } =
     useFormMessages(registerResultState);
   const { passwordStrength } = usePasswordStrength(password);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [nativeStatus, setNativeStatus] = useState<string>("Non-native");
 
   return (
-    <form action={formAction} className={styles.form}>
+    <form
+      action={formAction}
+      className={styles.form}
+      onSubmit={() => resetMessages()}
+    >
       {/* Hidden fields to include in form submission */}
       <input type="hidden" name="userType" value={userType ?? ""} />
       <input type="hidden" name="categoryType" value={categoryType ?? ""} />

--- a/frontend/src/app/components/features/registerForm/birthdateInput/BirthdateInput.module.scss
+++ b/frontend/src/app/components/features/registerForm/birthdateInput/BirthdateInput.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .birthdateInput {
   border: none;

--- a/frontend/src/app/components/features/registerForm/birthdateInput/BirthdateInput.tsx
+++ b/frontend/src/app/components/features/registerForm/birthdateInput/BirthdateInput.tsx
@@ -1,6 +1,6 @@
 import styles from "./BirthdateInput.module.scss";
 import FormValidationMessage from "@/app/components/elements/formValidationMessage/FormValidationMessage";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 const BirthdateInput = ({
   onValidDateChange,
@@ -15,22 +15,21 @@ const BirthdateInput = ({
   const [year, setYear] = useState(defaultYear ?? "");
   const [month, setMonth] = useState(defaultMonth ?? "");
   const [day, setDay] = useState(defaultDay ?? "");
-  const [localIsoDate, setLocalIsoDate] = useState<string | null>(null);
-
   const padZero = (val: string) => val.padStart(2, "0");
 
+  const isoDate = useMemo(() => {
+    if (year === "" || month === "" || day === "") return null;
+    return `${year}-${padZero(month)}-${padZero(day)}`;
+  }, [year, month, day]);
+
   useEffect(() => {
-    if (year === "" || month === "" || day === "") return;
-
-    const iso = `${year}-${padZero(month)}-${padZero(day)}`;
-
+    if (!isoDate) return;
     if (useFormAction) {
       onValidDateChange(undefined);
-      setLocalIsoDate(iso);
     } else {
-      onValidDateChange(iso);
+      onValidDateChange(isoDate);
     }
-  }, [year, month, day, onValidDateChange, useFormAction]);
+  }, [isoDate, onValidDateChange, useFormAction]);
 
   return (
     <fieldset className={styles.birthdateInput}>
@@ -82,8 +81,8 @@ const BirthdateInput = ({
       </div>
 
       {/* Hidden input for form submission */}
-      {useFormAction && localIsoDate && (
-        <input type="hidden" name="birthdate" value={localIsoDate ?? ""} />
+      {useFormAction && isoDate && (
+        <input type="hidden" name="birthdate" value={isoDate ?? ""} />
       )}
 
       {error && (

--- a/frontend/src/app/components/features/registerForm/prefectureSelect/PrefectureSelect.module.scss
+++ b/frontend/src/app/components/features/registerForm/prefectureSelect/PrefectureSelect.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .prefectureSelect {
   margin-bottom: 1rem;

--- a/frontend/src/app/components/features/registerForm/privacyPolicyAgreement/PrivacyPolicyAgreement.module.scss
+++ b/frontend/src/app/components/features/registerForm/privacyPolicyAgreement/PrivacyPolicyAgreement.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .label {
   font-size: 14px;

--- a/frontend/src/app/components/features/registerForm/registerChildForm/RegisterChildForm.module.scss
+++ b/frontend/src/app/components/features/registerForm/registerChildForm/RegisterChildForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .form {
   display: flex;

--- a/frontend/src/app/components/features/registerForm/registerChildForm/RegisterChildForm.tsx
+++ b/frontend/src/app/components/features/registerForm/registerChildForm/RegisterChildForm.tsx
@@ -10,7 +10,6 @@ import FormValidationMessage from "@/app/components/elements/formValidationMessa
 import { extractRegisterValidationErrors } from "@/app/helper/utils/validationErrorUtils";
 import { registerCustomer } from "@/app/helper/api/customersApi";
 import { createChildRegisterSchema } from "@/app/schemas/authSchema";
-import { useFormMessages } from "@/app/hooks/useFormMessages";
 import { useFormFieldSetter } from "@/app/hooks/useFormFieldSetter";
 import TextAreaInput from "@/app/components/elements/textAreaInput/TextAreaInput";
 
@@ -24,8 +23,19 @@ export default function RegisterChildForm({
 }: RegisterChildProps) {
   const [isLoading, setIsLoading] = useState(false);
 
-  const { localMessages, setLocalMessages, clearErrorMessage } =
-    useFormMessages<StringMessages>();
+  const [localMessages, setLocalMessages] = useState<StringMessages>({});
+
+  const clearErrorMessage = useCallback((field: string) => {
+    setLocalMessages((prev) => {
+      if (field === "all") {
+        return {};
+      }
+      const updatedMessages = { ...prev };
+      delete updatedMessages[field];
+      delete updatedMessages.errorMessage;
+      return updatedMessages;
+    });
+  }, []);
 
   const handleChange = useFormFieldSetter(setChildData);
 

--- a/frontend/src/app/components/features/registerForm/registerCompleteMessage/RegisterCompleteMessage.module.scss
+++ b/frontend/src/app/components/features/registerForm/registerCompleteMessage/RegisterCompleteMessage.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .complete {
   text-align: center;

--- a/frontend/src/app/components/features/registerForm/registerCustomerForm/RegisterCustomerForm.module.scss
+++ b/frontend/src/app/components/features/registerForm/registerCustomerForm/RegisterCustomerForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .buttonWrapper {
   display: flex;

--- a/frontend/src/app/components/features/registerForm/registerCustomerForm/RegisterCustomerForm.tsx
+++ b/frontend/src/app/components/features/registerForm/registerCustomerForm/RegisterCustomerForm.tsx
@@ -17,7 +17,6 @@ import ActionButton from "@/app/components/elements/buttons/actionButton/ActionB
 import { createCustomerRegisterSchema } from "@/app/schemas/authSchema";
 import { extractRegisterValidationErrors } from "@/app/helper/utils/validationErrorUtils";
 import { checkEmailConflicts } from "@/app/helper/api/customersApi";
-import { useFormMessages } from "@/app/hooks/useFormMessages";
 import { useFormFieldSetter } from "@/app/hooks/useFormFieldSetter";
 
 const RegisterCustomerForm = ({
@@ -29,8 +28,19 @@ const RegisterCustomerForm = ({
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { passwordStrength } = usePasswordStrength(customerData.password);
-  const { localMessages, setLocalMessages, clearErrorMessage } =
-    useFormMessages<StringMessages>();
+  const [localMessages, setLocalMessages] = useState<StringMessages>({});
+
+  const clearErrorMessage = useCallback((field: string) => {
+    setLocalMessages((prev) => {
+      if (field === "all") {
+        return {};
+      }
+      const updatedMessages = { ...prev };
+      delete updatedMessages[field];
+      delete updatedMessages.errorMessage;
+      return updatedMessages;
+    });
+  }, []);
 
   const handleChange = useFormFieldSetter(setCustomerData);
 

--- a/frontend/src/app/components/features/registerForm/uploadImages/Uploader.module.scss
+++ b/frontend/src/app/components/features/registerForm/uploadImages/Uploader.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .dragDrop {
   display: flex;

--- a/frontend/src/app/components/features/resetPasswordForm/ResetPasswordForm.module.scss
+++ b/frontend/src/app/components/features/resetPasswordForm/ResetPasswordForm.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .title {
   margin-bottom: 1rem;

--- a/frontend/src/app/components/features/resetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/app/components/features/resetPasswordForm/ResetPasswordForm.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useActionState, useState } from "react";
 import styles from "./ResetPasswordForm.module.scss";
-import { useFormState } from "react-dom";
 import TextInput from "../../elements/textInput/TextInput";
 import { LockClosedIcon } from "@heroicons/react/24/outline";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
-import { useFormMessages } from "@/app/hooks/useFormMessages";
 import Link from "next/link";
 import { useInput } from "@/app/hooks/useInput";
 import { usePasswordStrength } from "@/app/hooks/usePasswordStrength";
@@ -28,15 +26,12 @@ export default function ResetPasswordForm({
   const [showPassword, setShowPassword] = useState(false);
   const { passwordStrength } = usePasswordStrength(password);
 
-  const [resultState, formAction] = useFormState(resetPassword, undefined);
-
-  const { localMessages, clearErrorMessage } = useFormMessages(resultState);
-
-  const isError = !!localMessages.errorMessage;
+  const [resultState, formAction] = useActionState(resetPassword, undefined);
+  const isError = !!resultState?.errorMessage;
   const isErrorWithLink =
-    !!localMessages.errorMessageWithResetLink ||
+    !!resultState?.errorMessageWithResetLink ||
     !!tokenVerificationResult.needsResetLink;
-  const isSuccess = !!localMessages.successMessage;
+  const isSuccess = !!resultState?.successMessage;
 
   const { language } = useLanguage();
 
@@ -80,12 +75,11 @@ export default function ResetPasswordForm({
           }
           onChange={(event) => {
             onPasswordChange(event);
-            clearErrorMessage("password");
           }}
           icon={<LockClosedIcon className={styles.icon} />}
           required={true}
           minLength={8}
-          error={localMessages.password}
+          error={resultState?.password}
           showPassword={showPassword}
           onTogglePasswordVisibility={() => setShowPassword((prev) => !prev)}
         />
@@ -103,8 +97,7 @@ export default function ResetPasswordForm({
             language === "ja" ? "パスワード再入力" : "Re-enter password"
           }
           icon={<LockClosedIcon className={styles.icon} />}
-          error={localMessages.passConfirmation}
-          onChange={() => clearErrorMessage("passConfirmation")}
+          error={resultState?.passConfirmation}
           showPassword={showPassword}
           onTogglePasswordVisibility={() => setShowPassword((prev) => !prev)}
           language={language}
@@ -133,11 +126,11 @@ export default function ResetPasswordForm({
             <FormValidationMessage
               type={isSuccess ? "success" : "error"}
               message={
-                isError
-                  ? localMessages.errorMessage
+                (isError
+                  ? resultState?.errorMessage
                   : isErrorWithLink
-                    ? localMessages.errorMessageWithResetLink
-                    : localMessages.successMessage
+                    ? resultState?.errorMessageWithResetLink
+                    : resultState?.successMessage) ?? ""
               }
             />
           )}

--- a/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/ClassDetails.module.scss
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/ClassDetails.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../variables.module.scss";
+@use "../../../../variables.module.scss" as *;
 
 .classDetails {
   &__container {

--- a/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classDetailsCard/ClassDetailsCard.module.scss
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classDetailsCard/ClassDetailsCard.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../variables.module.scss";
+@use "../../../../../variables.module.scss" as *;
 
 .classCard {
   position: sticky;

--- a/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classItem/ClassItem.module.scss
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/classDetails/classItem/ClassItem.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../variables.module.scss";
+@use "../../../../../variables.module.scss" as *;
 
 .classItem {
   background-color: #ffffff;

--- a/frontend/src/app/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendar.tsx
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendar.tsx
@@ -8,7 +8,7 @@ import {
   getAllBusinessSchedules,
   getAllEvents,
 } from "@/app/helper/api/adminsApi";
-import { getCookie } from "../../../../../middleware";
+import { getCookie } from "../../../../../proxy";
 
 async function InstructorCalendar({
   adminId,

--- a/frontend/src/app/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
+++ b/frontend/src/app/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useId } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -24,6 +25,7 @@ const InstructorCalendarClient = ({
   colorsForEvents,
 }: InstructorCalendarClientProps) => {
   const router = useRouter();
+  const cacheBust = useId();
 
   const handleEventClick = (clickInfo: EventClickArg) => {
     if (clickInfo.event.title === "No booked class") return;
@@ -37,7 +39,10 @@ const InstructorCalendarClient = ({
     router.push(redirectURL);
   };
 
-  const renderInstructorEventContent = createRenderEventContent("instructor");
+  const renderInstructorEventContent = createRenderEventContent(
+    "instructor",
+    cacheBust,
+  );
 
   const classSlotTimes = getClassSlotTimesForCalendar();
 

--- a/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
+++ b/frontend/src/app/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .container {
   padding: 30px;

--- a/frontend/src/app/components/layouts/sideNav/SideNav.module.scss
+++ b/frontend/src/app/components/layouts/sideNav/SideNav.module.scss
@@ -1,4 +1,4 @@
-@import "../../../variables.module.scss";
+@use "../../../variables.module.scss" as *;
 
 .sideNavContainer {
   display: flex;

--- a/frontend/src/app/components/layouts/sideNav/SideNav.tsx
+++ b/frontend/src/app/components/layouts/sideNav/SideNav.tsx
@@ -7,7 +7,7 @@ import { getAdminById } from "@/app/helper/api/adminsApi";
 import { getCustomerById } from "@/app/helper/api/customersApi";
 import { getInstructorProfile } from "@/app/helper/api/instructorsApi";
 import LanguageSwitcher from "../../elements/languageSwitcher/LanguageSwitcher";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
 export default async function SideNav({
   userId,

--- a/frontend/src/app/contexts/LanguageContext.tsx
+++ b/frontend/src/app/contexts/LanguageContext.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useState } from "react";
 
 interface LanguageContextProps {
   language: LanguageType;
@@ -11,30 +10,22 @@ interface LanguageContextProps {
 const LanguageContext = createContext<LanguageContextProps | undefined>(
   undefined,
 );
-const Loading = dynamic(
-  () => import("../components/elements/loading/Loading"),
-  { ssr: false },
-);
 
 export const LanguageProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const [language, setLanguage] = useState<LanguageType | null>(null);
-
-  useEffect(() => {
-    const browserLang = navigator.language.startsWith("ja") ? "ja" : "en";
-    setLanguage(browserLang);
-  }, []);
+  const [language, setLanguage] = useState<LanguageType>(() => {
+    if (typeof navigator !== "undefined") {
+      return navigator.language.startsWith("ja") ? "ja" : "en";
+    }
+    return "en";
+  });
 
   const toggleLanguage = () => {
     setLanguage((prev) => (prev === "en" ? "ja" : "en"));
   };
-
-  if (language === null) {
-    return <Loading />;
-  }
 
   return (
     <LanguageContext.Provider value={{ language, toggleLanguage }}>

--- a/frontend/src/app/customers/[id]/business-calendar/page.tsx
+++ b/frontend/src/app/customers/[id]/business-calendar/page.tsx
@@ -4,9 +4,10 @@ import {
 } from "@/app/helper/api/adminsApi";
 import { businessCalendarValidRange } from "@/app/helper/utils/calendarUtils";
 import BusinessCalendarClient from "@/app/components/admins-dashboard/BusinessCalendarClient";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-const Page = async ({ params }: { params: { id: string } }) => {
+const Page = async (props: { params: Promise<{ id: string }> }) => {
+  const params = await props.params;
   const customerId = parseInt(params.id);
   if (isNaN(customerId)) {
     throw new Error("Invalid customerId");

--- a/frontend/src/app/customers/[id]/children-profiles/page.tsx
+++ b/frontend/src/app/customers/[id]/children-profiles/page.tsx
@@ -5,9 +5,12 @@ import {
   getChildProfiles,
   getCustomerById,
 } from "@/app/helper/api/customersApi";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-async function ChildrenProfilesPage({ params }: { params: { id: string } }) {
+async function ChildrenProfilesPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const params = await props.params;
   const customerId = parseInt(params.id);
 
   if (isNaN(customerId)) {

--- a/frontend/src/app/customers/[id]/classes/page.tsx
+++ b/frontend/src/app/customers/[id]/classes/page.tsx
@@ -1,7 +1,8 @@
 import ClassCalendar from "@/app/components/customers-dashboard/classes/ClassCalendar";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
 
-const ClassesPage = async ({ params }: { params: { id: string } }) => {
+const ClassesPage = async (props: { params: Promise<{ id: string }> }) => {
+  const params = await props.params;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(
     "customer",

--- a/frontend/src/app/customers/[id]/instructor-profiles/page.tsx
+++ b/frontend/src/app/customers/[id]/instructor-profiles/page.tsx
@@ -2,9 +2,12 @@ import InstructorsList from "@/app/components/customers-dashboard/instructor-pro
 import Breadcrumb from "@/app/components/elements/breadcrumb/Breadcrumb";
 import { getAllInstructorProfiles } from "@/app/helper/api/instructorsApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-async function InstructorProfilesPage({ params }: { params: { id: string } }) {
+async function InstructorProfilesPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const params = await props.params;
   const customerId = params.id;
   // Authenticate user session
   const userSessionType: UserType = await authenticateUserSession(

--- a/frontend/src/app/customers/[id]/layout.tsx
+++ b/frontend/src/app/customers/[id]/layout.tsx
@@ -1,13 +1,11 @@
 import styles from "./layout.module.scss";
 import SideNav from "@/app/components/layouts/sideNav/SideNav";
 
-export default function Layout({
-  children,
-  params,
-}: {
+export default async function Layout(props: {
   children: React.ReactNode;
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const params = await props.params;
   const customerId = parseInt(params.id);
   if (isNaN(customerId)) {
     throw new Error("Invalid customerId");
@@ -18,7 +16,7 @@ export default function Layout({
       <div className={styles.sidebar}>
         <SideNav userId={customerId} userType="customer" />
       </div>
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content}>{props.children}</div>
     </div>
   );
 }

--- a/frontend/src/app/customers/[id]/profile/page.tsx
+++ b/frontend/src/app/customers/[id]/profile/page.tsx
@@ -2,9 +2,10 @@ import CustomerProfile from "@/app/components/customers-dashboard/profile/Custom
 import Breadcrumb from "@/app/components/elements/breadcrumb/Breadcrumb";
 import { getCustomerById } from "@/app/helper/api/customersApi";
 import { authenticateUserSession } from "@/app/helper/auth/sessionUtils";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-async function CustomerProfilePage({ params }: { params: { id: string } }) {
+async function CustomerProfilePage(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   // Authenticate user session
   await authenticateUserSession("customer", params.id);
   const customerId = parseInt(params.id);

--- a/frontend/src/app/customers/[id]/regular-classes/page.tsx
+++ b/frontend/src/app/customers/[id]/regular-classes/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import RegularClasses from "@/app/components/customers-dashboard/regular-classes/RegularClasses";
-import { useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
 import styles from "./page.module.scss";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
-function Page({ params }: { params: { id: string } }) {
-  const customerId = parseInt(params.id);
+function Page() {
+  const params = useParams<{ id: string }>();
+  const customerId = parseInt(params.id ?? "");
   if (isNaN(customerId)) {
     throw new Error("Invalid customerId");
   }

--- a/frontend/src/app/customers/login/page.module.scss
+++ b/frontend/src/app/customers/login/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/customers/register/page.module.scss
+++ b/frontend/src/app/customers/register/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/globals.scss
+++ b/frontend/src/app/globals.scss
@@ -1,4 +1,4 @@
-@import "./variables.module.scss";
+@use "./variables.module.scss" as *;
 
 * {
   box-sizing: border-box;

--- a/frontend/src/app/helper/api/classesApi.ts
+++ b/frontend/src/app/helper/api/classesApi.ts
@@ -125,7 +125,7 @@ export const cancelClass = async (classId: number, cookie?: string) => {
 
 // POST create monthly classes
 export const generateClasses = async (
-  year: string,
+  year: number,
   month: string,
   cookie: string,
 ) => {
@@ -142,7 +142,7 @@ export const generateClasses = async (
       body,
     });
 
-    if (response.status !== 200) {
+    if (response.status !== 201) {
       throw new Error(`HTTP error. status ${response.status}`);
     }
 

--- a/frontend/src/app/helper/api/instructorsApi.ts
+++ b/frontend/src/app/helper/api/instructorsApi.ts
@@ -861,6 +861,7 @@ export const getInstructorAvailableSlots = async (
 export const getAllInstructorAvailableSlots = async (
   startDate: string,
   endDate: string,
+  isNative: boolean,
   cookie?: string,
 ) => {
   try {
@@ -868,6 +869,7 @@ export const getAllInstructorAvailableSlots = async (
       start: startDate,
       end: endDate,
       timezone: "Asia/Tokyo",
+      isNative: String(isNative),
     });
 
     let apiURL;

--- a/frontend/src/app/helper/types.d.ts
+++ b/frontend/src/app/helper/types.d.ts
@@ -254,6 +254,7 @@ type UpdateFormState = {
   passcode?: string;
   color?: string;
   eventId?: string;
+  description?: string;
   errorMessage?: string;
   successMessage?: string;
   skipProcessing?: string;
@@ -392,8 +393,7 @@ type RebookingModalProps = {
 };
 
 type RebookableClassListProps = RebookingModalProps & {
-  setClassToRebook: Dispatch<SetStateAction<number | null>>;
-  setRebookingStep: Dispatch<SetStateAction<RebookingSteps>>;
+  onRebookableClassSelect: (classId: number) => void;
   language: LanguageType;
   childProfiles: Child[];
 };
@@ -501,8 +501,7 @@ type RebookingFormProps = {
 type RebookableClassesListProps = {
   customerId: number;
   rebookableClasses: RebookableClass[] | [];
-  setClassToRebook: Dispatch<SetStateAction<number | null>>;
-  setRebookingStep: Dispatch<SetStateAction<RebookingSteps>>;
+  onRebookableClassSelect: (classId: number) => void;
   language: LanguageType;
   userSessionType?: UserType;
   childProfiles: Child[];
@@ -566,7 +565,7 @@ type ChildrenProfilesProps = {
 
 type AddChildFormProps = {
   language: LanguageType;
-  action: (payload: FormData) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
   customerId: number;
   localMessages: LocalizedMessages;
   userSessionType?: UserType;

--- a/frontend/src/app/helper/utils/calendarUtils.tsx
+++ b/frontend/src/app/helper/utils/calendarUtils.tsx
@@ -12,7 +12,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { formatTime24Hour } from "./dateUtils";
 
-export const createRenderEventContent = (userType: UserType) => {
+export const createRenderEventContent = (
+  userType: UserType,
+  cacheBust: string,
+) => {
   const RenderEventContent = (eventInfo: EventContentArg) => {
     const classDateTime = new Date(eventInfo.event.startStr);
     const classTime = formatTime24Hour(classDateTime);
@@ -35,7 +38,7 @@ export const createRenderEventContent = (userType: UserType) => {
         (classStatus === "booked" || classStatus === "rebooked") &&
         instructorIcon ? (
           <Image
-            src={`${instructorIcon}?t=${Date.now()}`}
+            src={`${instructorIcon}?t=${cacheBust}`}
             alt={instructorNickname || "Instructor"}
             width={30}
             height={30}

--- a/frontend/src/app/hooks/usePasswordStrength.ts
+++ b/frontend/src/app/hooks/usePasswordStrength.ts
@@ -1,20 +1,14 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import zxcvbn from "zxcvbn";
 
 export function usePasswordStrength(password: string) {
-  const [passwordStrength, setPasswordStrength] = useState<number | null>(null);
-  const [passwordFeedback, setPasswordFeedback] = useState<string>("");
-
-  useEffect(() => {
-    if (password) {
-      const result = zxcvbn(password);
-      setPasswordStrength(result.score);
-      setPasswordFeedback(result.feedback.suggestions.join(" "));
-    } else {
-      setPasswordStrength(null);
-      setPasswordFeedback("");
-    }
+  const result = useMemo(() => {
+    if (!password) return null;
+    return zxcvbn(password);
   }, [password]);
 
-  return { passwordStrength, passwordFeedback };
+  return {
+    passwordStrength: result ? result.score : null,
+    passwordFeedback: result ? result.feedback.suggestions.join(" ") : "",
+  };
 }

--- a/frontend/src/app/instructors/[id]/business-calendar/page.tsx
+++ b/frontend/src/app/instructors/[id]/business-calendar/page.tsx
@@ -4,9 +4,10 @@ import {
 } from "@/app/helper/api/adminsApi";
 import { businessCalendarValidRange } from "@/app/helper/utils/calendarUtils";
 import BusinessCalendarClient from "@/app/components/admins-dashboard/BusinessCalendarClient";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-const Page = async ({ params }: { params: { id: string } }) => {
+const Page = async (props: { params: Promise<{ id: string }> }) => {
+  const params = await props.params;
   const instructorId = parseInt(params.id);
   if (isNaN(instructorId)) {
     throw new Error("Invalid instructorId");

--- a/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
+++ b/frontend/src/app/instructors/[id]/class-schedule/[classId]/page.tsx
@@ -1,12 +1,11 @@
 import ClassDetails from "@/app/components/instructors-dashboard/class-schedule/classDetails/ClassDetails";
 import { getSameDateClasses } from "@/app/helper/api/instructorsApi";
-import { getCookie } from "../../../../../middleware";
+import { getCookie } from "../../../../../proxy";
 
-const ClassDetailsPage = async ({
-  params,
-}: {
-  params: { id: string; classId: string };
+const ClassDetailsPage = async (props: {
+  params: Promise<{ id: string; classId: string }>;
 }) => {
+  const params = await props.params;
   const instructorId = parseInt(params.id);
   if (isNaN(instructorId)) {
     throw new Error("Invalid instructorId");

--- a/frontend/src/app/instructors/[id]/class-schedule/page.tsx
+++ b/frontend/src/app/instructors/[id]/class-schedule/page.tsx
@@ -1,7 +1,10 @@
 import InstructorCalendar from "@/app/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendar";
 import { INVALID_INSTRUCTOR_ID } from "@/app/helper/messages/instructorDashboard";
 
-const ClassSchedulePage = async ({ params }: { params: { id: string } }) => {
+const ClassSchedulePage = async (props: {
+  params: Promise<{ id: string }>;
+}) => {
+  const params = await props.params;
   const instructorId = parseInt(params.id);
 
   if (isNaN(instructorId)) {

--- a/frontend/src/app/instructors/[id]/layout.tsx
+++ b/frontend/src/app/instructors/[id]/layout.tsx
@@ -1,13 +1,11 @@
 import styles from "./layout.module.scss";
 import SideNav from "@/app/components/layouts/sideNav/SideNav";
 
-export default function Layout({
-  children,
-  params,
-}: {
+export default async function Layout(props: {
   children: React.ReactNode;
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const params = await props.params;
   const instructorId = parseInt(params.id);
   if (isNaN(instructorId)) {
     throw new Error("Invalid instructorId");
@@ -18,7 +16,7 @@ export default function Layout({
       <div className={styles.sidebar}>
         <SideNav userId={instructorId} userType="instructor" />
       </div>
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content}>{props.children}</div>
     </div>
   );
 }

--- a/frontend/src/app/instructors/[id]/profile/page.tsx
+++ b/frontend/src/app/instructors/[id]/profile/page.tsx
@@ -1,8 +1,9 @@
 import InstructorProfile from "@/app/components/instructors-dashboard/instructor-profile/InstructorProfile";
 import { getInstructor } from "@/app/helper/api/instructorsApi";
-import { getCookie } from "../../../../middleware";
+import { getCookie } from "../../../../proxy";
 
-async function Page({ params }: { params: { id: string } }) {
+async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
   const instructorId = parseInt(params.id);
 
   if (isNaN(instructorId)) {

--- a/frontend/src/app/instructors/login/page.module.scss
+++ b/frontend/src/app/instructors/login/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../variables.module.scss";
+@use "../../variables.module.scss" as *;
 
 .outsideContainer {
   display: flex;

--- a/frontend/src/app/styles/colors.ts
+++ b/frontend/src/app/styles/colors.ts
@@ -1,0 +1,2 @@
+export const greenSuccess = "#65b72f";
+export const textLight = "#999";

--- a/frontend/src/app/variables.module.scss
+++ b/frontend/src/app/variables.module.scss
@@ -38,9 +38,4 @@ $background-medium: #e0dcdc;
 $background-hover: #ece8e8;
 $text-body: #495057;
 
-// CSS custom properties for use in TypeScript
-:export {
-  greenSuccess: $green-success;
-  textLight: $text-light;
-}
 $light-purple: #e3e4ff;

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,8 +1,10 @@
 import NextAuth from "next-auth";
-import { authConfig } from "../auth.config";
 import { headers } from "next/headers";
+import { authConfig } from "../auth.config";
 
-export default NextAuth(authConfig).auth;
+const { auth } = NextAuth(authConfig);
+
+export const proxy = auth;
 
 export const config = {
   matcher: [
@@ -14,7 +16,7 @@ export const config = {
 
 // Get the cookies from the request headers
 export const getCookie = async () => {
-  const cookie = headers().get("cookie");
+  const cookie = (await headers()).get("cookie");
   if (!cookie) {
     throw new Error("No cookies found in the request headers");
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -23,6 +23,12 @@
     },
     "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Upgraded frontend to Next.js 16.1.1 and React 19.2.3 with updated tooling (TS types, ESLint 9)
- Migrated ESLint to flat config and added Knip entrypoints for Next.js runtime files
- Renamed middleware.ts to proxy.ts and aligned proxy/cookie utilities
- Reworked table usage to avoid TanStack hook warnings and cleaned up state usage
- Converted SCSS `@import` to` @use` and resolved Sass deprecation warnings
- Fixed rebooking flow: use availableInstructors shape and include isNative query param
- Fixed Generate Classes API usage (expect 201 and send numeric year)
