### PR TITLE
docs: add lint:unused to Development Commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ AaasoBo! is an online English conversation service run by a Japanese NPO that ta
   - Start PostgreSQL: `npm run db:start` (Docker container)
   - Initialize/Reset DB: `npm run prisma:init` (runs migrations + seed)
 - **Testing**: `npm run test` (Vitest)
+- **Unused Code Check**: `npm run lint:unused`
 - **Formatting**: `npm run format` (Prettier + Prisma format)
 - **Build**: `npm run build` (generates Prisma client, resets DB, runs dummy seed)
 
@@ -34,6 +35,7 @@ AaasoBo! is an online English conversation service run by a Japanese NPO that ta
 - **Development**: `npm run dev` (Next.js dev server)
 - **Build**: `npm run build`
 - **Linting**: `npm run lint`
+- **Unused Code Check**: `npm run lint:unused`
 - **Formatting**: `npm run format`
 
 ## Architecture Overview


### PR DESCRIPTION
### Motivation
- Add `npm run lint:unused` to the Development Commands to surface and make it easy to run unused-code detection for both backend and frontend.

### Description
- Inserted `- **Unused Code Check**: `npm run lint:unused`` into the Backend and Frontend subsections of `AGENTS.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bbc57bea48330a7f896f50508fcf5)