### PR TITLE
test(backend): fix API and simulation test regressions

### DIFF
--- a/backend/src/test/api/customers.test.ts
+++ b/backend/src/test/api/customers.test.ts
@@ -23,7 +23,7 @@ async function createAdminAuthCookie() {
 }
 
 // Mock the resend email service to avoid sending real emails
-vi.mock("../../helper/resendClient", () => ({
+vi.mock("../../lib/email/resendClient", () => ({
   resend: {
     emails: {
       send: vi
@@ -34,10 +34,11 @@ vi.mock("../../helper/resendClient", () => ({
 }));
 
 // Mock the mail helper functions
-vi.mock("../../helper/mail", async (importOriginal) => {
+vi.mock("../../lib/email/mail", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/email/mail")>();
   return {
     ...actual,
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     resendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
   };

--- a/backend/src/test/api/instructors/schedules.test.ts
+++ b/backend/src/test/api/instructors/schedules.test.ts
@@ -979,8 +979,10 @@ describe("GET /instructors/:id/schedules/:scheduleId", () => {
   });
 });
 
-describe("POST /instructors/schedules/post-termination", () => {
-  it("succeed creating post-termination schedules", async () => {
+describe("POST /instructors/:id/schedules", () => {
+  it("succeed creating schedules for instructor with future termination date", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
     const futureDate = faker.date.future();
     const testData = generateTestInstructor();
     const instructor = await createInstructor({
@@ -991,12 +993,24 @@ describe("POST /instructors/schedules/post-termination", () => {
     await createInstructorSchedule(instructor.id, {
       effectiveFrom: new Date("2024-01-01"),
       effectiveTo: null,
+      timezone: "Asia/Tokyo",
     });
 
     const response = await request(server)
-      .post("/instructors/schedules/post-termination")
+      .post(`/instructors/${instructor.id}/schedules`)
+      .set("Cookie", authCookie)
+      .send({
+        effectiveFrom: "2025-02-01",
+        timezone: "Asia/Tokyo",
+        slots: [{ weekday: 1, startTime: "09:00" }],
+      })
       .expect(201);
 
-    expect(response.body.message).toContain("successfully");
+    expect(response.body.data).toMatchObject({
+      instructorId: instructor.id,
+      effectiveFrom: "2025-02-01T00:00:00.000Z",
+      effectiveTo: null,
+      timezone: "Asia/Tokyo",
+    });
   });
 });

--- a/backend/src/test/api/jobs.test.ts
+++ b/backend/src/test/api/jobs.test.ts
@@ -155,6 +155,7 @@ describe("/jobs", () => {
 
       const response = await request(server)
         .patch("/jobs/mask/instructors")
+        .set("Authorization", cronAuthHeader())
         .expect(200);
 
       expect(Array.isArray(response.body)).toBe(true);
@@ -187,6 +188,7 @@ describe("/jobs", () => {
 
       const response = await request(server)
         .patch("/jobs/mask/instructors")
+        .set("Authorization", cronAuthHeader())
         .expect(200);
 
       expect(response.body).toEqual([]);

--- a/backend/src/test/api/users.test.ts
+++ b/backend/src/test/api/users.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../testUtils";
 
 // Mock the resend email service to avoid sending real emails
-vi.mock("../../helper/resendClient", () => ({
+vi.mock("../../lib/email/resendClient", () => ({
   resend: {
     emails: {
       send: vi
@@ -25,10 +25,11 @@ vi.mock("../../helper/resendClient", () => ({
 }));
 
 // Mock the mail helper functions
-vi.mock("../../helper/mail", async (importOriginal) => {
+vi.mock("../../lib/email/mail", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/email/mail")>();
   return {
     ...actual,
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     resendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
   };

--- a/backend/src/test/simulation/bootstrap.test.ts
+++ b/backend/src/test/simulation/bootstrap.test.ts
@@ -3,7 +3,7 @@ import { prisma } from "../setup";
 import { bootstrapSimulation } from "./bootstrap";
 import { defaultSimulationBootstrapConfig } from "./config";
 
-vi.mock("../../helper/resendClient", () => ({
+vi.mock("../../lib/email/resendClient", () => ({
   resend: {
     emails: {
       send: vi
@@ -13,10 +13,11 @@ vi.mock("../../helper/resendClient", () => ({
   },
 }));
 
-vi.mock("../../helper/mail", async (importOriginal) => {
+vi.mock("../../lib/email/mail", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/email/mail")>();
   return {
     ...actual,
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     resendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
   };

--- a/backend/src/test/simulation/doubleBookingRebook.test.ts
+++ b/backend/src/test/simulation/doubleBookingRebook.test.ts
@@ -11,7 +11,7 @@ import {
   generateAuthCookie,
 } from "../testUtils";
 
-vi.mock("../../helper/resendClient", () => ({
+vi.mock("../../lib/email/resendClient", () => ({
   resend: {
     emails: {
       send: vi
@@ -21,10 +21,11 @@ vi.mock("../../helper/resendClient", () => ({
   },
 }));
 
-vi.mock("../../helper/mail", async (importOriginal) => {
+vi.mock("../../lib/email/mail", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/email/mail")>();
   return {
     ...actual,
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     resendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
     sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
   };


### PR DESCRIPTION
## Summary
- align jobs mask endpoint tests with cron auth middleware by adding authorization headers
- update email-related test mocks to current `src/lib/email/*` module paths and include `sendVerificationEmail` mock
- replace stale `POST /instructors/schedules/post-termination` test with current `POST /instructors/:id/schedules` coverage

## Testing
- cd backend && npm run test
- result: 24 passed, 0 failed (188 passed, 0 failed)
