### PR TITLE
test: expand normalized import execution coverage

### DIFF
--- a/backend/src/controllers/adminsImportController.ts
+++ b/backend/src/controllers/adminsImportController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import {
   buildNormalizedPackageZip,
+  executeNormalizedImportFiles,
   extractNormalizedFilesFromZip,
   getNormalizedImportJobZip,
   normalizeRawScheduleCsvToPackage,
@@ -99,16 +100,17 @@ export const executeNormalizedImportController = async (
       });
     }
 
+    await executeNormalizedImportFiles(files);
+
     return res.status(200).json({
-      message: "Normalized import package validated successfully",
-      imported: false,
+      message: "Normalized import executed successfully",
+      imported: true,
       report: validationResult.report,
     });
   } catch (error) {
     console.error("Failed to execute normalized import", { error });
-    return res.status(400).json({
-      message:
-        error instanceof Error ? error.message : "Import execution failed",
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : "Import execution failed",
     });
   }
 };

--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -1,4 +1,7 @@
 import JSZip from "jszip";
+import { Prisma, Status } from "../../../generated/prisma";
+import { prisma } from "../../../prisma/prismaClient";
+import { hashPassword } from "../../utils/commonUtils";
 import {
   MANDATORY_NORMALIZED_FILES,
   NORMALIZED_HEADERS,
@@ -154,6 +157,31 @@ interface RowEnvelope<T> {
   rowNumber: number;
   data: T;
 }
+
+type ParsedNormalizedRows = {
+  "plans.csv": RowEnvelope<RowByFile["plans.csv"]>[];
+  "customers.csv": RowEnvelope<RowByFile["customers.csv"]>[];
+  "children.csv": RowEnvelope<RowByFile["children.csv"]>[];
+  "subscriptions.csv": RowEnvelope<RowByFile["subscriptions.csv"]>[];
+  "instructors.csv": RowEnvelope<RowByFile["instructors.csv"]>[];
+  "instructor_schedules.csv": RowEnvelope<
+    RowByFile["instructor_schedules.csv"]
+  >[];
+  "instructor_absences.csv": RowEnvelope<
+    RowByFile["instructor_absences.csv"]
+  >[];
+  "events.csv": RowEnvelope<RowByFile["events.csv"]>[];
+  "schedules.csv": RowEnvelope<RowByFile["schedules.csv"]>[];
+  "system_status.csv": RowEnvelope<RowByFile["system_status.csv"]>[];
+  "recurring_classes.csv": RowEnvelope<RowByFile["recurring_classes.csv"]>[];
+  "recurring_class_attendance.csv": RowEnvelope<
+    RowByFile["recurring_class_attendance.csv"]
+  >[];
+  "classes.csv": RowEnvelope<RowByFile["classes.csv"]>[];
+  "class_attendance.csv": RowEnvelope<RowByFile["class_attendance.csv"]>[];
+};
+
+type TxClient = Prisma.TransactionClient;
 
 function isValidDate(value: string): boolean {
   if (!DATE_PATTERN.test(value)) {
@@ -409,41 +437,11 @@ function parseFileRows<K extends NormalizedFileName>(
   return rows;
 }
 
-export async function extractNormalizedFilesFromZip(
-  zipBuffer: Buffer,
-): Promise<Partial<Record<NormalizedFileName, string>>> {
-  const zip = await JSZip.loadAsync(zipBuffer);
-  const files: Partial<Record<NormalizedFileName, string>> = {};
-
-  for (const fileName of MANDATORY_NORMALIZED_FILES) {
-    const entry = zip.file(fileName);
-    if (!entry) {
-      continue;
-    }
-    files[fileName] = await entry.async("string");
-  }
-
-  return files;
-}
-
-export function validateNormalizedImportFiles(
+function parseNormalizedRows(
   files: Partial<Record<NormalizedFileName, string>>,
-): ImportValidationResult {
-  const issues: ImportValidationIssue[] = [];
-
-  for (const fileName of MANDATORY_NORMALIZED_FILES) {
-    if (typeof files[fileName] !== "string") {
-      addIssue(
-        issues,
-        fileName,
-        null,
-        null,
-        `Missing required file: ${fileName}`,
-      );
-    }
-  }
-
-  const parsed = {
+  issues: ImportValidationIssue[],
+): ParsedNormalizedRows {
+  return {
     "plans.csv": parseFileRows("plans.csv", files["plans.csv"] ?? "", issues),
     "customers.csv": parseFileRows(
       "customers.csv",
@@ -511,6 +509,43 @@ export function validateNormalizedImportFiles(
       issues,
     ),
   };
+}
+
+export async function extractNormalizedFilesFromZip(
+  zipBuffer: Buffer,
+): Promise<Partial<Record<NormalizedFileName, string>>> {
+  const zip = await JSZip.loadAsync(zipBuffer);
+  const files: Partial<Record<NormalizedFileName, string>> = {};
+
+  for (const fileName of MANDATORY_NORMALIZED_FILES) {
+    const entry = zip.file(fileName);
+    if (!entry) {
+      continue;
+    }
+    files[fileName] = await entry.async("string");
+  }
+
+  return files;
+}
+
+export function validateNormalizedImportFiles(
+  files: Partial<Record<NormalizedFileName, string>>,
+): ImportValidationResult {
+  const issues: ImportValidationIssue[] = [];
+
+  for (const fileName of MANDATORY_NORMALIZED_FILES) {
+    if (typeof files[fileName] !== "string") {
+      addIssue(
+        issues,
+        fileName,
+        null,
+        null,
+        `Missing required file: ${fileName}`,
+      );
+    }
+  }
+
+  const parsed = parseNormalizedRows(files, issues);
 
   const rowsByFile: Record<NormalizedFileName, number> = {
     "plans.csv": parsed["plans.csv"].length,
@@ -1475,5 +1510,336 @@ export function validateNormalizedImportFiles(
     isValid: issues.length === 0,
     issues,
     report: { rowsByFile },
+  };
+}
+
+const DEFAULT_SEED_ADMIN_EMAILS = ["admin@example.com", "admin2@example.com"];
+
+function parseOptionalDate(value: string): Date | null {
+  if (!value) {
+    return null;
+  }
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function parseOptionalDateTime(value: string): Date | null {
+  if (!value) {
+    return null;
+  }
+  return new Date(value);
+}
+
+function parseTimeAsDate(value: string): Date {
+  return new Date(`1970-01-01T${value}:00.000Z`);
+}
+
+function parseSeedAdminEmails(): string[] {
+  const configured =
+    process.env.IMPORT_SEED_ADMIN_EMAILS ?? process.env.SEED_ADMIN_EMAILS;
+  const source = configured
+    ? configured
+        .split(",")
+        .map((email) => email.trim().toLowerCase())
+        .filter((email) => email.length > 0)
+    : DEFAULT_SEED_ADMIN_EMAILS;
+  return Array.from(new Set(source));
+}
+
+async function resetImportTargetData(tx: TxClient) {
+  const seedAdminEmails = parseSeedAdminEmails();
+  const seedAdmins = await tx.admin.findMany({
+    where: {
+      email: {
+        in: seedAdminEmails,
+      },
+    },
+    select: {
+      name: true,
+      email: true,
+      password: true,
+    },
+  });
+
+  await tx.classAttendance.deleteMany();
+  await tx.class.deleteMany();
+  await tx.recurringClassAttendance.deleteMany();
+  await tx.recurringClass.deleteMany();
+  await tx.subscription.deleteMany();
+  await tx.child.deleteMany();
+  await tx.customer.deleteMany();
+  await tx.instructorAbsence.deleteMany();
+  await tx.instructorSlot.deleteMany();
+  await tx.instructorSchedule.deleteMany();
+  await tx.instructor.deleteMany();
+  await tx.schedule.deleteMany();
+  await tx.event.deleteMany();
+  await tx.plan.deleteMany();
+  await tx.systemStatus.deleteMany();
+  await tx.passwordResetToken.deleteMany();
+  await tx.verificationToken.deleteMany();
+  await tx.admin.deleteMany();
+
+  if (seedAdmins.length > 0) {
+    await tx.admin.createMany({
+      data: seedAdmins,
+    });
+  }
+}
+
+async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
+  const planIdByRef = new Map<string, number>();
+  for (const row of parsed["plans.csv"]) {
+    const created = await tx.plan.create({
+      data: {
+        name: row.data.name,
+        description: row.data.description,
+        weeklyClassTimes: Number(row.data.weekly_class_times),
+        isNative: row.data.is_native === "true",
+        terminationAt: parseOptionalDateTime(row.data.termination_at),
+      },
+    });
+    planIdByRef.set(row.data.plan_ref, created.id);
+  }
+
+  const customerIdByRef = new Map<string, number>();
+  for (const row of parsed["customers.csv"]) {
+    const created = await tx.customer.create({
+      data: {
+        name: row.data.name,
+        email: row.data.email,
+        password: await hashPassword(row.data.temp_password),
+        prefecture: row.data.prefecture,
+        hasSeenWelcome: row.data.has_seen_welcome === "true",
+        terminationAt: parseOptionalDateTime(row.data.termination_at),
+      },
+    });
+    customerIdByRef.set(row.data.customer_ref, created.id);
+  }
+
+  const childIdByRef = new Map<string, number>();
+  for (const row of parsed["children.csv"]) {
+    const created = await tx.child.create({
+      data: {
+        customerId: customerIdByRef.get(row.data.customer_ref)!,
+        name: row.data.name,
+        birthdate: parseOptionalDate(row.data.birthdate),
+        personalInfo: row.data.personal_info || null,
+      },
+    });
+    childIdByRef.set(row.data.child_ref, created.id);
+  }
+
+  const subscriptionIdByRef = new Map<string, number>();
+  for (const row of parsed["subscriptions.csv"]) {
+    const created = await tx.subscription.create({
+      data: {
+        customerId: customerIdByRef.get(row.data.customer_ref)!,
+        planId: planIdByRef.get(row.data.plan_ref)!,
+        startAt: new Date(row.data.start_at),
+        endAt: parseOptionalDateTime(row.data.end_at),
+      },
+    });
+    subscriptionIdByRef.set(row.data.subscription_ref, created.id);
+  }
+
+  const instructorIdByRef = new Map<string, number>();
+  for (const row of parsed["instructors.csv"]) {
+    const created = await tx.instructor.create({
+      data: {
+        name: row.data.name,
+        email: row.data.email,
+        password: await hashPassword(row.data.temp_password),
+        classURL: row.data.class_url,
+        icon: row.data.icon,
+        nickname: row.data.nickname,
+        meetingId: row.data.meeting_id,
+        passcode: row.data.passcode,
+        birthdate: new Date(`${row.data.birthdate}T00:00:00.000Z`),
+        favoriteFood: row.data.favorite_food,
+        hobby: row.data.hobby,
+        lifeHistory: row.data.life_history,
+        messageForChildren: row.data.message_for_children,
+        skill: row.data.skill,
+        workingTime: row.data.working_time,
+        isNative: row.data.is_native === "true",
+        terminationAt: parseOptionalDateTime(row.data.termination_at),
+      },
+    });
+    instructorIdByRef.set(row.data.instructor_ref, created.id);
+  }
+
+  const scheduleGroups = new Map<
+    string,
+    {
+      instructorId: number;
+      effectiveFrom: Date;
+      effectiveTo: Date | null;
+      timezone: string;
+      slots: Array<{ weekday: number; startTime: Date }>;
+    }
+  >();
+
+  for (const row of parsed["instructor_schedules.csv"]) {
+    const key = [
+      row.data.instructor_ref,
+      row.data.effective_from,
+      row.data.effective_to,
+      row.data.timezone,
+    ].join("\u0000");
+    if (!scheduleGroups.has(key)) {
+      scheduleGroups.set(key, {
+        instructorId: instructorIdByRef.get(row.data.instructor_ref)!,
+        effectiveFrom: parseOptionalDate(row.data.effective_from)!,
+        effectiveTo: parseOptionalDate(row.data.effective_to),
+        timezone: row.data.timezone,
+        slots: [],
+      });
+    }
+    scheduleGroups.get(key)!.slots.push({
+      weekday: Number(row.data.weekday),
+      startTime: parseTimeAsDate(row.data.start_time),
+    });
+  }
+
+  for (const group of scheduleGroups.values()) {
+    const createdSchedule = await tx.instructorSchedule.create({
+      data: {
+        instructorId: group.instructorId,
+        effectiveFrom: group.effectiveFrom,
+        effectiveTo: group.effectiveTo,
+        timezone: group.timezone,
+      },
+    });
+
+    if (group.slots.length > 0) {
+      await tx.instructorSlot.createMany({
+        data: group.slots.map((slot) => ({
+          scheduleId: createdSchedule.id,
+          weekday: slot.weekday,
+          startTime: slot.startTime,
+        })),
+      });
+    }
+  }
+
+  if (parsed["instructor_absences.csv"].length > 0) {
+    await tx.instructorAbsence.createMany({
+      data: parsed["instructor_absences.csv"].map((row) => ({
+        instructorId: instructorIdByRef.get(row.data.instructor_ref)!,
+        absentAt: new Date(row.data.absent_at),
+      })),
+    });
+  }
+
+  const eventIdByRef = new Map<string, number>();
+  for (const row of parsed["events.csv"]) {
+    const created = await tx.event.create({
+      data: {
+        name: row.data.name,
+        color: row.data.color,
+      },
+    });
+    eventIdByRef.set(row.data.event_ref, created.id);
+  }
+
+  for (const row of parsed["schedules.csv"]) {
+    await tx.schedule.create({
+      data: {
+        date: parseOptionalDate(row.data.date)!,
+        eventId: eventIdByRef.get(row.data.event_ref)!,
+      },
+    });
+  }
+
+  await tx.systemStatus.create({
+    data: {
+      status: parsed["system_status.csv"][0].data.status,
+    },
+  });
+
+  const recurringClassIdByRef = new Map<string, number>();
+  for (const row of parsed["recurring_classes.csv"]) {
+    const created = await tx.recurringClass.create({
+      data: {
+        subscriptionId: row.data.subscription_ref
+          ? subscriptionIdByRef.get(row.data.subscription_ref)!
+          : null,
+        instructorId: row.data.instructor_ref
+          ? instructorIdByRef.get(row.data.instructor_ref)!
+          : null,
+        startAt: parseOptionalDateTime(row.data.start_at),
+        endAt: parseOptionalDateTime(row.data.end_at),
+      },
+    });
+    recurringClassIdByRef.set(row.data.recurring_class_ref, created.id);
+  }
+
+  if (parsed["recurring_class_attendance.csv"].length > 0) {
+    await tx.recurringClassAttendance.createMany({
+      data: parsed["recurring_class_attendance.csv"].map((row) => ({
+        recurringClassId: recurringClassIdByRef.get(
+          row.data.recurring_class_ref,
+        )!,
+        childrenId: childIdByRef.get(row.data.child_ref)!,
+      })),
+    });
+  }
+
+  const classIdByRef = new Map<string, number>();
+  for (const row of parsed["classes.csv"]) {
+    const created = await tx.class.create({
+      data: {
+        customerId: customerIdByRef.get(row.data.customer_ref)!,
+        instructorId: row.data.instructor_ref
+          ? instructorIdByRef.get(row.data.instructor_ref)!
+          : null,
+        recurringClassId: row.data.recurring_class_ref
+          ? recurringClassIdByRef.get(row.data.recurring_class_ref)!
+          : null,
+        subscriptionId: row.data.subscription_ref
+          ? subscriptionIdByRef.get(row.data.subscription_ref)!
+          : null,
+        dateTime: parseOptionalDateTime(row.data.date_time),
+        status: row.data.status as Status,
+        rebookableUntil: parseOptionalDateTime(row.data.rebookable_until),
+        classCode: row.data.class_code,
+        isFreeTrial: row.data.is_free_trial === "true",
+        updatedAt: new Date(),
+      },
+    });
+    classIdByRef.set(row.data.class_ref, created.id);
+  }
+
+  if (parsed["class_attendance.csv"].length > 0) {
+    await tx.classAttendance.createMany({
+      data: parsed["class_attendance.csv"].map((row) => ({
+        classId: classIdByRef.get(row.data.class_ref)!,
+        childrenId: childIdByRef.get(row.data.child_ref)!,
+      })),
+    });
+  }
+}
+
+export async function executeNormalizedImportFiles(
+  files: Partial<Record<NormalizedFileName, string>>,
+) {
+  const validation = validateNormalizedImportFiles(files);
+  if (!validation.isValid) {
+    throw new Error("Normalized import validation failed");
+  }
+
+  const parseIssues: ImportValidationIssue[] = [];
+  const parsed = parseNormalizedRows(files, parseIssues);
+  if (parseIssues.length > 0) {
+    throw new Error("Normalized import parsing failed");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await resetImportTargetData(tx);
+    await insertValidatedRows(tx, parsed);
+  });
+
+  return {
+    report: validation.report,
   };
 }

--- a/backend/src/services/adminImport/index.ts
+++ b/backend/src/services/adminImport/index.ts
@@ -4,6 +4,7 @@ export {
 } from "./normalize";
 
 export {
+  executeNormalizedImportFiles,
   extractNormalizedFilesFromZip,
   validateNormalizedImportFiles,
 } from "./execute";

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -2,13 +2,54 @@ import { describe, expect, it } from "vitest";
 import request from "supertest";
 import JSZip from "jszip";
 import { server } from "../../../server";
-import { createAdmin, generateAuthCookie } from "../../testUtils";
+import {
+  createAdmin,
+  createCustomer,
+  generateAuthCookie,
+} from "../../testUtils";
+import { prisma } from "../../setup";
 
 const RAW_HEADER =
   ",英語村,,2020.10.,name,child name,plan,講師名,date,time,class,お子さま誕生日,兄弟お子さま誕生日,年齢,詳細,備考※月2回の場合は週を記入,favorite,,,";
 
 function rawRow(columns: string[]) {
   return columns.join(",");
+}
+
+function buildMinimalNormalizedFiles() {
+  return {
+    "plans.csv":
+      "plan_ref,name,description,weekly_class_times,is_native,termination_at\nPL0001,Starter,Starter plan,1,false,\n",
+    "customers.csv":
+      "customer_ref,name,email,temp_password,prefecture,termination_at,has_seen_welcome\nCU0001,Customer One,customer.one@example.com,TempPass123!,Tokyo,,false\n",
+    "children.csv":
+      "child_ref,customer_ref,name,birthdate,personal_info\nCH0001,CU0001,Child One,2016-01-02,\n",
+    "subscriptions.csv":
+      "subscription_ref,customer_ref,plan_ref,start_at,end_at\nSU0001,CU0001,PL0001,2025-01-01T00:00:00+09:00,2025-12-31T00:00:00+09:00\n",
+    "instructors.csv":
+      "instructor_ref,name,email,temp_password,class_url,icon,nickname,meeting_id,passcode,birthdate,favorite_food,hobby,life_history,message_for_children,skill,working_time,is_native,termination_at\nIN0001,Instructor One,instructor.one@example.com,TempPass456!,https://import.local/class/in0001,https://import.local/icon/in0001.png,instructor_in0001,11111111111,PASS0001,1990-01-01,Sushi,Reading,Life history,Message,Skill,Weekdays,false,\n",
+    "instructor_schedules.csv":
+      "instructor_ref,effective_from,effective_to,timezone,weekday,start_time\nIN0001,2025-01-01,2025-12-31,Asia/Tokyo,1,09:00\n",
+    "instructor_absences.csv": "instructor_ref,absent_at\n",
+    "events.csv": "event_ref,name,color\nEV0001,Regular,#00AAFF\n",
+    "schedules.csv": "schedule_ref,date,event_ref\nSD0001,2025-01-06,EV0001\n",
+    "system_status.csv": "status\nRunning\n",
+    "recurring_classes.csv":
+      "recurring_class_ref,subscription_ref,instructor_ref,start_at,end_at\nRC0001,SU0001,IN0001,2025-01-06T09:00:00+09:00,2025-12-31T09:00:00+09:00\n",
+    "recurring_class_attendance.csv":
+      "recurring_class_ref,child_ref\nRC0001,CH0001\n",
+    "classes.csv":
+      "class_ref,customer_ref,instructor_ref,recurring_class_ref,subscription_ref,date_time,status,rebookable_until,class_code,is_free_trial\nCL0001,CU0001,IN0001,RC0001,SU0001,2025-01-06T09:00:00+09:00,booked,2025-01-06T06:00:00+09:00,class-0001,false\n",
+    "class_attendance.csv": "class_ref,child_ref\nCL0001,CH0001\n",
+  };
+}
+
+async function buildZipBuffer(files: Record<string, string>) {
+  const zip = new JSZip();
+  for (const [name, content] of Object.entries(files)) {
+    zip.file(name, content);
+  }
+  return zip.generateAsync({ type: "nodebuffer" });
 }
 
 describe("POST /admins/import/normalize", () => {
@@ -237,7 +278,7 @@ describe("POST /admins/import/normalize", () => {
 });
 
 describe("POST /admins/import/execute", () => {
-  it("validates normalized package by jobId", async () => {
+  it("executes normalized package by jobId", async () => {
     const admin = await createAdmin();
     const authCookie = await generateAuthCookie(admin.id, "admin");
 
@@ -256,8 +297,19 @@ describe("POST /admins/import/execute", () => {
       .send({ jobId: normalizeResponse.body.jobId })
       .expect(200);
 
-    expect(response.body.imported).toBe(false);
+    expect(response.body.imported).toBe(true);
     expect(response.body.report.rowsByFile["system_status.csv"]).toBe(1);
+
+    const [customers, children, instructors, statuses] = await Promise.all([
+      prisma.customer.count(),
+      prisma.child.count(),
+      prisma.instructor.count(),
+      prisma.systemStatus.count(),
+    ]);
+    expect(customers).toBe(0);
+    expect(children).toBe(0);
+    expect(instructors).toBe(0);
+    expect(statuses).toBe(1);
   });
 
   it("returns validation issues when required files are missing in zip", async () => {
@@ -332,5 +384,183 @@ describe("POST /admins/import/execute", () => {
         }),
       ]),
     );
+  });
+
+  it("imports a normalized zip and persists cross-entity relationships", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    const zipBuffer = await buildZipBuffer(buildMinimalNormalizedFiles());
+
+    const response = await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(200);
+
+    expect(response.body.imported).toBe(true);
+
+    const [
+      plans,
+      customers,
+      children,
+      subscriptions,
+      instructors,
+      schedules,
+      recurringClasses,
+      classes,
+      recurringClassAttendance,
+      classAttendance,
+      status,
+    ] = await Promise.all([
+      prisma.plan.count(),
+      prisma.customer.count(),
+      prisma.child.count(),
+      prisma.subscription.count(),
+      prisma.instructor.count(),
+      prisma.schedule.count(),
+      prisma.recurringClass.count(),
+      prisma.class.count(),
+      prisma.recurringClassAttendance.count(),
+      prisma.classAttendance.count(),
+      prisma.systemStatus.findFirst(),
+    ]);
+
+    expect(plans).toBe(1);
+    expect(customers).toBe(1);
+    expect(children).toBe(1);
+    expect(subscriptions).toBe(1);
+    expect(instructors).toBe(1);
+    expect(schedules).toBe(1);
+    expect(recurringClasses).toBe(1);
+    expect(classes).toBe(1);
+    expect(recurringClassAttendance).toBe(1);
+    expect(classAttendance).toBe(1);
+    expect(status?.status).toBe("Running");
+
+    const importedClass = await prisma.class.findFirst({
+      include: {
+        customer: true,
+        instructor: true,
+        subscription: true,
+        recurringClass: true,
+      },
+    });
+    expect(importedClass?.customer.email).toBe("customer.one@example.com");
+    expect(importedClass?.instructor?.email).toBe("instructor.one@example.com");
+    expect(importedClass?.subscriptionId).toBeTruthy();
+    expect(importedClass?.recurringClassId).toBeTruthy();
+
+    const importedCustomer = await prisma.customer.findFirstOrThrow({
+      where: { email: "customer.one@example.com" },
+    });
+    expect(importedCustomer.password).not.toBe("TempPass123!");
+    expect(importedCustomer.password.startsWith("$2")).toBe(true);
+  });
+
+  it("preserves only seed admins during full reset import", async () => {
+    const seedAdmin1 = await createAdmin({
+      name: "Seed Admin 1",
+      email: "admin@example.com",
+      password: "SeedAdminPass1!",
+    });
+    const seedAdmin2 = await createAdmin({
+      name: "Seed Admin 2",
+      email: "admin2@example.com",
+      password: "SeedAdminPass2!",
+    });
+    const removableAdmin = await createAdmin({
+      name: "Temporary Admin",
+      email: "temporary-admin@example.com",
+      password: "TemporaryPass1!",
+    });
+    const authCookie = await generateAuthCookie(removableAdmin.id, "admin");
+
+    const seedBefore = await prisma.admin.findMany({
+      where: { email: { in: ["admin@example.com", "admin2@example.com"] } },
+      orderBy: { email: "asc" },
+    });
+    const seedBeforeByEmail = new Map(
+      seedBefore.map((item) => [item.email, item.password]),
+    );
+
+    const zipBuffer = await buildZipBuffer(buildMinimalNormalizedFiles());
+
+    await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(200);
+
+    const adminsAfter = await prisma.admin.findMany({
+      orderBy: { email: "asc" },
+    });
+    const emailsAfter = adminsAfter.map((item) => item.email);
+
+    expect(emailsAfter).toEqual(["admin2@example.com", "admin@example.com"]);
+    expect(emailsAfter).not.toContain("temporary-admin@example.com");
+
+    const seedAfterByEmail = new Map(
+      adminsAfter.map((item) => [item.email, item.password]),
+    );
+    expect(seedAfterByEmail.get("admin@example.com")).toBe(
+      seedBeforeByEmail.get("admin@example.com"),
+    );
+    expect(seedAfterByEmail.get("admin2@example.com")).toBe(
+      seedBeforeByEmail.get("admin2@example.com"),
+    );
+    expect(seedAdmin1.email).toBe("admin@example.com");
+    expect(seedAdmin2.email).toBe("admin2@example.com");
+  });
+
+  it("rolls back reset and inserts when import fails mid-transaction", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+    const existingCustomer = await createCustomer({
+      name: "Existing Customer",
+      email: "existing.customer@example.com",
+      password: "ExistingPass1!",
+      prefecture: "Tokyo",
+      emailVerified: null,
+    });
+
+    const files = buildMinimalNormalizedFiles();
+    files["instructor_schedules.csv"] = [
+      "instructor_ref,effective_from,effective_to,timezone,weekday,start_time",
+      "IN0001,2025-01-01,2025-12-31,Asia/Tokyo,1,09:00",
+      "IN0001,2025-02-01,2025-12-31,UTC,2,10:00",
+      "",
+    ].join("\n");
+    const zipBuffer = await buildZipBuffer(files);
+
+    await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(500);
+
+    const [customerAfter, plansCount, systemStatusCount, instructorCount] =
+      await Promise.all([
+        prisma.customer.findUnique({
+          where: { id: existingCustomer.id },
+        }),
+        prisma.plan.count(),
+        prisma.systemStatus.count(),
+        prisma.instructor.count(),
+      ]);
+
+    expect(customerAfter?.email).toBe("existing.customer@example.com");
+    expect(plansCount).toBe(0);
+    expect(systemStatusCount).toBe(0);
+    expect(instructorCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add integration tests for normalized import execution with persisted cross-entity relationships
- add seed-admin preservation coverage during full-reset imports
- add rollback coverage to verify reset/insert transaction rollback on mid-import failure
- align execute import runtime-failure response to return a 500 error payload with an error field so API response validation remains consistent

## Testing
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts
