### PR TITLE
feat: add admin data import normalization and execute UI

### DIFF
--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -383,7 +383,7 @@ function parseFileRows<K extends NormalizedFileName>(
     return [];
   }
 
-  const expectedHeaders = NORMALIZED_HEADERS[file] as string[];
+  const expectedHeaders = NORMALIZED_HEADERS[file] as readonly string[];
   const actualHeaders = (parsedRows[0] ?? []).map((cell) =>
     normalizeCell(cell),
   );

--- a/backend/src/services/adminImport/normalize.ts
+++ b/backend/src/services/adminImport/normalize.ts
@@ -665,14 +665,20 @@ function buildRawRows(allRows: CsvRow[]): RawClassRow[] {
   return out;
 }
 
-function rowsToCsvWithHeaders(
-  fileName: NormalizedFileName,
-  rows: Array<Record<string, string>>,
+function rowsToCsvWithHeaders<K extends NormalizedFileName, R extends object>(
+  fileName: K,
+  rows: R[],
 ): string {
-  const headers = NORMALIZED_HEADERS[fileName];
+  const headers = NORMALIZED_HEADERS[fileName] as readonly string[];
   const csvRows: string[][] = [
     [...headers],
-    ...rows.map((row) => headers.map((h) => row[h] ?? "")),
+    ...rows.map((row) =>
+      headers.map(
+        (h) =>
+          (row as Record<string, string | undefined>)[h] ??
+          "",
+      ),
+    ),
   ];
   return toCsv(csvRows);
 }

--- a/backend/src/services/adminImport/normalize.ts
+++ b/backend/src/services/adminImport/normalize.ts
@@ -673,11 +673,7 @@ function rowsToCsvWithHeaders<K extends NormalizedFileName, R extends object>(
   const csvRows: string[][] = [
     [...headers],
     ...rows.map((row) =>
-      headers.map(
-        (h) =>
-          (row as Record<string, string | undefined>)[h] ??
-          "",
-      ),
+      headers.map((h) => (row as Record<string, string | undefined>)[h] ?? ""),
     ),
   ];
   return toCsv(csvRows);

--- a/frontend/src/app/admins/[id]/data-import/page.tsx
+++ b/frontend/src/app/admins/[id]/data-import/page.tsx
@@ -1,0 +1,10 @@
+import DataImportDashboard from "@/components/admins-dashboard/import-dashboard/DataImportDashboard";
+import { authenticateUserSession } from "@/lib/auth/sessionUtils";
+
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  const adminId = params.id;
+  await authenticateUserSession("admin", adminId);
+
+  return <DataImportDashboard adminId={Number(adminId)} />;
+}

--- a/frontend/src/app/api/admin-import/normalized/[jobId]/download/route.ts
+++ b/frontend/src/app/api/admin-import/normalized/[jobId]/download/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCookie } from "@/proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ jobId: string }> },
+) {
+  try {
+    const params = await context.params;
+    const jobId = params.jobId?.trim();
+
+    if (!jobId) {
+      return NextResponse.json({ message: "jobId is required" }, { status: 400 });
+    }
+
+    const cookie = await getCookie();
+    const response = await fetch(
+      `${process.env.BACKEND_ORIGIN}/admins/import/normalized/${encodeURIComponent(jobId)}/download`,
+      {
+        method: "GET",
+        headers: {
+          Cookie: cookie,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      return NextResponse.json(
+        { message: text || "Failed to download normalized package" },
+        { status: response.status },
+      );
+    }
+
+    const fileBytes = await response.arrayBuffer();
+    const disposition =
+      response.headers.get("Content-Disposition") ??
+      `attachment; filename="normalized-import-${jobId}.zip"`;
+
+    return new Response(fileBytes, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": disposition,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to proxy normalized package download", { error });
+    return NextResponse.json(
+      { message: "Failed to download normalized package" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/admin-import/normalized/[jobId]/download/route.ts
+++ b/frontend/src/app/api/admin-import/normalized/[jobId]/download/route.ts
@@ -12,7 +12,10 @@ export async function GET(
     const jobId = params.jobId?.trim();
 
     if (!jobId) {
-      return NextResponse.json({ message: "jobId is required" }, { status: 400 });
+      return NextResponse.json(
+        { message: "jobId is required" },
+        { status: 400 },
+      );
     }
 
     const cookie = await getCookie();

--- a/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.module.scss
+++ b/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.module.scss
@@ -1,0 +1,187 @@
+@use "@/styles/variables.module.scss" as *;
+
+.container {
+  display: grid;
+  gap: 1rem;
+  max-width: 900px;
+}
+
+.formSection {
+  display: grid;
+  gap: 0.5rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    color: $text-dark;
+  }
+}
+
+.header {
+  h1 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: $text-dark;
+  }
+}
+
+.subText {
+  margin: 0.3rem 0 0;
+  color: $text-medium;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid $border-light;
+  border-radius: 0.5rem;
+  background: #fff;
+}
+
+.fileInputLabel {
+  font-weight: 600;
+}
+
+.normalizeButton {
+  width: fit-content;
+  border: 0;
+  border-radius: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  background: $blue_primary;
+  color: #fff;
+  font-weight: 600;
+
+  &:hover {
+    cursor: pointer;
+    background: $blue_primary_hover;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background: $border-medium;
+  }
+}
+
+.secondaryButton,
+.executeButton,
+.cancelButton,
+.dangerButton {
+  width: fit-content;
+  border: 0;
+  border-radius: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  color: #fff;
+  font-weight: 600;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background: $border-medium;
+  }
+}
+
+.secondaryButton {
+  background: #667085;
+
+  &:hover {
+    background: #4a5568;
+  }
+}
+
+.executeButton {
+  background: $green-success;
+
+  &:hover {
+    background: $green-success-hover;
+  }
+}
+
+.cancelButton {
+  background: #6b7280;
+
+  &:hover {
+    background: #4b5563;
+  }
+}
+
+.dangerButton {
+  background: $red-alert;
+
+  &:hover {
+    background: $red-alert-hover;
+  }
+}
+
+.error {
+  margin: 0;
+  color: $red-alert;
+  font-weight: 600;
+}
+
+.report {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid $border-light;
+  border-radius: 0.5rem;
+  background: #fff;
+
+  h2,
+  h3,
+  p {
+    margin: 0;
+  }
+}
+
+.jobId {
+  font-family: monospace;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  th,
+  td {
+    text-align: left;
+    border: 1px solid $border-light;
+    padding: 0.4rem 0.5rem;
+  }
+
+  th {
+    background: $background-light;
+  }
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.confirmModal {
+  width: min(520px, 90vw);
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+
+  h3,
+  p {
+    margin: 0;
+  }
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
+++ b/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Modal from "@/components/elements/modal/Modal";
+import {
+  downloadNormalizedImportPackage,
+  executeNormalizedImport,
+  normalizeAdminImportSource,
+  type AdminImportExecuteError,
+} from "@/lib/api/adminImportApi";
+import {
+  type ImportExecuteErrorResponse,
+  type ImportExecuteResponse,
+  type ImportNormalizeResponse,
+} from "@shared/schemas/admins";
+import styles from "./DataImportDashboard.module.scss";
+
+export default function DataImportDashboard({ adminId }: { adminId: number }) {
+  const [sourceFile, setSourceFile] = useState<File | null>(null);
+  const [normalizedZipFile, setNormalizedZipFile] = useState<File | null>(null);
+  const [normalizeResult, setNormalizeResult] =
+    useState<ImportNormalizeResponse | null>(null);
+  const [executeResult, setExecuteResult] = useState<ImportExecuteResponse | null>(
+    null,
+  );
+  const [executeIssues, setExecuteIssues] = useState<
+    ImportExecuteErrorResponse["issues"]
+  >([]);
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [executeErrorMessage, setExecuteErrorMessage] = useState<string>("");
+  const [isNormalizing, setIsNormalizing] = useState(false);
+  const [isDownloadingZip, setIsDownloadingZip] = useState(false);
+  const [isExecutingImport, setIsExecutingImport] = useState(false);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+
+  const normalizedRowsByFile = useMemo(() => {
+    if (!normalizeResult) {
+      return [];
+    }
+
+    return Object.entries(normalizeResult.report.normalizedRowsByFile).sort(
+      ([a], [b]) => a.localeCompare(b),
+    );
+  }, [normalizeResult]);
+
+  const executeRowsByFile = useMemo(() => {
+    if (!executeResult) {
+      return [];
+    }
+
+    return Object.entries(executeResult.report.rowsByFile).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+  }, [executeResult]);
+
+  const handleNormalize = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!sourceFile) {
+      setErrorMessage("Please select a CSV file to normalize.");
+      return;
+    }
+
+    setIsNormalizing(true);
+    setErrorMessage("");
+    setNormalizeResult(null);
+    setExecuteResult(null);
+    setExecuteErrorMessage("");
+    setExecuteIssues([]);
+
+    try {
+      const result = await normalizeAdminImportSource(sourceFile);
+      setNormalizeResult(result);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Normalization failed";
+      setErrorMessage(message);
+    } finally {
+      setIsNormalizing(false);
+    }
+  };
+
+  const triggerDownload = (blob: Blob, fileName: string) => {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDownloadNormalizedZip = async () => {
+    if (!normalizeResult?.jobId) {
+      setErrorMessage("Run normalization first to download a package.");
+      return;
+    }
+
+    setIsDownloadingZip(true);
+    setErrorMessage("");
+    try {
+      const blob = await downloadNormalizedImportPackage(normalizeResult.jobId);
+      triggerDownload(blob, `normalized-import-${normalizeResult.jobId}.zip`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Download failed";
+      setErrorMessage(message);
+    } finally {
+      setIsDownloadingZip(false);
+    }
+  };
+
+  const openExecuteModal = () => {
+    if (!normalizedZipFile && !normalizeResult?.jobId) {
+      setExecuteErrorMessage(
+        "Provide a normalized zip file or run normalization first.",
+      );
+      return;
+    }
+    setExecuteErrorMessage("");
+    setIsConfirmModalOpen(true);
+  };
+
+  const handleExecuteImport = async () => {
+    setIsExecutingImport(true);
+    setExecuteResult(null);
+    setExecuteIssues([]);
+    setExecuteErrorMessage("");
+
+    try {
+      const result = await executeNormalizedImport({
+        file: normalizedZipFile,
+        jobId: normalizedZipFile ? undefined : normalizeResult?.jobId,
+      });
+      setExecuteResult(result);
+      setIsConfirmModalOpen(false);
+    } catch (error) {
+      const typedError = error as AdminImportExecuteError;
+      const message =
+        typedError instanceof Error
+          ? typedError.message
+          : "Import execution failed";
+      setExecuteErrorMessage(message);
+
+      const details = typedError.details as
+        | ImportExecuteErrorResponse
+        | undefined;
+      if (details?.issues) {
+        setExecuteIssues(details.issues);
+      }
+    } finally {
+      setIsExecutingImport(false);
+    }
+  };
+
+  return (
+    <section className={styles.container}>
+      <header className={styles.header}>
+        <h1>Data Import</h1>
+        <p className={styles.subText}>
+          Normalize a raw CSV export, download the normalized zip, and execute a
+          full destructive import.
+        </p>
+        <p className={styles.subText}>Admin ID: {adminId}</p>
+      </header>
+
+      <div className={styles.formSection}>
+        <h2>1) Normalize raw CSV</h2>
+        <form className={styles.form} onSubmit={handleNormalize}>
+          <label className={styles.fileInputLabel} htmlFor="raw-import-file">
+            Raw source CSV
+          </label>
+          <input
+            id="raw-import-file"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(event) => {
+              setSourceFile(event.target.files?.[0] ?? null);
+            }}
+          />
+          <button
+            className={styles.normalizeButton}
+            type="submit"
+            disabled={isNormalizing}
+          >
+            {isNormalizing ? "Normalizing..." : "Run normalization"}
+          </button>
+        </form>
+      </div>
+
+      {errorMessage && <p className={styles.error}>{errorMessage}</p>}
+
+      {normalizeResult && (
+        <div className={styles.report}>
+          <h2>Normalization Report</h2>
+          <p>
+            <strong>Job ID:</strong>{" "}
+            <span className={styles.jobId}>{normalizeResult.jobId}</span>
+          </p>
+          <p>
+            <strong>Raw rows:</strong> {normalizeResult.report.rawRows}
+          </p>
+          <div className={styles.actions}>
+            <button
+              className={styles.secondaryButton}
+              onClick={handleDownloadNormalizedZip}
+              disabled={isDownloadingZip}
+              type="button"
+            >
+              {isDownloadingZip ? "Downloading..." : "Download normalized zip"}
+            </button>
+          </div>
+
+          <h3>Rows By File</h3>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Rows</th>
+              </tr>
+            </thead>
+            <tbody>
+              {normalizedRowsByFile.map(([fileName, rowCount]) => (
+                <tr key={fileName}>
+                  <td>{fileName}</td>
+                  <td>{rowCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <h3>Generated Customer Emails</h3>
+          {normalizeResult.report.generatedCustomerEmails.length === 0 ? (
+            <p>None</p>
+          ) : (
+            <ul className={styles.list}>
+              {normalizeResult.report.generatedCustomerEmails.map((item) => (
+                <li key={`${item.row}:${item.generatedEmail}`}>
+                  Row {item.row}: {item.customerName} ({item.generatedEmail})
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <h3>Warnings</h3>
+          {normalizeResult.report.warnings.length === 0 ? (
+            <p>None</p>
+          ) : (
+            <ul className={styles.list}>
+              {normalizeResult.report.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <div className={styles.formSection}>
+        <h2>2) Execute import</h2>
+        <form className={styles.form}>
+          <label className={styles.fileInputLabel} htmlFor="normalized-zip-file">
+            Normalized package zip (optional if you already normalized above)
+          </label>
+          <input
+            id="normalized-zip-file"
+            type="file"
+            accept=".zip,application/zip"
+            onChange={(event) => {
+              setNormalizedZipFile(event.target.files?.[0] ?? null);
+            }}
+          />
+          <button
+            className={styles.executeButton}
+            type="button"
+            onClick={openExecuteModal}
+          >
+            Execute import
+          </button>
+        </form>
+      </div>
+
+      {executeErrorMessage && <p className={styles.error}>{executeErrorMessage}</p>}
+
+      {executeIssues.length > 0 && (
+        <div className={styles.report}>
+          <h3>Validation Issues</h3>
+          <ul className={styles.list}>
+            {executeIssues.map((issue, index) => (
+              <li key={`${issue.file}:${issue.row}:${issue.column}:${index}`}>
+                [{issue.file}] row {issue.row ?? "-"}, column {issue.column ?? "-"}
+                : {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {executeResult && (
+        <div className={styles.report}>
+          <h2>Import Result</h2>
+          <p>{executeResult.message}</p>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Imported Rows</th>
+              </tr>
+            </thead>
+            <tbody>
+              {executeRowsByFile.map(([fileName, rowCount]) => (
+                <tr key={fileName}>
+                  <td>{fileName}</td>
+                  <td>{rowCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Modal
+        isOpen={isConfirmModalOpen}
+        onClose={() => setIsConfirmModalOpen(false)}
+        overlayClosable={true}
+      >
+        <div className={styles.confirmModal}>
+          <h3>Confirm destructive import</h3>
+          <p>
+            This will fully reset existing import-target data and replace it with
+            this package.
+          </p>
+          <p>
+            Seed admins are preserved, but other data may be permanently removed.
+          </p>
+          <div className={styles.modalActions}>
+            <button
+              className={styles.cancelButton}
+              type="button"
+              onClick={() => setIsConfirmModalOpen(false)}
+              disabled={isExecutingImport}
+            >
+              Cancel
+            </button>
+            <button
+              className={styles.dangerButton}
+              type="button"
+              onClick={handleExecuteImport}
+              disabled={isExecutingImport}
+            >
+              {isExecutingImport ? "Importing..." : "Yes, execute import"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </section>
+  );
+}

--- a/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
+++ b/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
@@ -20,9 +20,8 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
   const [normalizedZipFile, setNormalizedZipFile] = useState<File | null>(null);
   const [normalizeResult, setNormalizeResult] =
     useState<ImportNormalizeResponse | null>(null);
-  const [executeResult, setExecuteResult] = useState<ImportExecuteResponse | null>(
-    null,
-  );
+  const [executeResult, setExecuteResult] =
+    useState<ImportExecuteResponse | null>(null);
   const [executeIssues, setExecuteIssues] = useState<
     ImportExecuteErrorResponse["issues"]
   >([]);
@@ -102,7 +101,8 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
       const blob = await downloadNormalizedImportPackage(normalizeResult.jobId);
       triggerDownload(blob, `normalized-import-${normalizeResult.jobId}.zip`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Download failed";
+      const message =
+        error instanceof Error ? error.message : "Download failed";
       setErrorMessage(message);
     } finally {
       setIsDownloadingZip(false);
@@ -257,7 +257,10 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
       <div className={styles.formSection}>
         <h2>2) Execute import</h2>
         <form className={styles.form}>
-          <label className={styles.fileInputLabel} htmlFor="normalized-zip-file">
+          <label
+            className={styles.fileInputLabel}
+            htmlFor="normalized-zip-file"
+          >
             Normalized package zip (optional if you already normalized above)
           </label>
           <input
@@ -278,7 +281,9 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
         </form>
       </div>
 
-      {executeErrorMessage && <p className={styles.error}>{executeErrorMessage}</p>}
+      {executeErrorMessage && (
+        <p className={styles.error}>{executeErrorMessage}</p>
+      )}
 
       {executeIssues.length > 0 && (
         <div className={styles.report}>
@@ -286,8 +291,8 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
           <ul className={styles.list}>
             {executeIssues.map((issue, index) => (
               <li key={`${issue.file}:${issue.row}:${issue.column}:${index}`}>
-                [{issue.file}] row {issue.row ?? "-"}, column {issue.column ?? "-"}
-                : {issue.message}
+                [{issue.file}] row {issue.row ?? "-"}, column{" "}
+                {issue.column ?? "-"}: {issue.message}
               </li>
             ))}
           </ul>
@@ -325,11 +330,12 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
         <div className={styles.confirmModal}>
           <h3>Confirm destructive import</h3>
           <p>
-            This will fully reset existing import-target data and replace it with
-            this package.
+            This will fully reset existing import-target data and replace it
+            with this package.
           </p>
           <p>
-            Seed admins are preserved, but other data may be permanently removed.
+            Seed admins are preserved, but other data may be permanently
+            removed.
           </p>
           <div className={styles.modalActions}>
             <button

--- a/frontend/src/lib/api/adminImportApi.ts
+++ b/frontend/src/lib/api/adminImportApi.ts
@@ -44,9 +44,12 @@ export const normalizeAdminImportSource = async (
 export const downloadNormalizedImportPackage = async (
   jobId: string,
 ): Promise<Blob> => {
-  const response = await fetch(`/api/admin-import/normalized/${jobId}/download`, {
-    method: "GET",
-  });
+  const response = await fetch(
+    `/api/admin-import/normalized/${jobId}/download`,
+    {
+      method: "GET",
+    },
+  );
 
   if (!response.ok) {
     throw new Error(downloadErrorMessage);
@@ -69,7 +72,9 @@ export const executeNormalizedImport = async ({
   } else if (jobId) {
     formData.append("jobId", jobId);
   } else {
-    throw new Error("Provide either a normalization job or normalized zip file.");
+    throw new Error(
+      "Provide either a normalization job or normalized zip file.",
+    );
   }
 
   const response = await fetch(PROXY_URL, {

--- a/frontend/src/lib/api/adminImportApi.ts
+++ b/frontend/src/lib/api/adminImportApi.ts
@@ -1,0 +1,93 @@
+import {
+  type ImportExecuteResponse,
+  type ImportNormalizeResponse,
+} from "@shared/schemas/admins";
+
+const FRONTEND_ORIGIN =
+  process.env.NEXT_PUBLIC_FRONTEND_ORIGIN || "http://localhost:3000";
+
+const PROXY_URL = `${FRONTEND_ORIGIN}/api/proxy`;
+
+const normalizeErrorMessage = "Failed to normalize the source CSV";
+const executeErrorMessage = "Failed to execute normalized import";
+const downloadErrorMessage = "Failed to download normalized package";
+
+export interface AdminImportExecuteError extends Error {
+  details?: unknown;
+}
+
+export const normalizeAdminImportSource = async (
+  file: File,
+): Promise<ImportNormalizeResponse> => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(PROXY_URL, {
+    method: "POST",
+    headers: {
+      "backend-endpoint": "/admins/import/normalize",
+    },
+    body: formData,
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      typeof data?.message === "string" ? data.message : normalizeErrorMessage,
+    );
+  }
+
+  return data as ImportNormalizeResponse;
+};
+
+export const downloadNormalizedImportPackage = async (
+  jobId: string,
+): Promise<Blob> => {
+  const response = await fetch(`/api/admin-import/normalized/${jobId}/download`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(downloadErrorMessage);
+  }
+
+  return response.blob();
+};
+
+export const executeNormalizedImport = async ({
+  jobId,
+  file,
+}: {
+  jobId?: string;
+  file?: File | null;
+}): Promise<ImportExecuteResponse> => {
+  const formData = new FormData();
+
+  if (file) {
+    formData.append("file", file);
+  } else if (jobId) {
+    formData.append("jobId", jobId);
+  } else {
+    throw new Error("Provide either a normalization job or normalized zip file.");
+  }
+
+  const response = await fetch(PROXY_URL, {
+    method: "POST",
+    headers: {
+      "backend-endpoint": "/admins/import/execute",
+    },
+    body: formData,
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    const error = new Error(
+      typeof data?.message === "string" ? data.message : executeErrorMessage,
+    ) as AdminImportExecuteError;
+    error.details = data;
+    throw error;
+  }
+
+  return data as ImportExecuteResponse;
+};

--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -8,6 +8,7 @@ import {
   ClockIcon,
   AcademicCapIcon,
   BellIcon,
+  ArrowUpOnSquareIcon,
   ClipboardDocumentCheckIcon,
 } from "@heroicons/react/24/outline";
 
@@ -93,6 +94,11 @@ export function getLinks(
       name: "AaasoBo! Calendar",
       href: `/admins/${userId}/business-calendar`,
       icon: CalendarDaysIcon,
+    },
+    {
+      name: "Data Import",
+      href: `/admins/${userId}/data-import`,
+      icon: ArrowUpOnSquareIcon,
     },
     // Not in use for now
     // {


### PR DESCRIPTION
## Summary
- add a new admin Data Import page and sidebar entry
- implement raw CSV normalization workflow UI and reporting
- add normalized package zip download via a dedicated frontend API proxy route
- implement execute-import UI with destructive confirmation modal and result/validation reporting
- fix TypeScript typing issues in backend import normalization/execute helpers used by dev runtime

## Testing
- npm run lint (frontend)
- manual Playwright smoke check:
  - login as admin
  - navigate to Data Import
  - upload raw CSV and run normalization
  - verify normalization report appears
  - verify download button appears
  - open/cancel destructive execute modal
