### PR TITLE
Add 50MB upload guardrail for admin import endpoints

### DIFF
--- a/backend/src/middlewares/upload.middleware.ts
+++ b/backend/src/middlewares/upload.middleware.ts
@@ -1,6 +1,32 @@
 import multer from "multer";
+import { Request, Response, NextFunction } from "express";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage });
+const IMPORT_FILE_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
+const importUpload = multer({
+  storage,
+  limits: { fileSize: IMPORT_FILE_SIZE_LIMIT_BYTES },
+});
+
+export const uploadAdminImportFile = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  importUpload.single("file")(req, res, (error: unknown) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return res.status(413).json({
+        message: `Uploaded file exceeds max size of ${Math.floor(IMPORT_FILE_SIZE_LIMIT_BYTES / (1024 * 1024))}MB.`,
+      });
+    }
+    if (error) {
+      return res.status(400).json({
+        message: "Invalid file upload.",
+      });
+    }
+    return next();
+  });
+};
 
 export default upload;

--- a/backend/src/middlewares/upload.middleware.ts
+++ b/backend/src/middlewares/upload.middleware.ts
@@ -15,7 +15,10 @@ export const uploadAdminImportFile = (
   next: NextFunction,
 ) => {
   importUpload.single("file")(req, res, (error: unknown) => {
-    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+    if (
+      error instanceof multer.MulterError &&
+      error.code === "LIMIT_FILE_SIZE"
+    ) {
       return res.status(413).json({
         message: `Uploaded file exceeds max size of ${Math.floor(IMPORT_FILE_SIZE_LIMIT_BYTES / (1024 * 1024))}MB.`,
       });

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -82,7 +82,9 @@ import {
 
 import { AUTH_ROLES } from "../utils/commonUtils";
 import { verifyAuthentication } from "../middlewares/auth.middleware";
-import upload, { uploadAdminImportFile } from "../middlewares/upload.middleware";
+import upload, {
+  uploadAdminImportFile,
+} from "../middlewares/upload.middleware";
 
 // Route configurations
 const registerAdminConfig = {

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -82,7 +82,7 @@ import {
 
 import { AUTH_ROLES } from "../utils/commonUtils";
 import { verifyAuthentication } from "../middlewares/auth.middleware";
-import upload from "../middlewares/upload.middleware";
+import upload, { uploadAdminImportFile } from "../middlewares/upload.middleware";
 
 // Route configurations
 const registerAdminConfig = {
@@ -807,7 +807,7 @@ const normalizeImportSourceConfig = {
   method: "post" as const,
   middleware: [
     verifyAuthentication(AUTH_ROLES.A),
-    upload.single("file"),
+    uploadAdminImportFile,
   ] as RequestHandler[],
   handler: normalizeImportSourceController,
   openapi: {
@@ -825,6 +825,10 @@ const normalizeImportSourceConfig = {
       },
       401: {
         description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      413: {
+        description: "Uploaded file exceeds size limit",
         schema: MessageErrorResponse,
       },
       500: {
@@ -869,7 +873,7 @@ const executeNormalizedImportConfig = {
   bodySchema: ImportExecuteRequest,
   middleware: [
     verifyAuthentication(AUTH_ROLES.A),
-    upload.single("file"),
+    uploadAdminImportFile,
   ] as RequestHandler[],
   handler: executeNormalizedImportController,
   openapi: {
@@ -887,6 +891,10 @@ const executeNormalizedImportConfig = {
       },
       401: {
         description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      413: {
+        description: "Uploaded file exceeds size limit",
         schema: MessageErrorResponse,
       },
       404: {

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -11,6 +11,7 @@ import { prisma } from "../../setup";
 
 const RAW_HEADER =
   ",英語村,,2020.10.,name,child name,plan,講師名,date,time,class,お子さま誕生日,兄弟お子さま誕生日,年齢,詳細,備考※月2回の場合は週を記入,favorite,,,";
+const IMPORT_FILE_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
 
 function rawRow(columns: string[]) {
   return columns.join(",");
@@ -266,6 +267,20 @@ describe("POST /admins/import/normalize", () => {
       .expect(400);
   });
 
+  it("returns 413 when uploaded source CSV exceeds max size", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    await request(server)
+      .post("/admins/import/normalize")
+      .set("Cookie", authCookie)
+      .attach("file", Buffer.alloc(IMPORT_FILE_SIZE_LIMIT_BYTES + 1, "a"), {
+        filename: "raw-schedule.csv",
+        contentType: "text/csv",
+      })
+      .expect(413);
+  });
+
   it("returns 401 when unauthenticated", async () => {
     await request(server)
       .post("/admins/import/normalize")
@@ -341,6 +356,20 @@ describe("POST /admins/import/execute", () => {
         }),
       ]),
     );
+  });
+
+  it("returns 413 when uploaded normalized zip exceeds max size", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", Buffer.alloc(IMPORT_FILE_SIZE_LIMIT_BYTES + 1, "a"), {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(413);
   });
 
   it("returns validation issues when cross-file references are broken", async () => {


### PR DESCRIPTION
## Summary
- add a dedicated admin import upload middleware with a 50MB file size limit
- return HTTP 413 with a clear message when normalize/execute uploads exceed the limit
- wire the new middleware into the admin import normalize and execute endpoints
- add API tests covering oversized uploads for both endpoints

## Testing
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts