### PR TITLE
docs: refine concurrency and performance test designs; add schedule-update vs booking race

### DIFF
--- a/backend/docs/testing/concurrency-test-design.md
+++ b/backend/docs/testing/concurrency-test-design.md
@@ -1,0 +1,120 @@
+# Concurrency Test Design
+
+## Goals
+
+- Validate correctness under race conditions for class booking workflows.
+- Catch data integrity bugs that do not appear in regular API tests.
+- Keep scenarios deterministic and reproducible.
+
+## Non-goals
+
+- Randomized mixed/fuzz concurrency execution.
+- Response code normalization (for now we tolerate existing inconsistency where appropriate).
+- Performance benchmarking.
+
+## Test suite placement
+
+- New suite directory: `backend/src/test/concurrency/`
+- Existing `simulation` tests can be referenced and gradually moved/renamed into this suite.
+
+## Execution model
+
+- Use Vitest + supertest against the real app server.
+- Use fixed clock (`vi.useFakeTimers`, `vi.setSystemTime`) for deterministic behavior.
+- Use fixed seed by default; allow overriding via CLI/env in runner helpers.
+- Repetition count is configurable.
+  - Default: `1`
+  - Override: `CONCURRENCY_REPETITIONS=<n>`
+
+## Scenarios
+
+### C1. Double booking race (same instructor + same datetime)
+
+**Intent**
+
+- Ensure only one booking/rebook can win for the same instructor slot when requests are concurrent.
+
+**Setup**
+
+- One instructor.
+- Two or more customers with rebookable classes.
+- Same target datetime for all concurrent requests.
+
+**Operation**
+
+- Execute requests in parallel (`Promise.all`) for the same instructor+slot.
+
+**Expected**
+
+- Exactly one request succeeds.
+- Remaining requests fail with conflict-like response.
+- DB invariant: exactly one booked/rebooked class for that instructor+datetime.
+
+### C2. Absence creation vs booking race (same instructor + same datetime)
+
+**Intent**
+
+- Ensure system stays consistent when admin marks absence while customer books/rebooks the same slot.
+
+**Setup**
+
+- One instructor with available slot at target datetime.
+- Customer with class eligible for booking/rebooking.
+- Admin operation to create absence for same instructor+datetime.
+
+**Operation**
+
+- Run absence create request and booking/rebooking request concurrently.
+
+**Expected**
+
+- Only one path wins in a consistent way:
+  - booking succeeds and absence is rejected/conflicted, or
+  - absence succeeds and booking is rejected as unavailable/conflicted.
+- DB invariants after completion:
+  - no contradictory final state (no class confirmed at a slot that is effectively blocked by accepted absence logic).
+  - exactly one final truth for that instructor+datetime.
+
+### C3. Schedule update vs booking race (slot being removed)
+
+**Intent**
+
+- Ensure consistency when an admin updates an instructor schedule and removes a slot while a customer books/rebooks that same slot concurrently.
+
+**Setup**
+
+- One instructor with an active schedule that includes the target slot.
+- A schedule update payload that removes the target slot from the next effective schedule.
+- A customer with class eligible for booking/rebooking to that target slot.
+
+**Operation**
+
+- Execute schedule update request and booking/rebooking request concurrently.
+
+**Expected**
+
+- Only one path wins in a consistent way:
+  - booking/rebooking succeeds and schedule update is rejected/conflicted, or
+  - schedule update succeeds and booking/rebooking is rejected as unavailable/conflicted.
+- DB invariants after completion:
+  - no class remains confirmed in a slot removed by the accepted schedule version.
+  - final schedule and class records describe one consistent state for that instructor+datetime.
+
+## Invariants to assert in every concurrency test
+
+- No double booking for same instructor+datetime.
+- No class in impossible status transition for the scenario under test.
+- All assertions are made against persisted DB state, not only response payloads.
+
+## Proposed command interface
+
+- `npm run test:concurrency`
+- Optional flags/env:
+  - `CONCURRENCY_REPETITIONS=1`
+  - `CONCURRENCY_SEED=123456`
+  - `CONCURRENCY_SCENARIO=C1|C2|C3` (optional filter)
+
+## CI policy
+
+- Concurrency tests are intended to be lightweight and merge-gate candidates.
+- Keep data setup minimal per test to avoid flaky runtime.

--- a/backend/docs/testing/performance-test-design.md
+++ b/backend/docs/testing/performance-test-design.md
@@ -1,0 +1,87 @@
+# Performance Test Design
+
+## Goals
+
+- Verify that class-related workflows run reliably at realistic-to-heavy local scale.
+- Surface practical latency/throughput/error signals.
+- Keep initial model simple (uniform traffic), domain-aware, and runnable on developer machines.
+
+## Non-goals
+
+- CI gating or hard SLO thresholds.
+- DB-level profiling/lock metrics.
+- Production-grade regression dashboarding.
+
+## Test suite placement
+
+- New suite directory: `backend/src/test/performance/`
+- Reuse bootstrap patterns from existing simulation helpers where practical.
+
+## Workload model
+
+The workload follows domain flow rather than synthetic random endpoint spam.
+
+1. Bootstrap data:
+   - customers: `1000`
+   - instructors: `250`
+   - slots per instructor: `10`
+   - multiple plans with different weekly class counts
+   - each customer gets random subscriptions count in `1..3`
+2. Register recurring classes.
+3. Simulate time period day-by-day (example: `2025-01-01` to `2025-03-31`).
+4. For each simulated day:
+   - execute configured count of operations (uniform selection)
+   - ensure scheduled classes for the day are fully processed (complete or cancel) before advancing day
+5. At month boundaries, trigger class generation for upcoming period.
+
+## Execution model
+
+- Single-node app process.
+- Concurrent clients simulated via async/await + parallel request batches.
+- Fake clock control via Vitest time APIs.
+- Isolated local DB through test setup (Testcontainers-compatible approach).
+
+## Metrics (application-level only)
+
+Collect and report per endpoint + aggregate:
+
+- total request count
+- success/failure counts
+- error breakdown (HTTP status + errorType when available)
+- latency p50/p95/p99
+- throughput (requests/sec)
+
+## Invariants (checked at end of full run)
+
+- No double-booked instructor slot (same instructor+datetime).
+- No class assigned to an unavailable instructor slot.
+- No unresolved invalid states for processed classes in the simulated period.
+
+## Output format
+
+- Human-readable markdown report written to file.
+- Include:
+  - test config snapshot (seed, scale, period, operation budget)
+  - summary table of endpoint metrics
+  - invariant check results
+
+## Proposed command interface
+
+- `npm run test:performance`
+- Optional flags/env:
+  - `PERF_SEED=123456`
+  - `PERF_START_DATE=2025-01-01`
+  - `PERF_END_DATE=2025-03-31`
+  - `PERF_DAILY_OPERATIONS=<n>`
+  - `PERF_OUTPUT=./artifacts/performance-report.md`
+
+## Operational policy
+
+- Run locally (developer machine), non-blocking.
+- Any exception or unexpected operation error should fail the run.
+
+## Future extensions (post-v1)
+
+- Run against deployed environment with configurable server URL.
+- Externalized isolated DB configuration for shared staging-style runs.
+- Optional regression comparison reports.


### PR DESCRIPTION
### Motivation

- Make the concurrency and performance testing docs evergreen by removing versioned labels and redundant scope text.
- Capture an additional realistic concurrency scenario where a schedule update that removes a slot races with a customer booking that slot.

### Description

- Renamed the concurrency and performance design headings to remove the `v1` label and simplified version-specific wording in both docs (`backend/docs/testing/concurrency-test-design.md` and `backend/docs/testing/performance-test-design.md`).
- Added scenario `C3: Schedule update vs booking race (slot being removed)` to the concurrency doc with intent, setup, operation, expected outcomes, and DB invariants.
- Removed the `## Out of scope for now` section from the concurrency doc and updated the `CONCURRENCY_SCENARIO` filter example to include `C3`.

### Testing

- Formatted the modified docs with Prettier using `cd backend && npx prettier --write docs/testing/concurrency-test-design.md docs/testing/performance-test-design.md`, which completed successfully.
- No automated unit/test-suite changes were made, so no backend tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a188597c83308a1f28b4409651fb)