### PR TITLE
Implement performance test basics

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .env*.local
 .vitest
 .vitest-attachments
+
+logs/

--- a/backend/docs/testing/performance-test-design.md
+++ b/backend/docs/testing/performance-test-design.md
@@ -73,7 +73,7 @@ Collect and report per endpoint + aggregate:
   - `PERF_START_DATE=2025-01-01`
   - `PERF_END_DATE=2025-03-31`
   - `PERF_DAILY_OPERATIONS=<n>`
-  - `PERF_OUTPUT=./artifacts/performance-report.md`
+  - `PERF_OUTPUT=./logs/performance-report.md`
 
 ## Operational policy
 

--- a/backend/docs/testing/performance-test-design.md
+++ b/backend/docs/testing/performance-test-design.md
@@ -85,3 +85,16 @@ Collect and report per endpoint + aggregate:
 - Run against deployed environment with configurable server URL.
 - Externalized isolated DB configuration for shared staging-style runs.
 - Optional regression comparison reports.
+
+## Worklog / Change log
+
+### Planned for next PR
+
+- Replace manual class seeding (`createClass()`) with domain flow:
+  - call regular-class registration API
+  - let backend automatically generate classes from recurring class entries
+- Replace day-grouped in-memory class management with request-driven workload:
+  - for each simulated day, each instructor fetches target classes via GET
+  - then send completion requests (PATCH status=completed) for returned classes
+  - this adds GET load in addition to completion PATCH load
+  - remove explicit "classes grouped by day" tracking from test logic

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "dev": "nodemon --exec ts-node ./api/app.ts",
     "prisma:init": "npx prisma migrate reset && npx ts-node ./src/seed/dummy.ts",
     "test": "vitest run",
+    "test:performance": "vitest run src/test/performance",
     "build": "cd ../shared && npm install && cd ../backend && prisma generate && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
     "lint:unused": "knip"
   },

--- a/backend/src/test/globalSetup.ts
+++ b/backend/src/test/globalSetup.ts
@@ -62,11 +62,24 @@ async function dropLeakedTestDatabases(baseDatabaseUrl: string) {
 export default async function globalSetup() {
   dotenv.config();
   await mkdir(stateDir, { recursive: true });
+  const keepDatabase = process.env.KEEP_DATABASE === "1";
 
   let container: StartedPostgreSqlContainer | undefined;
   let baseDatabaseUrlForTeardown: string | undefined;
 
   const baseDatabaseUrl = await (async () => {
+    if (keepDatabase) {
+      if (process.env.POSTGRES_PRISMA_URL)
+        return process.env.POSTGRES_PRISMA_URL;
+      if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+      throw new Error(
+        [
+          "KEEP_DATABASE=1 requires backend/.env database settings.",
+          "Fix: set POSTGRES_PRISMA_URL or DATABASE_URL in `backend/.env`.",
+        ].join("\n"),
+      );
+    }
+
     if (process.env.TEST_DATABASE_URL) return process.env.TEST_DATABASE_URL;
     if (process.env.POSTGRES_PRISMA_URL) return process.env.POSTGRES_PRISMA_URL;
     if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
@@ -95,15 +108,19 @@ export default async function globalSetup() {
 
   baseDatabaseUrlForTeardown = baseDatabaseUrl;
   await writeFile(baseDatabaseUrlFile, baseDatabaseUrl, "utf8");
-  try {
-    await dropLeakedTestDatabases(baseDatabaseUrl);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(["Test DB cleanup skipped due to error.", message].join("\n"));
+  if (!keepDatabase) {
+    try {
+      await dropLeakedTestDatabases(baseDatabaseUrl);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        ["Test DB cleanup skipped due to error.", message].join("\n"),
+      );
+    }
   }
 
   return async () => {
-    if (baseDatabaseUrlForTeardown) {
+    if (baseDatabaseUrlForTeardown && !keepDatabase) {
       try {
         await dropLeakedTestDatabases(baseDatabaseUrlForTeardown);
       } catch (error) {

--- a/backend/src/test/performance/bootstrap.ts
+++ b/backend/src/test/performance/bootstrap.ts
@@ -1,0 +1,132 @@
+import {
+  createAdmin,
+  createChild,
+  createClass,
+  createCustomer,
+  createInstructor,
+  createPlan,
+  generateAuthCookie,
+} from "../testUtils";
+import type { PerformanceTestConfig } from "./config";
+
+type Slot = { weekday: number; startTime: string };
+
+export type CompletionTarget = {
+  classId: number;
+  dateKey: string;
+};
+
+type PerformanceBootstrapState = {
+  adminAuthCookie: string;
+  completionTargets: CompletionTarget[];
+};
+
+const PERFORMANCE_ADMIN = {
+  email: "admin@example.com",
+  password: "AaasoBo!Admin",
+  name: "Admin",
+};
+
+function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
+  const current = new Date(`${startDate}T00:00:00.000Z`);
+  const end = new Date(`${endDate}T00:00:00.000Z`);
+
+  while (current <= end) {
+    yield new Date(current);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildSlots(count: number): Slot[] {
+  const weekdays = [1, 2, 3, 4, 5];
+  const times: string[] = [];
+  for (let hour = 16; hour <= 20; hour += 1) {
+    times.push(`${String(hour).padStart(2, "0")}:00`);
+    times.push(`${String(hour).padStart(2, "0")}:30`);
+  }
+
+  const templateSlots: Slot[] = weekdays.flatMap((weekday) =>
+    times.map((startTime) => ({ weekday, startTime })),
+  );
+
+  if (count > templateSlots.length) {
+    throw new Error(
+      `PERF_SLOTS_PER_INSTRUCTOR=${count} exceeds weekday slot capacity ${templateSlots.length}.`,
+    );
+  }
+
+  return templateSlots.slice(0, count);
+}
+
+function toClassDateTime(day: Date, slot: Slot): Date {
+  const target = new Date(day);
+  const [hours, minutes] = slot.startTime
+    .split(":")
+    .map((value) => Number.parseInt(value, 10));
+  target.setUTCHours(hours ?? 0, minutes ?? 0, 0, 0);
+  return target;
+}
+
+export async function initializePerformanceData(
+  config: PerformanceTestConfig,
+): Promise<PerformanceBootstrapState> {
+  const admin = await createAdmin(PERFORMANCE_ADMIN);
+  const adminAuthCookie = await generateAuthCookie(admin.id, "admin", {
+    expirationTime: "180d",
+  });
+  const plan = await createPlan({
+    name: "パフォーマンステスト / Performance Test",
+    weeklyClassTimes: 1,
+    description: "Seeded plan for performance test inspection",
+    isNative: false,
+  });
+
+  const instructors = await Promise.all(
+    Array.from({ length: config.instructors }, () => createInstructor()),
+  );
+  const customers = await Promise.all(
+    Array.from({ length: config.customers }, async () => {
+      const customer = await createCustomer();
+      const child = await createChild(customer.id);
+      return { customerId: customer.id, childId: child.id };
+    }),
+  );
+
+  const slots = buildSlots(config.slotsPerInstructor);
+  const completionTargets: CompletionTarget[] = [];
+
+  for (const day of enumerateDays(config.startDate, config.endDate)) {
+    const weekday = day.getUTCDay();
+    if (weekday === 0 || weekday === 6) continue;
+
+    for (
+      let customerIndex = 0;
+      customerIndex < customers.length;
+      customerIndex += 1
+    ) {
+      const instructor = instructors[customerIndex % instructors.length]!;
+      const slot = slots[customerIndex % slots.length]!;
+      const dateTime = toClassDateTime(day, slot);
+
+      const classRecord = await createClass(
+        customers[customerIndex]!.customerId,
+        instructor.id,
+        dateTime,
+      );
+
+      completionTargets.push({
+        classId: classRecord.id,
+        dateKey: toDateKey(day),
+      });
+    }
+  }
+
+  return {
+    adminAuthCookie,
+    completionTargets,
+  };
+}

--- a/backend/src/test/performance/config.ts
+++ b/backend/src/test/performance/config.ts
@@ -1,0 +1,64 @@
+const DEFAULT_PERFORMANCE_CONFIG = {
+  seed: 123456,
+  startDate: "2025-01-01",
+  endDate: "2025-01-31",
+  instructors: 5,
+  slotsPerInstructor: 10,
+  customers: 10,
+  outputPath: "./logs/performance-report.md",
+};
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function parseDate(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return value;
+}
+
+export type PerformanceTestConfig = {
+  seed: number;
+  startDate: string;
+  endDate: string;
+  instructors: number;
+  slotsPerInstructor: number;
+  customers: number;
+  outputPath: string;
+};
+
+export function getPerformanceTestConfig(): PerformanceTestConfig {
+  return {
+    seed: parsePositiveInt(
+      process.env.PERF_SEED,
+      DEFAULT_PERFORMANCE_CONFIG.seed,
+    ),
+    startDate: parseDate(
+      process.env.PERF_START_DATE,
+      DEFAULT_PERFORMANCE_CONFIG.startDate,
+    ),
+    endDate: parseDate(
+      process.env.PERF_END_DATE,
+      DEFAULT_PERFORMANCE_CONFIG.endDate,
+    ),
+    instructors: parsePositiveInt(
+      process.env.PERF_INSTRUCTORS,
+      DEFAULT_PERFORMANCE_CONFIG.instructors,
+    ),
+    slotsPerInstructor: parsePositiveInt(
+      process.env.PERF_SLOTS_PER_INSTRUCTOR,
+      DEFAULT_PERFORMANCE_CONFIG.slotsPerInstructor,
+    ),
+    customers: parsePositiveInt(
+      process.env.PERF_CUSTOMERS,
+      DEFAULT_PERFORMANCE_CONFIG.customers,
+    ),
+    outputPath:
+      process.env.PERF_OUTPUT || DEFAULT_PERFORMANCE_CONFIG.outputPath,
+  };
+}

--- a/backend/src/test/performance/report.ts
+++ b/backend/src/test/performance/report.ts
@@ -1,0 +1,58 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+type PerformanceSummary = {
+  elapsedMs: number;
+  daysPassed: number;
+  completedClasses: number;
+  latencyMinMs: number;
+  latencyMaxMs: number;
+  latencyAvgMs: number;
+  latencyMedianMs: number;
+  errors: string[];
+};
+
+export async function writePerformanceReport(args: {
+  config: Record<string, unknown>;
+  summary: PerformanceSummary;
+  outputPath: string;
+}) {
+  const lines: string[] = [];
+  lines.push("# Performance Test Report");
+  lines.push("");
+  lines.push("## Config");
+  lines.push("");
+  lines.push("```json");
+  lines.push(JSON.stringify(args.config, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- elapsed time (ms): ${args.summary.elapsedMs.toFixed(2)}`);
+  lines.push(`- days passed: ${args.summary.daysPassed}`);
+  lines.push(`- completed classes: ${args.summary.completedClasses}`);
+  lines.push(`- latency min (ms): ${args.summary.latencyMinMs.toFixed(2)}`);
+  lines.push(`- latency max (ms): ${args.summary.latencyMaxMs.toFixed(2)}`);
+  lines.push(`- latency average (ms): ${args.summary.latencyAvgMs.toFixed(2)}`);
+  lines.push(
+    `- latency median (ms): ${args.summary.latencyMedianMs.toFixed(2)}`,
+  );
+  lines.push("");
+
+  lines.push("## Errors");
+  lines.push("");
+  if (args.summary.errors.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const error of args.summary.errors) {
+      lines.push(`- ${error}`);
+    }
+  }
+
+  const absolutePath = path.resolve(args.outputPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, `${lines.join("\n")}\n`, "utf8");
+
+  return absolutePath;
+}

--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { server } from "../../server";
+import { getPerformanceTestConfig } from "./config";
+import { initializePerformanceData, type CompletionTarget } from "./bootstrap";
+import { writePerformanceReport } from "./report";
+
+vi.mock("../../lib/email/resendClient", () => ({
+  resend: {
+    emails: {
+      send: vi
+        .fn()
+        .mockResolvedValue({ data: { id: "mock-email-id" }, error: null }),
+    },
+  },
+}));
+
+vi.mock("../../lib/email/mail", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/email/mail")>();
+  return {
+    ...actual,
+    sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
+    resendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
+    sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
+  const current = new Date(`${startDate}T00:00:00.000Z`);
+  const end = new Date(`${endDate}T00:00:00.000Z`);
+
+  while (current <= end) {
+    yield new Date(current);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function calcLatencyStats(latencies: number[]) {
+  if (latencies.length === 0) {
+    return {
+      min: 0,
+      max: 0,
+      average: 0,
+      median: 0,
+    };
+  }
+
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const total = latencies.reduce((sum, value) => sum + value, 0);
+  const medianIndex = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0
+      ? (sorted[medianIndex - 1]! + sorted[medianIndex]!) / 2
+      : sorted[medianIndex]!;
+
+  return {
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    average: total / latencies.length,
+    median,
+  };
+}
+
+async function handleSimulationDay(args: {
+  dayTargets: CompletionTarget[];
+  adminAuthCookie: string;
+}) {
+  const results = await Promise.all(
+    args.dayTargets.map(async (target) => {
+      const startedAt = performance.now();
+      const response = await request(server)
+        .patch(`/classes/${target.classId}/status`)
+        .set("Cookie", args.adminAuthCookie)
+        .send({ status: "completed" });
+      const endedAt = performance.now();
+
+      return {
+        classId: target.classId,
+        latencyMs: endedAt - startedAt,
+        status: response.status,
+        body: response.body,
+      };
+    }),
+  );
+
+  const latencies = results.map((result) => result.latencyMs);
+  const errors = results
+    .filter((result) => result.status !== 200)
+    .map(
+      (result) =>
+        `classId=${result.classId} status=${result.status} body=${JSON.stringify(result.body)}`,
+    );
+
+  return {
+    latencies,
+    errors,
+    completedClasses: results.length - errors.length,
+  };
+}
+
+describe("performance: simple completion workload", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ticks day-by-day and completes scheduled classes", async () => {
+    const config = getPerformanceTestConfig();
+    const state = await initializePerformanceData(config);
+
+    const targetsByDate = new Map<string, CompletionTarget[]>();
+    for (const target of state.completionTargets) {
+      const existing = targetsByDate.get(target.dateKey) ?? [];
+      existing.push(target);
+      targetsByDate.set(target.dateKey, existing);
+    }
+
+    const runStartedAt = performance.now();
+    const allLatencies: number[] = [];
+    const allErrors: string[] = [];
+    let completedClasses = 0;
+    let daysPassed = 0;
+
+    for (const day of enumerateDays(config.startDate, config.endDate)) {
+      vi.setSystemTime(day);
+      daysPassed += 1;
+
+      const dayTargets = targetsByDate.get(toDateKey(day)) ?? [];
+      const dayResult = await handleSimulationDay({
+        dayTargets,
+        adminAuthCookie: state.adminAuthCookie,
+      });
+
+      allLatencies.push(...dayResult.latencies);
+      allErrors.push(...dayResult.errors);
+      completedClasses += dayResult.completedClasses;
+    }
+
+    const runEndedAt = performance.now();
+    const latencyStats = calcLatencyStats(allLatencies);
+
+    const reportPath = await writePerformanceReport({
+      config,
+      summary: {
+        elapsedMs: runEndedAt - runStartedAt,
+        daysPassed,
+        completedClasses,
+        latencyMinMs: latencyStats.min,
+        latencyMaxMs: latencyStats.max,
+        latencyAvgMs: latencyStats.average,
+        latencyMedianMs: latencyStats.median,
+        errors: allErrors,
+      },
+      outputPath: config.outputPath,
+    });
+
+    expect(daysPassed).toBeGreaterThan(0);
+    expect(completedClasses).toBe(state.completionTargets.length);
+    expect(allErrors).toEqual([]);
+    expect(reportPath.endsWith(".md")).toBe(true);
+  }, 180_000);
+});

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -17,16 +17,23 @@ let prismaInitialized = false;
 await (async () => {
   try {
     const baseDatabaseUrl = await getBaseDatabaseUrl();
-    const workerId =
-      process.env.VITEST_WORKER_ID ?? process.env.VITEST_POOL_ID ?? "0";
-    const workerDbName = `aaasobo_test_${workerId}`;
-    requireSafeDbName(workerDbName);
+    const keepDatabase = process.env.KEEP_DATABASE === "1";
 
-    const workerDatabaseUrl = withDatabase(baseDatabaseUrl, workerDbName);
-    process.env.DATABASE_URL = workerDatabaseUrl;
-    process.env.POSTGRES_PRISMA_URL = workerDatabaseUrl;
+    if (keepDatabase) {
+      process.env.DATABASE_URL = baseDatabaseUrl;
+      process.env.POSTGRES_PRISMA_URL = baseDatabaseUrl;
+    } else {
+      const workerId =
+        process.env.VITEST_WORKER_ID ?? process.env.VITEST_POOL_ID ?? "0";
+      const workerDbName = `aaasobo_test_${workerId}`;
+      requireSafeDbName(workerDbName);
 
-    await ensureDatabaseExists(baseDatabaseUrl, workerDbName);
+      const workerDatabaseUrl = withDatabase(baseDatabaseUrl, workerDbName);
+      process.env.DATABASE_URL = workerDatabaseUrl;
+      process.env.POSTGRES_PRISMA_URL = workerDatabaseUrl;
+
+      await ensureDatabaseExists(baseDatabaseUrl, workerDbName);
+    }
 
     // Initialize Prisma client (engineType="client" requires a driver adapter)
     const adapter = new PrismaPg({
@@ -52,7 +59,7 @@ await (async () => {
         "Test database setup failed.",
         message,
         "Fix: start Docker, or set TEST_DATABASE_URL to a reachable PostgreSQL instance.",
-        "Note: the configured DB user must be able to create/drop databases for parallel tests.",
+        "Note: without KEEP_DATABASE=1, the configured DB user must be able to create/drop databases for parallel tests.",
       ].join("\n"),
       { cause: error },
     );

--- a/backend/src/test/testUtils.ts
+++ b/backend/src/test/testUtils.ts
@@ -38,13 +38,17 @@ export function generateTestCustomer(): {
  */
 export function generateTestInstructor() {
   const birthdate = faker.date.past({ years: 30 });
+  const uniqueId = faker.string.uuid();
+  const uniqueDigits = faker.string.numeric(11);
+  const uniquePasscode = faker.string.alphanumeric(8);
+  const uniqueIcon = `${faker.image.avatar()}?id=${uniqueId}`;
   return {
     email: faker.internet.email().toLowerCase(),
     password: faker.internet.password(),
     name: faker.person.fullName(),
-    classURL: faker.internet.url(),
-    icon: faker.image.avatar(),
-    nickname: faker.person.firstName(),
+    classURL: `https://example.com/class/${uniqueId}`,
+    icon: uniqueIcon,
+    nickname: `${faker.person.firstName()}_${uniqueId.slice(0, 8)}`,
     birthdate: birthdate.toISOString().split("T")[0], // YYYY-MM-DD format for API
     lifeHistory: faker.lorem.paragraph(),
     favoriteFood: faker.food.dish(),
@@ -52,8 +56,8 @@ export function generateTestInstructor() {
     messageForChildren: faker.lorem.sentence(),
     workingTime: faker.lorem.words(3),
     skill: faker.lorem.sentence(),
-    meetingId: faker.string.numeric(11),
-    passcode: faker.string.alphanumeric(8),
+    meetingId: uniqueDigits,
+    passcode: uniquePasscode,
     isNative: false,
   };
 }
@@ -353,6 +357,7 @@ export async function createInstructorAbsence(
 async function generateAuthToken(
   userId: number,
   userType: "admin" | "customer" | "instructor",
+  expirationTime: string = "1h",
 ): Promise<string> {
   const { SignJWT } = await import("jose");
   const secret = process.env.AUTH_SECRET;
@@ -365,7 +370,7 @@ async function generateAuthToken(
     userType,
   })
     .setProtectedHeader({ alg: "HS256" })
-    .setExpirationTime("1h")
+    .setExpirationTime(expirationTime)
     .sign(new TextEncoder().encode(secret));
 
   return token;
@@ -377,8 +382,13 @@ async function generateAuthToken(
 export async function generateAuthCookie(
   userId: number,
   userType: "admin" | "customer" | "instructor",
+  options?: { expirationTime?: string },
 ): Promise<string> {
   const salt = process.env.AUTH_SALT || "authjs.session-token";
-  const token = await generateAuthToken(userId, userType);
+  const token = await generateAuthToken(
+    userId,
+    userType,
+    options?.expirationTime ?? "1h",
+  );
   return `${salt}=${token}`;
 }


### PR DESCRIPTION
### Motivation
- Improve the performance workload to better simulate multiple clients acting concurrently by running per-day class completion requests in parallel.
- Keep the existing day-by-day time progression and simple completion baseline intact while aligning request execution with realistic concurrent traffic.

### Description
- Replaced the sequential per-target `for...of` updates in `handleSimulationDay` with a `Promise.all` that runs all `PATCH /classes/:id/status` requests in parallel in `backend/src/test/performance/workload.test.ts`.
- Aggregated per-request `latencyMs`, collected non-200 responses into an `errors` list, and computed `completedClasses` from the parallel results, preserving previous summary metrics.
- Left the outer day iteration, report generation via `writePerformanceReport`, and overall test assertions unchanged.

### Testing
- Ran `npx prettier --write backend/src/test/performance/workload.test.ts` and `npx prettier --check backend/src/test/performance/workload.test.ts`, which passed formatting checks.
- Attempted `cd backend && npm run test -- src/test/performance/workload.test.ts`, but the run failed in this environment because the `vitest` binary was not available.
- Attempted `cd backend && npm run format`, but the run failed here at `npx prisma format` due to an upstream npm registry `403` error, preventing full format validation in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991223ac36c8330af594521c3fe0050)