### PR TITLE
Add responsive behavior to admin dashboard pages

### DIFF
--- a/frontend/src/app/admins/[id]/AdminLayout.tsx
+++ b/frontend/src/app/admins/[id]/AdminLayout.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import styles from "./layout.module.scss";
+
+export default function AdminLayout({
+  sideNav,
+  children,
+}: {
+  sideNav: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => setIsOpen((prev) => !prev);
+  const closeMenu = () => setIsOpen(false);
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.mobileHeader}>
+        <button
+          type="button"
+          className={styles.menuButton}
+          onClick={toggleMenu}
+          aria-expanded={isOpen}
+          aria-controls="admin-sidebar"
+          aria-label={isOpen ? "Close menu" : "Open menu"}
+        >
+          {isOpen ? (
+            <XMarkIcon className={styles.menuIcon} />
+          ) : (
+            <Bars3Icon className={styles.menuIcon} />
+          )}
+        </button>
+        <Image
+          src="/images/logo2.svg"
+          alt="Aaasobo logo"
+          width={120}
+          height={34}
+        />
+      </header>
+      <div
+        id="admin-sidebar"
+        className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ""}`}
+      >
+        {sideNav}
+      </div>
+      {isOpen ? (
+        <button
+          type="button"
+          className={styles.overlay}
+          onClick={closeMenu}
+          aria-label="Close menu"
+        />
+      ) : null}
+      <div className={styles.content} onClick={closeMenu}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admins/[id]/layout.module.scss
+++ b/frontend/src/app/admins/[id]/layout.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/variables.module.scss" as *;
+
 .container {
   display: flex;
   height: 100vh;
@@ -9,6 +11,9 @@
   overflow: auto;
   width: 15rem;
   flex: none;
+  background: inherit;
+  transition: transform 0.2s ease;
+  z-index: 30;
 }
 
 .content {
@@ -17,4 +22,84 @@
   margin-left: 15rem;
   height: 100vh;
   overflow: auto;
+}
+
+.mobileHeader {
+  display: none;
+}
+
+.menuButton {
+  display: none;
+}
+
+.overlay {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .container {
+    position: relative;
+  }
+
+  .mobileHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 40;
+    padding: 0.75rem 1rem;
+    background: $blue_primary;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .menuButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: transparent;
+    color: #ffffff;
+  }
+
+  .menuIcon {
+    width: 22px;
+    height: 22px;
+  }
+
+  .sidebar {
+    width: 15rem;
+    transform: translateX(-100%);
+  }
+
+  .sidebarOpen {
+    transform: translateX(0);
+  }
+
+  .overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 20;
+  }
+
+  .content {
+    margin-left: 0;
+    padding: 4.5rem 1rem 1rem;
+  }
+}
+
+@media (min-width: 641px) and (max-width: 1024px) {
+  .sidebar {
+    width: 12rem;
+  }
+
+  .content {
+    margin-left: 12rem;
+  }
 }

--- a/frontend/src/app/admins/[id]/layout.tsx
+++ b/frontend/src/app/admins/[id]/layout.tsx
@@ -1,6 +1,6 @@
-import styles from "./layout.module.scss";
 import SideNav from "@/components/layouts/sideNav/SideNav";
 import { getUserSession } from "@/lib/auth/sessionUtils";
+import AdminLayout from "./AdminLayout";
 
 export default async function Layout(props: {
   children: React.ReactNode;
@@ -21,11 +21,8 @@ export default async function Layout(props: {
   }
 
   return (
-    <div className={styles.container}>
-      <div className={styles.sidebar}>
-        <SideNav userId={adminId} userType="admin" />
-      </div>
-      <div className={styles.content}>{props.children}</div>
-    </div>
+    <AdminLayout sideNav={<SideNav userId={adminId} userType="admin" />}>
+      {props.children}
+    </AdminLayout>
   );
 }


### PR DESCRIPTION
### Motivation
- Make admin dashboard pages behave like customer/instructor dashboards on small and tablet screens by adding a mobile header, off-canvas sidebar and overlay so the admin UI is responsive.

### Description
- Add a client `AdminLayout` component at `frontend/src/app/admins/[id]/AdminLayout.tsx` that mirrors the mobile header, menu toggle and overlay used by customer/instructor layouts.
- Update `frontend/src/app/admins/[id]/layout.tsx` to render admin pages through `AdminLayout` while preserving the existing admin ID and session fallback logic.
- Expand `frontend/src/app/admins/[id]/layout.module.scss` with mobile and tablet rules (mobile header, menu button, sidebar open/close transform, overlay and adjusted sidebar widths) matching the other dashboards.
- Files changed: `AdminLayout.tsx`, `layout.tsx`, and `layout.module.scss` under `frontend/src/app/admins/[id]`.

### Testing
- Ran `cd frontend && npm run format` and it completed successfully.
- Ran `cd frontend && npm run lint` and it completed successfully.
- Launched the dev server with `cd frontend && npm run dev` and captured a mobile-size screenshot of `/admins/1` using Playwright to validate the responsive header and menu toggle, and the capture completed successfully.