### PR TITLE
perf test: generate monthly classes at end of month

### DIFF
--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -100,6 +100,7 @@ function calcLatencyStats(latencies: number[]) {
 
 async function handleSimulationDay(args: {
   day: Date;
+  simulationEndDate: Date;
   adminAuthCookie: string;
   instructorIds: number[];
 }) {
@@ -173,7 +174,7 @@ async function handleSimulationDay(args: {
 
   const generationErrors: string[] = [];
 
-  if (isEndOfMonth(args.day)) {
+  if (isEndOfMonth(args.day) && args.day.getTime() < args.simulationEndDate.getTime()) {
     const { year, month } = getNextMonthParams(args.day);
     const generationResponse = await request(server)
       .post("/classes/create-classes")
@@ -210,6 +211,7 @@ describe("performance: simple completion workload", () => {
   it("ticks day-by-day and completes scheduled classes", async () => {
     const config = getPerformanceTestConfig();
     const state = await initializePerformanceData(config);
+    const simulationEndDate = new Date(`${config.endDate}T00:00:00.000Z`);
 
     const runStartedAt = performance.now();
     const allLatencies: number[] = [];
@@ -223,6 +225,7 @@ describe("performance: simple completion workload", () => {
 
       const dayResult = await handleSimulationDay({
         day,
+        simulationEndDate,
         adminAuthCookie: state.adminAuthCookie,
         instructorIds: state.instructorIds,
       });

--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -174,7 +174,10 @@ async function handleSimulationDay(args: {
 
   const generationErrors: string[] = [];
 
-  if (isEndOfMonth(args.day) && args.day.getTime() < args.simulationEndDate.getTime()) {
+  if (
+    isEndOfMonth(args.day) &&
+    args.day.getTime() < args.simulationEndDate.getTime()
+  ) {
     const { year, month } = getNextMonthParams(args.day);
     const generationResponse = await request(server)
       .post("/classes/create-classes")

--- a/backend/src/test/performance/workload.test.ts
+++ b/backend/src/test/performance/workload.test.ts
@@ -36,6 +36,40 @@ function* enumerateDays(startDate: string, endDate: string): Generator<Date> {
   }
 }
 
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+function isEndOfMonth(day: Date): boolean {
+  const nextDay = new Date(day);
+  nextDay.setUTCDate(day.getUTCDate() + 1);
+  return nextDay.getUTCDate() === 1;
+}
+
+function getNextMonthParams(day: Date): {
+  year: number;
+  month: (typeof MONTH_NAMES)[number];
+} {
+  const nextMonthDate = new Date(
+    Date.UTC(day.getUTCFullYear(), day.getUTCMonth() + 1, 1),
+  );
+  return {
+    year: nextMonthDate.getUTCFullYear(),
+    month: MONTH_NAMES[nextMonthDate.getUTCMonth()]!,
+  };
+}
+
 const COMPLETABLE_CLASS_STATUSES = new Set(["pending", "booked", "rebooked"]);
 
 function calcLatencyStats(latencies: number[]) {
@@ -137,12 +171,28 @@ async function handleSimulationDay(args: {
         `classId=${result.classId} status=${result.status} body=${JSON.stringify(result.body)}`,
     );
 
+  const generationErrors: string[] = [];
+
+  if (isEndOfMonth(args.day)) {
+    const { year, month } = getNextMonthParams(args.day);
+    const generationResponse = await request(server)
+      .post("/classes/create-classes")
+      .set("Cookie", args.adminAuthCookie)
+      .send({ year, month });
+
+    if (generationResponse.status !== 201) {
+      generationErrors.push(
+        `create-classes year=${year} month=${month} status=${generationResponse.status} body=${JSON.stringify(generationResponse.body)}`,
+      );
+    }
+  }
+
   return {
     latencies: [
       ...classFetchResults.map((result) => result.latencyMs),
       ...completionResults.map((result) => result.latencyMs),
     ],
-    errors: [...fetchErrors, ...completionErrors],
+    errors: [...fetchErrors, ...completionErrors, ...generationErrors],
     completedClasses: completionResults.length - completionErrors.length,
   };
 }


### PR DESCRIPTION
### Motivation
- Ensure the performance workload simulates the production monthly class-generation workflow by invoking the API that creates next-month classes at month boundaries.
- Detect and surface failures in the monthly generation step during long-running perf simulations so reports include generation issues.

### Description
- Added UTC-safe helpers `MONTH_NAMES`, `isEndOfMonth`, and `getNextMonthParams` to compute the next-month `year` and `month` payload deterministically. (modified `backend/src/test/performance/workload.test.ts`)
- On the last simulated day of each month, call `POST /classes/create-classes` with `{ year, month }` to trigger server-side class generation. (modified `backend/src/test/performance/workload.test.ts`)
- Collect any class-generation failures and include them in the workload `errors` aggregation so the final performance report shows generation errors. (modified `backend/src/test/performance/workload.test.ts`)

### Testing
- Ran `npm run format` which executed Prettier but `prisma format` failed in this environment because `POSTGRES_PRISMA_URL` is not set, so formatting could not fully complete. (failed)
- Attempted to run the perf test `npm run test -- src/test/performance/workload.test.ts` but the test environment could not start a test database (no container runtime / missing DB env such as `TEST_DATABASE_URL` / `POSTGRES_PRISMA_URL`), so the test did not execute. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9c0b6884833091d8966f93e4669b)