### PR TITLE
Fix normalized instructor schedule validation and import timeout

### DIFF
--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -1240,13 +1240,6 @@ export function validateNormalizedImportFiles(
     issues,
     "instructor_schedules.csv",
     parsed["instructor_schedules.csv"],
-    ["instructor_ref", "effective_from", "effective_to", "timezone"],
-    "(instructor_ref,effective_from,effective_to,timezone)",
-  );
-  assertUnique(
-    issues,
-    "instructor_schedules.csv",
-    parsed["instructor_schedules.csv"],
     [
       "instructor_ref",
       "effective_from",

--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -152,6 +152,7 @@ const STATUS_VALUES = new Set([
   "rebooked",
   "declined",
 ]);
+const IMPORT_TRANSACTION_TIMEOUT_MS = 180_000;
 
 interface RowEnvelope<T> {
   rowNumber: number;
@@ -1827,10 +1828,13 @@ export async function executeNormalizedImportFiles(
     throw new Error("Normalized import parsing failed");
   }
 
-  await prisma.$transaction(async (tx) => {
-    await resetImportTargetData(tx);
-    await insertValidatedRows(tx, parsed);
-  });
+  await prisma.$transaction(
+    async (tx) => {
+      await resetImportTargetData(tx);
+      await insertValidatedRows(tx, parsed);
+    },
+    { timeout: IMPORT_TRANSACTION_TIMEOUT_MS },
+  );
 
   return {
     report: validation.report,

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -490,6 +490,39 @@ describe("POST /admins/import/execute", () => {
     expect(importedCustomer.password.startsWith("$2")).toBe(true);
   });
 
+  it("accepts multiple slot rows that share the same instructor schedule key", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+
+    const files = buildMinimalNormalizedFiles();
+    files["instructor_schedules.csv"] = [
+      "instructor_ref,effective_from,effective_to,timezone,weekday,start_time",
+      "IN0001,2025-01-01,2025-12-31,Asia/Tokyo,1,09:00",
+      "IN0001,2025-01-01,2025-12-31,Asia/Tokyo,3,09:30",
+      "",
+    ].join("\n");
+    const zipBuffer = await buildZipBuffer(files);
+
+    const response = await request(server)
+      .post("/admins/import/execute")
+      .set("Cookie", authCookie)
+      .attach("file", zipBuffer, {
+        filename: "normalized.zip",
+        contentType: "application/zip",
+      })
+      .expect(200);
+
+    expect(response.body.imported).toBe(true);
+
+    const [scheduleCount, slotCount] = await Promise.all([
+      prisma.instructorSchedule.count(),
+      prisma.instructorSlot.count(),
+    ]);
+
+    expect(scheduleCount).toBe(1);
+    expect(slotCount).toBe(2);
+  });
+
   it("preserves only seed admins during full reset import", async () => {
     const seedAdmin1 = await createAdmin({
       name: "Seed Admin 1",

--- a/docs/data-import-normalization-plan.md
+++ b/docs/data-import-normalization-plan.md
@@ -322,8 +322,15 @@ Exact table order should be finalized against Prisma schema, but expected depend
    - Status: strict/fully-structured 4.1 approach is intentionally not planned for current v1 scope.
 2. Add guardrails for very large uploads.
    - Status: done (50MB limit + HTTP 413 on oversized uploads).
-3. Add operational docs and runbook.
-4. Evaluate whether to disable/remove feature in production release process.
+3. Add operational docs and runbook. *(Out of scope for v1 simplicity)*
+4. Evaluate whether to disable/remove feature in production release process. *(Out of scope for v1 simplicity)*
+
+### Next Step (Post-Implementation Validation)
+
+1. Run end-to-end validation using a sample source export converted to CSV:
+   normalize -> download normalized zip -> execute import.
+2. Verify key outcomes in DB/UI (entity counts, core relationships, seed admin preservation).
+3. Create and commit a sanitized simplified CSV fixture set (no real customer data) for repeatable test sharing.
 
 ## Open Questions
 
@@ -344,6 +351,7 @@ None at this stage.
 11. Import feature is always available to authenticated admins in v1 (no environment kill-switch).
 12. Missing emails are auto-generated during normalization (no toggle), and normalization output/report must list which rows were assigned generated emails.
 13. For v1 bootstrap/testing usage, prioritize simple, human-readable backend errors over deeply structured error contracts.
+14. Hardening scope for v1 is intentionally reduced to upload-size guardrails only; other hardening items are deferred.
 
 ## Risks and Mitigations
 


### PR DESCRIPTION
## Summary
- allow repeated instructor schedule keys across multiple slot rows during normalized import validation
- increase admin import transaction timeout to 180 seconds to reduce timeout failures on larger imports
- include related planning doc update for the simplified validation scope

## Testing
- cd backend && npm run test -- src/test/api/admins/import-normalize.test.ts
- playwright e2e import flow on localhost:3000 (manual run)
