### PR TITLE
Organize existing cron jobs

### DIFF
--- a/backend/src/controllers/instructorScheduleController.ts
+++ b/backend/src/controllers/instructorScheduleController.ts
@@ -8,7 +8,6 @@ import {
   getActiveInstructorSchedule,
   getAvailableSlotsByType,
 } from "../services/instructorScheduleService";
-import { getInstructorsToLeave } from "../services/instructorsService";
 import { Request } from "express";
 import {
   RequestWithParams,
@@ -90,51 +89,6 @@ export const createInstructorScheduleController = async (
     res.status(201).json({
       message: "Schedule version created successfully",
       data: schedule,
-    });
-  } catch (error) {
-    console.error("Error creating schedule version:", error);
-    res.status(500).json({
-      message: "Failed to create schedule version",
-      error: error instanceof Error ? error.message : "Unknown error",
-    });
-  }
-};
-
-// Create instructor post-termination schedule
-export const createInstructorPostTerminationScheduleController = async (
-  _: Request,
-  res: Response,
-) => {
-  try {
-    // Fetch instructors' id who will be leaving
-    const leavingInstructors = await getInstructorsToLeave();
-
-    // Create post termination schedule for each instructor
-    const schedules = await Promise.all(
-      leavingInstructors.map(async (instructor) => {
-        const { id, terminationAt } = instructor;
-
-        if (!id || !terminationAt) {
-          return {};
-        }
-
-        const effectiveFrom = terminationAt;
-
-        // Create a schedule for the instructor
-        const schedule = await createInstructorSchedule({
-          instructorId: id,
-          effectiveFrom,
-          timezone: "Asia/Tokyo",
-          slots: [], // No class schedules
-        });
-
-        return schedule;
-      }),
-    );
-
-    res.status(201).json({
-      message: "Schedule version created successfully",
-      data: schedules,
     });
   } catch (error) {
     console.error("Error creating schedule version:", error);

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -40,7 +40,6 @@ import {
   InstructorAbsencesResponse,
   CreateAbsenceResponse,
   DeleteAbsenceResponse,
-  PostTerminationScheduleResponse,
 } from "../../../shared/schemas/instructors";
 import {
   type RequestWithId,

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -51,7 +51,6 @@ import {
   getInstructorSchedulesController,
   getInstructorScheduleController,
   createInstructorScheduleController,
-  createInstructorPostTerminationScheduleController,
   getInstructorAvailableSlotsController,
   getAllAvailableSlotsController,
   getActiveInstructorScheduleController,
@@ -584,27 +583,6 @@ const deleteAbsenceConfig = {
   },
 } as const;
 
-// Only for cron job use
-const postTerminationScheduleConfig = {
-  method: "post" as const,
-  handler: createInstructorPostTerminationScheduleController,
-  openapi: {
-    summary: "Create post-termination schedules",
-    description:
-      "Create post-termination schedules for all instructors scheduled to leave",
-    responses: {
-      201: {
-        description: "Post-termination schedules created successfully",
-        schema: PostTerminationScheduleResponse,
-      },
-      500: {
-        description: "Internal server error",
-        schema: MessageErrorResponse,
-      },
-    },
-  },
-} as const;
-
 const validatedRouteConfigs = {
   "/all-profiles": [allProfilesConfig],
   "/available-slots": [availableSlotsConfig],
@@ -613,7 +591,6 @@ const validatedRouteConfigs = {
   "/profiles": [profilesConfig],
   "/profiles/native": [nativeProfilesConfig],
   "/profiles/non-native": [nonNativeProfilesConfig],
-  "/schedules/post-termination": [postTerminationScheduleConfig],
   "/:id": [instructorByIdConfig],
   "/:id/absences": [instructorAbsencesConfig, createAbsenceConfig],
   "/:id/absences/:absentAt": [deleteAbsenceConfig],

--- a/backend/src/routes/jobsRouter.ts
+++ b/backend/src/routes/jobsRouter.ts
@@ -99,7 +99,7 @@ const validatedRouteConfigs = {
   "/mask/instructors": [
     {
       method: "patch",
-      // middleware: [verifyCronJobAuthorization],
+      middleware: [verifyCronJobAuthorization],
       handler: maskInstructorsController,
       openapi: {
         summary: "Mask instructors who have left",

--- a/backend/src/services/instructorsService.ts
+++ b/backend/src/services/instructorsService.ts
@@ -345,25 +345,6 @@ export const getInstructorContactById = async (id: number) => {
   });
 };
 
-// Fetch instructors who will be leaving
-export const getInstructorsToLeave = async () => {
-  try {
-    const now = new Date();
-    return await prisma.instructor.findMany({
-      where: {
-        AND: [
-          { terminationAt: { not: null } },
-          { terminationAt: { gt: now } }, // Future termination
-        ],
-      },
-      select: { id: true, terminationAt: true },
-    });
-  } catch (error) {
-    console.error("Error fetching instructors to leave:", error);
-    throw new Error("Failed to fetch instructors to leave");
-  }
-};
-
 // Fetch instructors who have left the organization and has not been masked
 export const getInstructorsToMask = async () => {
   try {

--- a/frontend/src/app/api/cron-job/delete-old-classes/route.ts
+++ b/frontend/src/app/api/cron-job/delete-old-classes/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { updateSundayColor } from "@/app/helper/api/calendarsApi";
+import { deleteOldClasses } from "@/app/helper/api/classesApi";
 
 export const runtime = "nodejs";
 
@@ -16,21 +16,18 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    console.log("Cron job (updateSundayColor) started");
-    await updateSundayColor(authorization); // Update next year's all Sunday's color of business calendar
-    console.log("Cron job (updateSundayColor) executed successfully.");
+    console.log("Cron job (deleteOldClasses) started");
+    await deleteOldClasses(authorization); // Delete classes older than 1 year (13 months)
+    console.log("Cron job (deleteOldClasses) executed successfully.");
     return NextResponse.json(
-      { message: "Cron job (updateSundayColor) executed successfully." },
+      { message: "Cron job (deleteOldClasses) executed successfully." },
       { status: 200 },
     );
   } catch (error) {
-    console.error(
-      "Error during cron job (updateSundayColor) execution:",
-      error,
-    );
+    console.error("Error during cron job (deleteOldClasses) execution:", error);
     return NextResponse.json(
       {
-        error: "Cron job (updateSundayColor) failed",
+        error: "Cron job (deleteOldClasses) failed",
         details: (error as Error).message,
       },
       { status: 500 },

--- a/frontend/src/app/api/cron-job/mask-instructor/route.ts
+++ b/frontend/src/app/api/cron-job/mask-instructor/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { updateSundayColor } from "@/app/helper/api/calendarsApi";
+import { maskInstructor } from "@/app/helper/api/instructorsApi";
 
 export const runtime = "nodejs";
 
@@ -16,21 +16,18 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    console.log("Cron job (updateSundayColor) started");
-    await updateSundayColor(authorization); // Update next year's all Sunday's color of business calendar
-    console.log("Cron job (updateSundayColor) executed successfully.");
+    console.log("Cron job (maskInstructor) started");
+    await maskInstructor(authorization); // Mask instructor information who has left the organization
+    console.log("Cron job (maskInstructor) executed successfully.");
     return NextResponse.json(
-      { message: "Cron job (updateSundayColor) executed successfully." },
+      { message: "Cron job (maskInstructor) executed successfully." },
       { status: 200 },
     );
   } catch (error) {
-    console.error(
-      "Error during cron job (updateSundayColor) execution:",
-      error,
-    );
+    console.error("Error during cron job (maskInstructor) execution:", error);
     return NextResponse.json(
       {
-        error: "Cron job (updateSundayColor) failed",
+        error: "Cron job (maskInstructor) failed",
         details: (error as Error).message,
       },
       { status: 500 },

--- a/frontend/src/app/helper/api/instructorsApi.ts
+++ b/frontend/src/app/helper/api/instructorsApi.ts
@@ -259,7 +259,7 @@ export const updateInstructor = async (
 };
 
 // Mask instructor information (Cron Job use only)
-export const maskInstructors = async (authorization: string): Promise<void> => {
+export const maskInstructor = async (authorization: string): Promise<void> => {
   try {
     // From server component
     const apiURL = `${BACKEND_ORIGIN}/jobs/mask/instructors`;
@@ -762,41 +762,6 @@ export const createInstructorSchedule = async (
     return { schedule: result.data };
   } catch (error) {
     console.error("Failed to create instructor schedule:", error);
-    throw error;
-  }
-};
-
-// Create instructors post termination Schedule (Cron Job use only)
-export const createInstructorPostTerminationSchedule = async (
-  authorization: string,
-) => {
-  try {
-    // From server component
-    const apiURL = `${BASE_URL}/schedules/post-termination`;
-    const method = "POST";
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: authorization,
-    };
-    const response = await fetch(apiURL, {
-      method,
-      headers,
-    });
-
-    if (response.status !== 200) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const result = (await response.json()) as {
-      data: InstructorScheduleWithSlots;
-    };
-
-    return { schedule: result.data };
-  } catch (error) {
-    console.error(
-      "Failed to create instructor post termination schedule:",
-      error,
-    );
     throw error;
   }
 };

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,12 +2,24 @@
   "buildCommand": "cd ../shared && npm ci && cd ../frontend && npm run build",
   "crons": [
     {
-      "path": "/api/cron-job/update-sunday-color",
+      "path": "/api/cron-job/delete-old-classes",
+      "schedule": "0 23 * * 0"
+    },
+    {
+      "path": "/api/cron-job/mask-instructor",
       "schedule": "0 22 * * *"
+    },
+    {
+      "path": "/api/cron-job/update-sunday-color",
+      "schedule": "30 0 1 1 *"
     },
     {
       "path": "/api/cron-job/update-system-status",
       "schedule": "0 0 1 1 *"
+    },
+    {
+      "path": "/api/cron-job/update-system-status",
+      "schedule": "2 0 1 1 *"
     }
   ]
 }


### PR DESCRIPTION
### Overview
- Add cron jobs (`delete-old-classes`, `mask-instructor`) to `frontend/vercel.json`
- Delete unnecessary api (`createInstructorPostTerminationSchedule`)

### Future improvement
- Add other cron jobs to delete old data in `Customer`, `Instructor`, `Plan`, `Schedule` tables