### PR TITLE
Bootstrap perf test via subscription/recurring-class APIs and fetch daily classes via instructor calendar

### DIFF
--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -29,6 +29,7 @@ import {
   InstructorAvailableSlotsQuery,
   AvailableSlotsResponse,
   InstructorAvailableSlotsResponse,
+  InstructorCalendarClassesResponse,
   InstructorClassParams,
   ActiveScheduleQuery,
   ActiveScheduleResponse,
@@ -365,7 +366,7 @@ const calendarClassesConfig = {
     responses: {
       200: {
         description: "Successfully retrieved calendar classes",
-        // Using any schema for now since the response is complex class data
+        schema: InstructorCalendarClassesResponse,
       },
       400: {
         description: "Invalid instructor ID",

--- a/backend/src/test/performance/bootstrap.ts
+++ b/backend/src/test/performance/bootstrap.ts
@@ -58,7 +58,7 @@ async function createInstructorSchedule(args: {
     .post(`/instructors/${args.instructorId}/schedules`)
     .set("Cookie", args.adminAuthCookie)
     .send({
-      effectiveFrom: toJstDateString(args.startDate),
+      effectiveFrom: args.startDate,
       timezone: "Asia/Tokyo",
       slots: args.slots,
     });
@@ -117,7 +117,7 @@ async function createRecurringClass(args: {
       customerId: args.customerId,
       childrenIds: [args.childId],
       subscriptionId: args.subscriptionId,
-      startDate: toJstDateString(args.startDate),
+      startDate: args.startDate,
       timezone: "Asia/Tokyo",
     });
 

--- a/backend/src/test/performance/bootstrap.ts
+++ b/backend/src/test/performance/bootstrap.ts
@@ -1,7 +1,8 @@
+import request from "supertest";
+import { server } from "../../server";
 import {
   createAdmin,
   createChild,
-  createClass,
   createCustomer,
   createInstructor,
   createPlan,
@@ -11,14 +12,9 @@ import type { PerformanceTestConfig } from "./config";
 
 type Slot = { weekday: number; startTime: string };
 
-export type CompletionTarget = {
-  classId: number;
-  dateKey: string;
-};
-
 type PerformanceBootstrapState = {
   adminAuthCookie: string;
-  completionTargets: CompletionTarget[];
+  instructorIds: number[];
 };
 
 const PERFORMANCE_ADMIN = {
@@ -26,20 +22,6 @@ const PERFORMANCE_ADMIN = {
   password: "AaasoBo!Admin",
   name: "Admin",
 };
-
-function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
-  const current = new Date(`${startDate}T00:00:00.000Z`);
-  const end = new Date(`${endDate}T00:00:00.000Z`);
-
-  while (current <= end) {
-    yield new Date(current);
-    current.setUTCDate(current.getUTCDate() + 1);
-  }
-}
-
-function toDateKey(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
 
 function buildSlots(count: number): Slot[] {
   const weekdays = [1, 2, 3, 4, 5];
@@ -62,13 +44,88 @@ function buildSlots(count: number): Slot[] {
   return templateSlots.slice(0, count);
 }
 
-function toClassDateTime(day: Date, slot: Slot): Date {
-  const target = new Date(day);
-  const [hours, minutes] = slot.startTime
-    .split(":")
-    .map((value) => Number.parseInt(value, 10));
-  target.setUTCHours(hours ?? 0, minutes ?? 0, 0, 0);
-  return target;
+function toJstDateString(date: string): string {
+  return `${date}T00:00:00+09:00`;
+}
+
+async function createInstructorSchedule(args: {
+  adminAuthCookie: string;
+  instructorId: number;
+  slots: Slot[];
+  startDate: string;
+}) {
+  const response = await request(server)
+    .post(`/instructors/${args.instructorId}/schedules`)
+    .set("Cookie", args.adminAuthCookie)
+    .send({
+      effectiveFrom: toJstDateString(args.startDate),
+      timezone: "Asia/Tokyo",
+      slots: args.slots,
+    });
+
+  if (response.status !== 201) {
+    throw new Error(
+      `failed to create instructor schedule: instructorId=${args.instructorId}, status=${response.status}, body=${JSON.stringify(response.body)}`,
+    );
+  }
+}
+
+async function registerSubscription(args: {
+  adminAuthCookie: string;
+  customerId: number;
+  planId: number;
+  startDate: string;
+}) {
+  const response = await request(server)
+    .post(`/customers/${args.customerId}/subscription`)
+    .set("Cookie", args.adminAuthCookie)
+    .send({
+      planId: args.planId,
+      startAt: toJstDateString(args.startDate),
+    });
+
+  if (response.status !== 200) {
+    throw new Error(
+      `failed to register subscription: customerId=${args.customerId}, status=${response.status}, body=${JSON.stringify(response.body)}`,
+    );
+  }
+
+  const subscriptionId = response.body?.newSubscription?.id;
+  if (typeof subscriptionId !== "number") {
+    throw new Error(
+      `missing subscription id in response: customerId=${args.customerId}, body=${JSON.stringify(response.body)}`,
+    );
+  }
+
+  return subscriptionId;
+}
+
+async function createRecurringClass(args: {
+  instructorId: number;
+  customerId: number;
+  childId: number;
+  subscriptionId: number;
+  slot: Slot;
+  startDate: string;
+}) {
+  const response = await request(server)
+    .post("/recurring-classes")
+    .send({
+      instructorId: args.instructorId,
+      weekday: args.slot.weekday,
+      startTime: args.slot.startTime,
+      customerId: args.customerId,
+      childrenIds: [args.childId],
+      subscriptionId: args.subscriptionId,
+      startDate: toJstDateString(args.startDate),
+      timezone: "Asia/Tokyo",
+    });
+
+  if (response.status !== 201) {
+    throw new Error(
+      `failed to create recurring class: customerId=${args.customerId}, instructorId=${args.instructorId}, status=${response.status}, body=${JSON.stringify(response.body)}`,
+    );
+  }
 }
 
 export async function initializePerformanceData(
@@ -88,45 +145,48 @@ export async function initializePerformanceData(
   const instructors = await Promise.all(
     Array.from({ length: config.instructors }, () => createInstructor()),
   );
-  const customers = await Promise.all(
-    Array.from({ length: config.customers }, async () => {
-      const customer = await createCustomer();
-      const child = await createChild(customer.id);
-      return { customerId: customer.id, childId: child.id };
-    }),
-  );
 
   const slots = buildSlots(config.slotsPerInstructor);
-  const completionTargets: CompletionTarget[] = [];
+  await Promise.all(
+    instructors.map((instructor) =>
+      createInstructorSchedule({
+        adminAuthCookie,
+        instructorId: instructor.id,
+        slots,
+        startDate: config.startDate,
+      }),
+    ),
+  );
 
-  for (const day of enumerateDays(config.startDate, config.endDate)) {
-    const weekday = day.getUTCDay();
-    if (weekday === 0 || weekday === 6) continue;
+  for (
+    let customerIndex = 0;
+    customerIndex < config.customers;
+    customerIndex += 1
+  ) {
+    const customer = await createCustomer();
+    const child = await createChild(customer.id);
+    const instructor = instructors[customerIndex % instructors.length]!;
+    const slot = slots[customerIndex % slots.length]!;
 
-    for (
-      let customerIndex = 0;
-      customerIndex < customers.length;
-      customerIndex += 1
-    ) {
-      const instructor = instructors[customerIndex % instructors.length]!;
-      const slot = slots[customerIndex % slots.length]!;
-      const dateTime = toClassDateTime(day, slot);
+    const subscriptionId = await registerSubscription({
+      adminAuthCookie,
+      customerId: customer.id,
+      planId: plan.id,
+      startDate: config.startDate,
+    });
 
-      const classRecord = await createClass(
-        customers[customerIndex]!.customerId,
-        instructor.id,
-        dateTime,
-      );
-
-      completionTargets.push({
-        classId: classRecord.id,
-        dateKey: toDateKey(day),
-      });
-    }
+    await createRecurringClass({
+      instructorId: instructor.id,
+      customerId: customer.id,
+      childId: child.id,
+      subscriptionId,
+      slot,
+      startDate: config.startDate,
+    });
   }
 
   return {
     adminAuthCookie,
-    completionTargets,
+    instructorIds: instructors.map((instructor) => instructor.id),
   };
 }

--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import { server } from "../../server";
 import { getPerformanceTestConfig } from "./config";
-import { initializePerformanceData, type CompletionTarget } from "./bootstrap";
+import { initializePerformanceData } from "./bootstrap";
 import { writePerformanceReport } from "./report";
 
 vi.mock("../../lib/email/resendClient", () => ({
@@ -35,10 +35,6 @@ function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
   }
 }
 
-function toDateKey(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
 function calcLatencyStats(latencies: number[]) {
   if (latencies.length === 0) {
     return {
@@ -66,20 +62,22 @@ function calcLatencyStats(latencies: number[]) {
 }
 
 async function handleSimulationDay(args: {
-  dayTargets: CompletionTarget[];
+  day: Date;
   adminAuthCookie: string;
+  instructorIds: number[];
 }) {
-  const results = await Promise.all(
-    args.dayTargets.map(async (target) => {
+  const dayDateKey = args.day.toISOString().slice(0, 10);
+
+  const classFetchResults = await Promise.all(
+    args.instructorIds.map(async (instructorId) => {
       const startedAt = performance.now();
       const response = await request(server)
-        .patch(`/classes/${target.classId}/status`)
-        .set("Cookie", args.adminAuthCookie)
-        .send({ status: "completed" });
+        .get(`/instructors/${instructorId}/calendar-classes`)
+        .set("Cookie", args.adminAuthCookie);
       const endedAt = performance.now();
 
       return {
-        classId: target.classId,
+        instructorId,
         latencyMs: endedAt - startedAt,
         status: response.status,
         body: response.body,
@@ -87,8 +85,50 @@ async function handleSimulationDay(args: {
     }),
   );
 
-  const latencies = results.map((result) => result.latencyMs);
-  const errors = results
+  const fetchErrors = classFetchResults
+    .filter((result) => result.status !== 200)
+    .map(
+      (result) =>
+        `calendar-classes instructorId=${result.instructorId} status=${result.status} body=${JSON.stringify(result.body)}`,
+    );
+
+  const classIds = new Set<number>();
+  for (const result of classFetchResults) {
+    if (result.status !== 200 || !Array.isArray(result.body)) {
+      continue;
+    }
+
+    for (const classRecord of result.body) {
+      if (
+        classRecord?.status === "pending" &&
+        typeof classRecord?.dateTime === "string" &&
+        classRecord.dateTime.slice(0, 10) === dayDateKey &&
+        typeof classRecord?.id === "number"
+      ) {
+        classIds.add(classRecord.id);
+      }
+    }
+  }
+
+  const completionResults = await Promise.all(
+    Array.from(classIds).map(async (classId) => {
+      const startedAt = performance.now();
+      const response = await request(server)
+        .patch(`/classes/${classId}/status`)
+        .set("Cookie", args.adminAuthCookie)
+        .send({ status: "completed" });
+      const endedAt = performance.now();
+
+      return {
+        classId,
+        latencyMs: endedAt - startedAt,
+        status: response.status,
+        body: response.body,
+      };
+    }),
+  );
+
+  const completionErrors = completionResults
     .filter((result) => result.status !== 200)
     .map(
       (result) =>
@@ -96,9 +136,12 @@ async function handleSimulationDay(args: {
     );
 
   return {
-    latencies,
-    errors,
-    completedClasses: results.length - errors.length,
+    latencies: [
+      ...classFetchResults.map((result) => result.latencyMs),
+      ...completionResults.map((result) => result.latencyMs),
+    ],
+    errors: [...fetchErrors, ...completionErrors],
+    completedClasses: completionResults.length - completionErrors.length,
   };
 }
 
@@ -116,13 +159,6 @@ describe("performance: simple completion workload", () => {
     const config = getPerformanceTestConfig();
     const state = await initializePerformanceData(config);
 
-    const targetsByDate = new Map<string, CompletionTarget[]>();
-    for (const target of state.completionTargets) {
-      const existing = targetsByDate.get(target.dateKey) ?? [];
-      existing.push(target);
-      targetsByDate.set(target.dateKey, existing);
-    }
-
     const runStartedAt = performance.now();
     const allLatencies: number[] = [];
     const allErrors: string[] = [];
@@ -133,10 +169,10 @@ describe("performance: simple completion workload", () => {
       vi.setSystemTime(day);
       daysPassed += 1;
 
-      const dayTargets = targetsByDate.get(toDateKey(day)) ?? [];
       const dayResult = await handleSimulationDay({
-        dayTargets,
+        day,
         adminAuthCookie: state.adminAuthCookie,
+        instructorIds: state.instructorIds,
       });
 
       allLatencies.push(...dayResult.latencies);
@@ -163,7 +199,7 @@ describe("performance: simple completion workload", () => {
     });
 
     expect(daysPassed).toBeGreaterThan(0);
-    expect(completedClasses).toBe(state.completionTargets.length);
+    expect(completedClasses).toBeGreaterThan(0);
     expect(allErrors).toEqual([]);
     expect(reportPath.endsWith(".md")).toBe(true);
   }, 180_000);

--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -4,6 +4,7 @@ import { server } from "../../server";
 import { getPerformanceTestConfig } from "./config";
 import { initializePerformanceData } from "./bootstrap";
 import { writePerformanceReport } from "./report";
+import { InstructorCalendarClassesResponse } from "../../../../shared/schemas/instructors";
 
 vi.mock("../../lib/email/resendClient", () => ({
   resend: {
@@ -34,6 +35,8 @@ function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
     current.setUTCDate(current.getUTCDate() + 1);
   }
 }
+
+const COMPLETABLE_CLASS_STATUSES = new Set(["pending", "booked", "rebooked"]);
 
 function calcLatencyStats(latencies: number[]) {
   if (latencies.length === 0) {
@@ -98,14 +101,13 @@ async function handleSimulationDay(args: {
       continue;
     }
 
-    for (const classRecord of result.body) {
+    const parsedClasses = InstructorCalendarClassesResponse.parse(result.body);
+    for (const classRecord of parsedClasses) {
       if (
-        classRecord?.status === "pending" &&
-        typeof classRecord?.dateTime === "string" &&
-        classRecord.dateTime.slice(0, 10) === dayDateKey &&
-        typeof classRecord?.id === "number"
+        COMPLETABLE_CLASS_STATUSES.has(classRecord.classStatus) &&
+        classRecord.start.slice(0, 10) === dayDateKey
       ) {
-        classIds.add(classRecord.id);
+        classIds.add(classRecord.classId);
       }
     }
   }

--- a/shared/schemas/instructors.ts
+++ b/shared/schemas/instructors.ts
@@ -241,6 +241,19 @@ export const AvailableSlotsResponse = z.object({
     .describe("Array of available time slots with instructor availability"),
 });
 
+export const InstructorCalendarClass = z.object({
+  classId: z.number().int().positive().describe("Class ID"),
+  start: z.iso.datetime().describe("Class start time"),
+  end: z.iso.datetime().describe("Class end time"),
+  title: z.string().describe("Class title"),
+  color: z.string().describe("Class color code"),
+  classStatus: z.string().describe("Class status"),
+});
+
+export const InstructorCalendarClassesResponse = z
+  .array(InstructorCalendarClass)
+  .describe("Array of instructor calendar classes");
+
 // Dual parameter schemas for complex routes
 export const InstructorClassParams = z.object({
   id: z
@@ -373,6 +386,10 @@ export type InstructorAvailableSlotsResponse = z.infer<
   typeof InstructorAvailableSlotsResponse
 >;
 export type AvailableSlotsResponse = z.infer<typeof AvailableSlotsResponse>;
+export type InstructorCalendarClass = z.infer<typeof InstructorCalendarClass>;
+export type InstructorCalendarClassesResponse = z.infer<
+  typeof InstructorCalendarClassesResponse
+>;
 export type InstructorClassParams = z.infer<typeof InstructorClassParams>;
 export type InstructorScheduleParams = z.infer<typeof InstructorScheduleParams>;
 export type CreateSlotRequest = z.infer<typeof CreateSlotRequest>;


### PR DESCRIPTION
### Motivation
- Make the performance test bootstrap follow the real domain flow so classes are generated by the backend instead of being seeded directly in the test.
- Use the public API surface as much as possible to exercise realistic workflows during the perf run.
- Move per-day processing to query the system for scheduled classes (the expected runtime flow) and then complete them.

### Description
- Reworked `backend/src/test/performance/bootstrap.ts` to create instructor schedules via the API, register subscriptions via `POST /customers/:id/subscription`, and create recurring classes via `POST /recurring-classes` so the backend generates class records automatically instead of seeding one-off classes directly.
- Updated `backend/src/test/performance/bootstrap.ts` to return `instructorIds` (instead of precomputed class targets) for use by the workload simulation.
- Updated `backend/src/test/performance/workload.test.ts` so each simulated day now fetches classes through the API using `GET /instructors/:id/calendar-classes`, filters same-day pending classes, and completes them with `PATCH /classes/:id/status` rather than relying on bootstrap-kept arrays.
- Removed precomputation of completion targets and changed assertions to reflect the new runtime-driven completion flow.

### Testing
- Ran formatting with `cd backend && npm run format`, which ran Prettier successfully but `prisma format` failed in this environment due to an npm registry `403` error.
- Ran targeted prettier formatting for the modified files with `npx prettier --write src/test/performance/bootstrap.ts src/test/performance/workload.test.ts`, which completed successfully.
- Attempted to run the perf test with `cd backend && npm run test -- src/test/performance/workload.test.ts`, but the run failed in this environment because the `vitest` binary is not available (command not found).
- No test failures in local file edits; full test execution could not be completed in the current environment due to missing test tooling and external registry access errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b74873c34833083fbf72ecbb96829)