### PR TITLE
feat: add normalized import zip download and normalization edge tests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jose": "^6.0.11",
+        "jszip": "^3.10.1",
         "multer": "^2.0.1",
         "resend": "^4.1.2",
         "swagger-ui-express": "^5.0.1",
@@ -3392,7 +3393,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -4780,6 +4780,12 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4911,7 +4917,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -5063,6 +5068,48 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/knip": {
       "version": "5.64.1",
       "resolved": "https://registry.npmjs.org/knip/-/knip-5.64.1.tgz",
@@ -5170,6 +5217,15 @@
       "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -5801,6 +5857,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseley": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
@@ -6164,7 +6226,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proper-lockfile": {
@@ -6707,6 +6768,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,6 +56,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jose": "^6.0.11",
+    "jszip": "^3.10.1",
     "multer": "^2.0.1",
     "resend": "^4.1.2",
     "swagger-ui-express": "^5.0.1",

--- a/backend/src/controllers/adminsImportController.ts
+++ b/backend/src/controllers/adminsImportController.ts
@@ -1,5 +1,12 @@
 import { Request, Response } from "express";
-import { normalizeRawScheduleCsvToPackage } from "../services/adminImportService";
+import {
+  buildNormalizedPackageZip,
+  normalizeRawScheduleCsvToPackage,
+} from "../services/adminImportService";
+import {
+  getNormalizedImportJobZip,
+  storeNormalizedImportJob,
+} from "../services/adminImportJobStore";
 
 export const normalizeImportSourceController = async (
   req: Request,
@@ -16,12 +23,40 @@ export const normalizeImportSourceController = async (
     const normalized = normalizeRawScheduleCsvToPackage(
       file.buffer.toString("utf-8"),
     );
+    const zipBuffer = await buildNormalizedPackageZip(normalized.files);
+    const jobId = storeNormalizedImportJob(zipBuffer);
 
-    return res.status(200).json(normalized);
+    return res.status(200).json({
+      jobId,
+      ...normalized,
+    });
   } catch (error) {
     console.error("Failed to normalize import source CSV", { error });
     return res.status(400).json({
       message: error instanceof Error ? error.message : "Normalization failed",
     });
   }
+};
+
+export const downloadNormalizedImportPackageController = async (
+  req: Request,
+  res: Response,
+) => {
+  const { jobId } = req.params;
+  const zipBuffer = getNormalizedImportJobZip(jobId);
+
+  if (!zipBuffer) {
+    return res.status(404).json({
+      message: `Normalized import package "${jobId}" was not found or expired`,
+    });
+  }
+
+  return res
+    .status(200)
+    .set("Content-Type", "application/zip")
+    .set(
+      "Content-Disposition",
+      `attachment; filename="normalized-import-${jobId}.zip"`,
+    )
+    .send(zipBuffer);
 };

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -24,7 +24,10 @@ import {
   getAllEventsController,
   getClassesWithinPeriodController,
 } from "../../src/controllers/adminsController";
-import { normalizeImportSourceController } from "../controllers/adminsImportController";
+import {
+  downloadNormalizedImportPackageController,
+  normalizeImportSourceController,
+} from "../controllers/adminsImportController";
 import {
   getAllSchedulesController,
   updateBusinessScheduleController,
@@ -70,6 +73,7 @@ import {
   ConflictErrorResponse,
   InstructorUpdateErrorResponse,
   ImportNormalizeResponse,
+  ImportNormalizedDownloadParams,
 } from "../../../shared/schemas/admins";
 
 import { AUTH_ROLES } from "../utils/commonUtils";
@@ -827,6 +831,35 @@ const normalizeImportSourceConfig = {
   },
 } as const;
 
+const downloadNormalizedImportPackageConfig = {
+  method: "get" as const,
+  paramsSchema: ImportNormalizedDownloadParams,
+  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  handler: downloadNormalizedImportPackageController,
+  openapi: {
+    summary: "Download normalized import zip",
+    description:
+      "Download normalized CSV package zip by job ID generated from normalization",
+    responses: {
+      200: {
+        description: "Normalized package zip file",
+      },
+      401: {
+        description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Job not found or expired",
+        schema: MessageErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: ErrorResponse,
+      },
+    },
+  },
+} as const;
+
 const validatedRouteConfigs = {
   "/:id": [updateAdminConfig],
   "/admin-list": [getAllAdminsConfig],
@@ -850,6 +883,7 @@ const validatedRouteConfigs = {
   "/instructor-list/update/:id": [updateInstructorConfig],
   "/instructor-list/update/:id/withIcon": [updateInstructorWithIconConfig],
   "/import/normalize": [normalizeImportSourceConfig],
+  "/import/normalized/:jobId/download": [downloadNormalizedImportPackageConfig],
   "/plan-list": [getAllPlansConfig],
   "/plan-list/delete/:id": [deletePlanConfig],
   "/plan-list/register": [registerPlanConfig],

--- a/backend/src/services/adminImportJobStore.ts
+++ b/backend/src/services/adminImportJobStore.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+interface NormalizedJobEntry {
+  zipBuffer: Buffer;
+  expiresAt: number;
+}
+
+const jobs = new Map<string, NormalizedJobEntry>();
+
+function cleanupExpiredJobs(now = Date.now()) {
+  for (const [jobId, entry] of jobs.entries()) {
+    if (entry.expiresAt <= now) {
+      jobs.delete(jobId);
+    }
+  }
+}
+
+export function storeNormalizedImportJob(zipBuffer: Buffer): string {
+  cleanupExpiredJobs();
+  const jobId = randomUUID();
+  jobs.set(jobId, {
+    zipBuffer,
+    expiresAt: Date.now() + DEFAULT_TTL_MS,
+  });
+  return jobId;
+}
+
+export function getNormalizedImportJobZip(jobId: string): Buffer | null {
+  cleanupExpiredJobs();
+  const entry = jobs.get(jobId);
+  if (!entry) {
+    return null;
+  }
+  if (entry.expiresAt <= Date.now()) {
+    jobs.delete(jobId);
+    return null;
+  }
+  return entry.zipBuffer;
+}

--- a/backend/src/services/adminImportService.ts
+++ b/backend/src/services/adminImportService.ts
@@ -3,7 +3,7 @@ import JSZip from "jszip";
 
 type CsvRow = string[];
 
-export type NormalizedFileName =
+type NormalizedFileName =
   | "plans.csv"
   | "customers.csv"
   | "children.csv"
@@ -19,7 +19,7 @@ export type NormalizedFileName =
   | "classes.csv"
   | "class_attendance.csv";
 
-export type NormalizedFileMap = Record<NormalizedFileName, string>;
+type NormalizedFileMap = Record<NormalizedFileName, string>;
 
 interface GeneratedEmailReportItem {
   row: number;
@@ -34,7 +34,7 @@ interface NormalizationReport {
   warnings: string[];
 }
 
-export interface NormalizeRawScheduleResult {
+interface NormalizeRawScheduleResult {
   files: NormalizedFileMap;
   report: NormalizationReport;
 }

--- a/backend/src/services/adminImportService.ts
+++ b/backend/src/services/adminImportService.ts
@@ -1,8 +1,9 @@
 import { randomBytes } from "node:crypto";
+import JSZip from "jszip";
 
 type CsvRow = string[];
 
-type NormalizedFileName =
+export type NormalizedFileName =
   | "plans.csv"
   | "customers.csv"
   | "children.csv"
@@ -18,7 +19,7 @@ type NormalizedFileName =
   | "classes.csv"
   | "class_attendance.csv";
 
-type NormalizedFileMap = Record<NormalizedFileName, string>;
+export type NormalizedFileMap = Record<NormalizedFileName, string>;
 
 interface GeneratedEmailReportItem {
   row: number;
@@ -33,7 +34,7 @@ interface NormalizationReport {
   warnings: string[];
 }
 
-interface NormalizeRawScheduleResult {
+export interface NormalizeRawScheduleResult {
   files: NormalizedFileMap;
   report: NormalizationReport;
 }
@@ -735,4 +736,22 @@ export function normalizeRawScheduleCsvToPackage(
       warnings: mapped.warnings,
     },
   };
+}
+
+export async function buildNormalizedPackageZip(
+  files: NormalizedFileMap,
+): Promise<Buffer> {
+  const zip = new JSZip();
+
+  for (const fileName of Object.keys(files) as NormalizedFileName[]) {
+    zip.file(fileName, files[fileName], { binary: false });
+  }
+
+  return zip.generateAsync({
+    type: "nodebuffer",
+    compression: "DEFLATE",
+    compressionOptions: {
+      level: 9,
+    },
+  });
 }

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import request from "supertest";
+import JSZip from "jszip";
 import { server } from "../../../server";
 import { createAdmin, generateAuthCookie } from "../../testUtils";
 
@@ -96,6 +97,7 @@ describe("POST /admins/import/normalize", () => {
       .expect(200);
 
     expect(response.body.files).toBeTruthy();
+    expect(response.body.jobId).toEqual(expect.any(String));
     expect(Object.keys(response.body.files).sort()).toEqual([
       "children.csv",
       "class_attendance.csv",
@@ -143,6 +145,74 @@ describe("POST /admins/import/normalize", () => {
     expect(plansCsv).toContain("plan_ref,name,description,weekly_class_times");
     expect(plansCsv).toContain("1980円（週1回25分）");
     expect(plansCsv).toContain("1480円（月2回25分）");
+  });
+
+  it("downloads normalized files as a zip bundle by jobId", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    const normalizeResponse = await request(server)
+      .post("/admins/import/normalize")
+      .set("Cookie", authCookie)
+      .attach("file", Buffer.from(`${RAW_HEADER}\n`, "utf-8"), {
+        filename: "raw-schedule.csv",
+        contentType: "text/csv",
+      })
+      .expect(200);
+
+    const jobId = normalizeResponse.body.jobId as string;
+
+    const downloadResponse = await request(server)
+      .get(`/admins/import/normalized/${jobId}/download`)
+      .set("Cookie", authCookie)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(200);
+
+    expect(downloadResponse.headers["content-type"]).toContain(
+      "application/zip",
+    );
+    expect(downloadResponse.headers["content-disposition"]).toContain(
+      `normalized-import-${jobId}.zip`,
+    );
+
+    const zip = await JSZip.loadAsync(downloadResponse.body as Buffer);
+    const entryNames = Object.keys(zip.files).sort();
+    expect(entryNames).toEqual([
+      "children.csv",
+      "class_attendance.csv",
+      "classes.csv",
+      "customers.csv",
+      "events.csv",
+      "instructor_absences.csv",
+      "instructor_schedules.csv",
+      "instructors.csv",
+      "plans.csv",
+      "recurring_class_attendance.csv",
+      "recurring_classes.csv",
+      "schedules.csv",
+      "subscriptions.csv",
+      "system_status.csv",
+    ]);
+
+    const plansCsv = await zip.file("plans.csv")!.async("string");
+    expect(plansCsv).toBe(
+      "plan_ref,name,description,weekly_class_times,is_native,termination_at",
+    );
+  });
+
+  it("returns 404 when normalized package jobId does not exist", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    await request(server)
+      .get("/admins/import/normalized/not-a-real-job/download")
+      .set("Cookie", authCookie)
+      .expect(404);
   });
 
   it("returns 400 when upload is missing", async () => {

--- a/backend/src/test/services/adminImportService.test.ts
+++ b/backend/src/test/services/adminImportService.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildNormalizedPackageZip,
+  normalizeRawScheduleCsvToPackage,
+} from "../../services/adminImportService";
+import JSZip from "jszip";
+
+const RAW_HEADER =
+  ",英語村,,2020.10.,name,child name,plan,講師名,date,time,class,お子さま誕生日,兄弟お子さま誕生日,年齢,詳細,備考※月2回の場合は週を記入,favorite,,,";
+
+function csvEscape(value: string): string {
+  if (
+    value.includes(",") ||
+    value.includes('"') ||
+    value.includes("\n") ||
+    value.includes("\r")
+  ) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function rawRow(columns: string[]): string {
+  return columns.map(csvEscape).join(",");
+}
+
+describe("adminImportService", () => {
+  it("throws when raw header row is missing", () => {
+    expect(() => normalizeRawScheduleCsvToPackage("a,b,c\n1,2,3")).toThrow(
+      "Header row for raw schedule CSV not found",
+    );
+  });
+
+  it("reports warnings for un-normalizable weekday and start time", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "Grace",
+        "Funday",
+        "invalid-time",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    expect(normalized.report.warnings).toHaveLength(2);
+    expect(normalized.report.warnings[0]).toContain("Row 2");
+    expect(normalized.report.warnings[1]).toContain("Row 2");
+  });
+
+  it("generates deterministic unique fallback emails for missing/invalid emails", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ]),
+      rawRow([
+        "",
+        "",
+        "大阪",
+        "10/3",
+        "鈴木一郎",
+        "Aoi",
+        "1480円（月2回25分）",
+        "",
+        "Tue",
+        "17:00-17:25",
+        "R",
+        "7/7",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "not-an-email",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    expect(normalized.report.generatedCustomerEmails).toHaveLength(2);
+    expect(normalized.report.generatedCustomerEmails[0].generatedEmail).toBe(
+      "customer+0001@aaasobo-import.local",
+    );
+    expect(normalized.report.generatedCustomerEmails[1].generatedEmail).toBe(
+      "customer+0002@aaasobo-import.local",
+    );
+
+    const customersCsv = normalized.files["customers.csv"];
+    expect(customersCsv).toContain("customer+0001@aaasobo-import.local");
+    expect(customersCsv).toContain("customer+0002@aaasobo-import.local");
+  });
+
+  it("throws on customer reference overflow after 9999 unique customers", () => {
+    const rows = [RAW_HEADER];
+    for (let i = 1; i <= 10000; i += 1) {
+      rows.push(
+        rawRow([
+          "",
+          "",
+          "東京",
+          "10/2",
+          `Customer ${i}`,
+          `Child ${i}`,
+          "1980円（週1回25分）",
+          "",
+          "Mon",
+          "19:00-19:25",
+          "R",
+          "6/2",
+          "",
+          "4",
+          "",
+          "",
+          "",
+          `customer${i}@example.com`,
+          "",
+          "",
+        ]),
+      );
+    }
+
+    expect(() => normalizeRawScheduleCsvToPackage(rows.join("\n"))).toThrow(
+      "Reference overflow for prefix CU",
+    );
+  });
+
+  it("escapes commas, quotes, and newlines in normalized CSV output", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        'Line1, "quoted"\nLine2',
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    const childrenCsv = normalized.files["children.csv"];
+    expect(childrenCsv).toContain('"Line1, ""quoted""');
+    expect(childrenCsv).toContain('Line2"');
+  });
+
+  it("builds a zip that contains all normalized files", async () => {
+    const normalized = normalizeRawScheduleCsvToPackage(`${RAW_HEADER}\n`);
+    const zipBuffer = await buildNormalizedPackageZip(normalized.files);
+    const zip = await JSZip.loadAsync(zipBuffer);
+    expect(Object.keys(zip.files).sort()).toEqual(
+      Object.keys(normalized.files).sort(),
+    );
+  });
+});

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -389,7 +389,12 @@ export const ImportNormalizeGeneratedEmailItem = z.object({
   generatedEmail: z.string(),
 });
 
+export const ImportNormalizedDownloadParams = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+});
+
 export const ImportNormalizeResponse = z.object({
+  jobId: z.string(),
   files: z.record(z.string(), z.string()),
   report: z.object({
     rawRows: z.number().int().nonnegative(),
@@ -454,3 +459,6 @@ export type UpdateSubscriptionToTerminateClassRequest = z.infer<
   typeof UpdateSubscriptionToTerminateClassRequest
 >;
 export type ImportNormalizeResponse = z.infer<typeof ImportNormalizeResponse>;
+export type ImportNormalizedDownloadParams = z.infer<
+  typeof ImportNormalizedDownloadParams
+>;


### PR DESCRIPTION
## Summary
- add in-memory normalized job storage and a new `GET /admins/import/normalized/:jobId/download` endpoint
- return `jobId` from `POST /admins/import/normalize` and generate zip artifacts for normalized CSV files
- add service-level edge-case tests for normalization mapping/validation behavior (missing header, warnings, generated emails, reference overflow, escaping, zip integrity)
- extend API tests for normalize flow with zip download success and not-found cases

## Testing
- cd backend && npm run test -- src/test/services/adminImportService.test.ts
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts
