### PR TITLE
Fix booking calendar rawEvents error

### DIFF
--- a/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
+++ b/frontend/src/app/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
@@ -85,7 +85,7 @@ export default function AllInstructorAvailabilityCalendar({
 
   const fetchCalendarEvents = useCallback(
     async (info: EventSourceFuncArg) => {
-      if (isNative === undefined) return;
+      if (isNative === undefined) return [];
       const startStr = formatJSTDate(info.start);
       const exclusiveEnd = new Date(info.end);
       exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);


### PR DESCRIPTION
## Summary
- return an empty array when booking calendar lacks isNative so FullCalendar always receives iterable events