### PR TITLE
ci: restrict PRs targeting main to develop only

### DIFF
--- a/.github/workflows/restrict-main-merge-source.yml
+++ b/.github/workflows/restrict-main-merge-source.yml
@@ -1,0 +1,24 @@
+name: restrict-main-merge-source
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+
+jobs:
+  enforce_develop_source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure only develop can target main
+        run: |
+          if [ "${{ github.event.pull_request.head.ref }}" != "develop" ]; then
+            echo "Only pull requests from 'develop' can target 'main'."
+            echo "Found source branch: '${{ github.event.pull_request.head.ref }}'"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,11 @@ Full-stack class management system with separate backend and frontend applicatio
 
 ## Development Guidelines
 
+### Branch Strategy
+- Use `develop` as the base branch for all new pull requests.
+- Open and merge pull requests into `develop` (not `main`).
+- `main` is a release branch: only merge `develop` into `main` via pull request.
+
 ### Code Quality
 - Always run `npm run format` before committing changes
 - Run `npm run lint` on frontend for code quality checks


### PR DESCRIPTION
### Motivation
- Ensure `main` is treated as a release branch and prevent accidental merges from arbitrary branches into `main`.
- Branch protection alone cannot enforce the PR source branch, so an automated guard is needed to ensure only `develop` can be merged into `main`.

### Description
- Updated `AGENTS.md` Branch Strategy to explicitly state that `main` is a release branch and only `develop -> main` PRs are allowed.
- Added a GitHub Actions workflow at `.github/workflows/restrict-main-merge-source.yml` that runs on pull requests targeting `main` and fails unless `github.event.pull_request.head.ref` is exactly `develop`.
- Recommend configuring `main` branch protection to require the workflow job `enforce_develop_source` as a required status check to block non-`develop` PRs.

### Testing
- Ran `git diff --check` which returned no issues.
- Ran `git status --short` to confirm the modified files are present in the working tree.
- No CI workflow runs were executed in this change; the new workflow will be validated when a PR targets `main` and the branch protection requires the `enforce_develop_source` status check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c5baf6f08330a03719c32bf9f75c)