### PR TITLE
Remove KEEP_DATABASE branching from test DB setup

### DIFF
--- a/backend/src/test/globalSetup.ts
+++ b/backend/src/test/globalSetup.ts
@@ -62,24 +62,11 @@ async function dropLeakedTestDatabases(baseDatabaseUrl: string) {
 export default async function globalSetup() {
   dotenv.config();
   await mkdir(stateDir, { recursive: true });
-  const keepDatabase = process.env.KEEP_DATABASE === "1";
 
   let container: StartedPostgreSqlContainer | undefined;
   let baseDatabaseUrlForTeardown: string | undefined;
 
   const baseDatabaseUrl = await (async () => {
-    if (keepDatabase) {
-      if (process.env.POSTGRES_PRISMA_URL)
-        return process.env.POSTGRES_PRISMA_URL;
-      if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
-      throw new Error(
-        [
-          "KEEP_DATABASE=1 requires backend/.env database settings.",
-          "Fix: set POSTGRES_PRISMA_URL or DATABASE_URL in `backend/.env`.",
-        ].join("\n"),
-      );
-    }
-
     if (process.env.TEST_DATABASE_URL) return process.env.TEST_DATABASE_URL;
     if (process.env.POSTGRES_PRISMA_URL) return process.env.POSTGRES_PRISMA_URL;
     if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
@@ -108,19 +95,15 @@ export default async function globalSetup() {
 
   baseDatabaseUrlForTeardown = baseDatabaseUrl;
   await writeFile(baseDatabaseUrlFile, baseDatabaseUrl, "utf8");
-  if (!keepDatabase) {
-    try {
-      await dropLeakedTestDatabases(baseDatabaseUrl);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(
-        ["Test DB cleanup skipped due to error.", message].join("\n"),
-      );
-    }
+  try {
+    await dropLeakedTestDatabases(baseDatabaseUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(["Test DB cleanup skipped due to error.", message].join("\n"));
   }
 
   return async () => {
-    if (baseDatabaseUrlForTeardown && !keepDatabase) {
+    if (baseDatabaseUrlForTeardown) {
       try {
         await dropLeakedTestDatabases(baseDatabaseUrlForTeardown);
       } catch (error) {

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -17,23 +17,17 @@ let prismaInitialized = false;
 await (async () => {
   try {
     const baseDatabaseUrl = await getBaseDatabaseUrl();
-    const keepDatabase = process.env.KEEP_DATABASE === "1";
 
-    if (keepDatabase) {
-      process.env.DATABASE_URL = baseDatabaseUrl;
-      process.env.POSTGRES_PRISMA_URL = baseDatabaseUrl;
-    } else {
-      const workerId =
-        process.env.VITEST_WORKER_ID ?? process.env.VITEST_POOL_ID ?? "0";
-      const workerDbName = `aaasobo_test_${workerId}`;
-      requireSafeDbName(workerDbName);
+    const workerId =
+      process.env.VITEST_WORKER_ID ?? process.env.VITEST_POOL_ID ?? "0";
+    const workerDbName = `aaasobo_test_${workerId}`;
+    requireSafeDbName(workerDbName);
 
-      const workerDatabaseUrl = withDatabase(baseDatabaseUrl, workerDbName);
-      process.env.DATABASE_URL = workerDatabaseUrl;
-      process.env.POSTGRES_PRISMA_URL = workerDatabaseUrl;
+    const workerDatabaseUrl = withDatabase(baseDatabaseUrl, workerDbName);
+    process.env.DATABASE_URL = workerDatabaseUrl;
+    process.env.POSTGRES_PRISMA_URL = workerDatabaseUrl;
 
-      await ensureDatabaseExists(baseDatabaseUrl, workerDbName);
-    }
+    await ensureDatabaseExists(baseDatabaseUrl, workerDbName);
 
     // Initialize Prisma client (engineType="client" requires a driver adapter)
     const adapter = new PrismaPg({
@@ -59,7 +53,7 @@ await (async () => {
         "Test database setup failed.",
         message,
         "Fix: start Docker, or set TEST_DATABASE_URL to a reachable PostgreSQL instance.",
-        "Note: without KEEP_DATABASE=1, the configured DB user must be able to create/drop databases for parallel tests.",
+        "Note: the configured DB user must be able to create/drop databases for parallel tests.",
       ].join("\n"),
       { cause: error },
     );


### PR DESCRIPTION
### Motivation
- The `KEEP_DATABASE` toggle added conditional complexity to the test database setup and is unnecessary for the performance tests, so tests should always use worker-specific databases and always perform leak cleanup.

### Description
- Remove the `KEEP_DATABASE` conditional branch from `backend/src/test/globalSetup.ts` and always resolve a base DB URL from env or a testcontainer, and always attempt to drop leaked `aaasobo_test_%` databases on startup and shutdown.
- Remove the `KEEP_DATABASE` branch from `backend/src/test/setup.ts` so each worker always creates/uses a `aaasobo_test_<workerId>` database and calls `ensureDatabaseExists`.
- Update error guidance text to remove references to `KEEP_DATABASE=1` and reflect that the DB user must be able to create/drop databases for parallel tests.
- Files changed: `backend/src/test/globalSetup.ts`, `backend/src/test/setup.ts`.

### Testing
- Ran `cd backend && npm run format`; Prettier ran successfully but `prisma format` failed in this environment due to registry access (`npm ERR! 403 Forbidden`).
- Attempted `cd backend && npm run test:performance`; the run failed because `vitest` (test runner) is not available in the current environment (`vitest: not found`).
- Changes were committed as `test: remove KEEP_DATABASE toggle from test DB setup`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6dc78eec83308b5a0169c840f289)