### PR TITLE
Improve normalized import validation issue granularity

### DIFF
--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -221,6 +221,10 @@ function addIssue(
   issues.push({ file, row, column, message });
 }
 
+function formatExtraColumn(position: number): string {
+  return `column:${position}`;
+}
+
 function assertRequired(
   issues: ImportValidationIssue[],
   file: NormalizedFileName,
@@ -394,13 +398,43 @@ function parseFileRows<K extends NormalizedFileName>(
   );
 
   if (!sameLength || !sameOrder) {
-    addIssue(
-      issues,
-      file,
-      1,
-      null,
-      `Header mismatch. Expected: ${expectedHeaders.join(",")}`,
-    );
+    const maxColumns = Math.max(expectedHeaders.length, actualHeaders.length);
+    for (let index = 0; index < maxColumns; index += 1) {
+      const expected = expectedHeaders[index];
+      const actual = actualHeaders[index];
+
+      if (expected && !actual) {
+        addIssue(
+          issues,
+          file,
+          1,
+          expected,
+          `Missing header column "${expected}" at position ${index + 1}`,
+        );
+        continue;
+      }
+
+      if (!expected && actual) {
+        addIssue(
+          issues,
+          file,
+          1,
+          formatExtraColumn(index + 1),
+          `Unexpected extra header "${actual}" at position ${index + 1}`,
+        );
+        continue;
+      }
+
+      if (expected && actual && expected !== actual) {
+        addIssue(
+          issues,
+          file,
+          1,
+          expected,
+          `Header mismatch at position ${index + 1}: expected "${expected}" but got "${actual}"`,
+        );
+      }
+    }
     return [];
   }
 
@@ -416,8 +450,8 @@ function parseFileRows<K extends NormalizedFileName>(
         issues,
         file,
         i + 1,
-        null,
-        `Row has too many columns. Expected ${expectedHeaders.length}`,
+        formatExtraColumn(expectedHeaders.length + 1),
+        `Row has too many columns. Expected ${expectedHeaders.length}, got ${row.length}`,
       );
       continue;
     }

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -386,6 +386,66 @@ describe("POST /admins/import/execute", () => {
     );
   });
 
+  it("returns header mismatch issues with expected column names", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    const files = buildMinimalNormalizedFiles();
+    files["customers.csv"] =
+      "customer_ref,name,wrong_email,temp_password,prefecture,termination_at,has_seen_welcome\nCU0001,Customer One,customer.one@example.com,TempPass123!,Tokyo,,false\n";
+    const zipBuffer = await buildZipBuffer(files);
+
+    const response = await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(400);
+
+    expect(response.body.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "customers.csv",
+          row: 1,
+          column: "email",
+          message: expect.stringContaining("Header mismatch"),
+        }),
+      ]),
+    );
+  });
+
+  it("returns extra-column issues with column position details", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    const files = buildMinimalNormalizedFiles();
+    files["events.csv"] =
+      "event_ref,name,color\nEV0001,Regular,#00AAFF,EXTRA\n";
+    const zipBuffer = await buildZipBuffer(files);
+
+    const response = await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(400);
+
+    expect(response.body.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "events.csv",
+          row: 2,
+          column: "column:4",
+          message: expect.stringContaining("too many columns"),
+        }),
+      ]),
+    );
+  });
+
   it("imports a normalized zip and persists cross-entity relationships", async () => {
     const admin = await createAdmin();
     const authCookie = await generateAuthCookie(admin.id, "admin");


### PR DESCRIPTION
## Summary
- improve normalized import CSV validation issues to include column-level details for header mismatches
- report explicit extra column positions for row overflows using column:<position> markers
- add API tests covering header mismatch column reporting and extra-column reporting

## Testing
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts