### PR TITLE
Simplify import validation direction and update normalization worklog

### DIFF
--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -221,10 +221,6 @@ function addIssue(
   issues.push({ file, row, column, message });
 }
 
-function formatExtraColumn(position: number): string {
-  return `column:${position}`;
-}
-
 function assertRequired(
   issues: ImportValidationIssue[],
   file: NormalizedFileName,
@@ -398,43 +394,13 @@ function parseFileRows<K extends NormalizedFileName>(
   );
 
   if (!sameLength || !sameOrder) {
-    const maxColumns = Math.max(expectedHeaders.length, actualHeaders.length);
-    for (let index = 0; index < maxColumns; index += 1) {
-      const expected = expectedHeaders[index];
-      const actual = actualHeaders[index];
-
-      if (expected && !actual) {
-        addIssue(
-          issues,
-          file,
-          1,
-          expected,
-          `Missing header column "${expected}" at position ${index + 1}`,
-        );
-        continue;
-      }
-
-      if (!expected && actual) {
-        addIssue(
-          issues,
-          file,
-          1,
-          formatExtraColumn(index + 1),
-          `Unexpected extra header "${actual}" at position ${index + 1}`,
-        );
-        continue;
-      }
-
-      if (expected && actual && expected !== actual) {
-        addIssue(
-          issues,
-          file,
-          1,
-          expected,
-          `Header mismatch at position ${index + 1}: expected "${expected}" but got "${actual}"`,
-        );
-      }
-    }
+    addIssue(
+      issues,
+      file,
+      1,
+      null,
+      `Header mismatch. Expected: ${expectedHeaders.join(",")}`,
+    );
     return [];
   }
 
@@ -450,8 +416,8 @@ function parseFileRows<K extends NormalizedFileName>(
         issues,
         file,
         i + 1,
-        formatExtraColumn(expectedHeaders.length + 1),
-        `Row has too many columns. Expected ${expectedHeaders.length}, got ${row.length}`,
+        null,
+        `Row has too many columns. Expected ${expectedHeaders.length}`,
       );
       continue;
     }

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -415,66 +415,6 @@ describe("POST /admins/import/execute", () => {
     );
   });
 
-  it("returns header mismatch issues with expected column names", async () => {
-    const admin = await createAdmin();
-    const authCookie = await generateAuthCookie(admin.id, "admin");
-
-    const files = buildMinimalNormalizedFiles();
-    files["customers.csv"] =
-      "customer_ref,name,wrong_email,temp_password,prefecture,termination_at,has_seen_welcome\nCU0001,Customer One,customer.one@example.com,TempPass123!,Tokyo,,false\n";
-    const zipBuffer = await buildZipBuffer(files);
-
-    const response = await request(server)
-      .post("/admins/import/execute")
-      .set("Cookie", authCookie)
-      .attach("file", zipBuffer, {
-        filename: "normalized.zip",
-        contentType: "application/zip",
-      })
-      .expect(400);
-
-    expect(response.body.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: "customers.csv",
-          row: 1,
-          column: "email",
-          message: expect.stringContaining("Header mismatch"),
-        }),
-      ]),
-    );
-  });
-
-  it("returns extra-column issues with column position details", async () => {
-    const admin = await createAdmin();
-    const authCookie = await generateAuthCookie(admin.id, "admin");
-
-    const files = buildMinimalNormalizedFiles();
-    files["events.csv"] =
-      "event_ref,name,color\nEV0001,Regular,#00AAFF,EXTRA\n";
-    const zipBuffer = await buildZipBuffer(files);
-
-    const response = await request(server)
-      .post("/admins/import/execute")
-      .set("Cookie", authCookie)
-      .attach("file", zipBuffer, {
-        filename: "normalized.zip",
-        contentType: "application/zip",
-      })
-      .expect(400);
-
-    expect(response.body.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: "events.csv",
-          row: 2,
-          column: "column:4",
-          message: expect.stringContaining("too many columns"),
-        }),
-      ]),
-    );
-  });
-
   it("imports a normalized zip and persists cross-entity relationships", async () => {
     const admin = await createAdmin();
     const authCookie = await generateAuthCookie(admin.id, "admin");

--- a/docs/data-import-normalization-plan.md
+++ b/docs/data-import-normalization-plan.md
@@ -274,7 +274,8 @@ Exact table order should be finalized against Prisma schema, but expected depend
 5. Phase 4.2 guardrails for large uploads implemented:
    - 50MB upload limit enforced on `/admins/import/normalize` and `/admins/import/execute`.
    - Oversized uploads return HTTP 413.
-6. Rollback applied for strict execute-side issue granularity changes from PR #451 to keep the feature simpler for bootstrap/testing usage.
+6. Phase 4.1 strict error-granularity expansion is intentionally de-scoped for v1.
+7. Rollback applied for strict execute-side issue granularity changes from PR #451 to keep the feature simpler for bootstrap/testing usage.
 
 ### Current Direction (Confirmed)
 
@@ -318,7 +319,9 @@ Exact table order should be finalized against Prisma schema, but expected depend
 ### Phase 4: Hardening
 
 1. Improve error reporting granularity (file/row/column) only where low-cost and high-value; avoid heavy schema complexity.
+   - Status: strict/fully-structured 4.1 approach is intentionally not planned for current v1 scope.
 2. Add guardrails for very large uploads.
+   - Status: done (50MB limit + HTTP 413 on oversized uploads).
 3. Add operational docs and runbook.
 4. Evaluate whether to disable/remove feature in production release process.
 
@@ -347,7 +350,7 @@ None at this stage.
 1. Risk: accidental destructive execution.
    - Mitigation: strong modal warning and explicit admin-only access.
 2. Risk: source data quality issues.
-   - Mitigation: strict normalization validation and actionable error reports.
+   - Mitigation: pragmatic normalization/import validation with actionable backend errors.
 3. Risk: broken relationships across entities.
    - Mitigation: generated stable references + cross-file validation before write.
 4. Risk: large-batch performance.

--- a/docs/data-import-normalization-plan.md
+++ b/docs/data-import-normalization-plan.md
@@ -263,6 +263,25 @@ Exact table order should be finalized against Prisma schema, but expected depend
 6. bookings/registrations
 7. other dependent operational records
 
+## Progress / Worklog
+
+### Completed
+
+1. Phase 0 discovery/design baseline captured in this document.
+2. Phase 1 backend normalization implemented (raw CSV parsing, mapping, normalized artifact generation, zip packaging, unit tests).
+3. Phase 2 backend import implemented (normalized validation, dependency-ordered import, full reset with seed-admin preservation, transactional safety, integration tests).
+4. Phase 3 admin UI implemented (normalize flow, report display, zip download, destructive confirmation, execute + result summary).
+5. Phase 4.2 guardrails for large uploads implemented:
+   - 50MB upload limit enforced on `/admins/import/normalize` and `/admins/import/execute`.
+   - Oversized uploads return HTTP 413.
+6. Rollback applied for strict execute-side issue granularity changes from PR #451 to keep the feature simpler for bootstrap/testing usage.
+
+### Current Direction (Confirmed)
+
+1. Prioritize simplicity and easy customization over highly strict/fully modeled error structures.
+2. Keep backend validation pragmatic: enough to prevent broken imports, without over-constraining data migration workflows.
+3. Backend should return human-readable parse/validation errors; frontend should display those details directly.
+
 ## TODO (Implementation Plan)
 
 ### Phase 0: Discovery
@@ -298,7 +317,7 @@ Exact table order should be finalized against Prisma schema, but expected depend
 
 ### Phase 4: Hardening
 
-1. Improve error reporting granularity (file/row/column).
+1. Improve error reporting granularity (file/row/column) only where low-cost and high-value; avoid heavy schema complexity.
 2. Add guardrails for very large uploads.
 3. Add operational docs and runbook.
 4. Evaluate whether to disable/remove feature in production release process.
@@ -321,6 +340,7 @@ None at this stage.
 10. Temporary passwords are regenerated on every normalization run.
 11. Import feature is always available to authenticated admins in v1 (no environment kill-switch).
 12. Missing emails are auto-generated during normalization (no toggle), and normalization output/report must list which rows were assigned generated emails.
+13. For v1 bootstrap/testing usage, prioritize simple, human-readable backend errors over deeply structured error contracts.
 
 ## Risks and Mitigations
 


### PR DESCRIPTION
## Summary
- revert PR #451 (execute validation issue column granularity) to keep import validation behavior simple for bootstrap/testing workflows
- keep the existing import guardrail work from PR #452 intact
- update docs/data-import-normalization-plan.md with progress/worklog status
- explicitly record that strict Phase 4.1 expansion is de-scoped for current v1 scope

## Rationale
- this feature is currently internal/bootstrap-focused, so we are prioritizing easy customization and pragmatic validation over strict error modeling

## Testing
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts