### PR TITLE
Guard localStorage access and memoize calendar initial date and breadcrumbs

### DIFF
--- a/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
+++ b/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
@@ -5,7 +5,7 @@ import FullCalendar from "@fullcalendar/react";
 import multiMonthPlugin from "@fullcalendar/multimonth";
 import interactionPlugin from "@fullcalendar/interaction";
 import { DateSelectArg } from "@fullcalendar/core";
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Modal from "@/components/elements/modal/Modal";
@@ -131,20 +131,22 @@ const BusinessCalendarClient = ({
     }
   };
 
-  // Get the initial date to display the appropriate year in the calendar
-  const getInitialDate = () => {
+  const initialDate = useMemo(() => {
+    if (typeof window === "undefined") {
+      return new Date().toISOString();
+    }
+
     const saved = localStorage.getItem("calendarPosition");
+
     switch (saved) {
       case "prev":
         return new Date(new Date().getFullYear() - 1, 1, 0).toISOString();
       case "next":
         return new Date(new Date().getFullYear() + 1, 1, 0).toISOString();
-      case "default":
-        return new Date().toISOString();
       default:
         return new Date().toISOString();
     }
-  };
+  }, []);
 
   // Fetch the schedule data when the schedule is updated
   const fetchSchedule = async () => {
@@ -203,7 +205,7 @@ const BusinessCalendarClient = ({
           ref={calendarRef}
           plugins={[interactionPlugin, multiMonthPlugin]}
           initialView="multiMonthYear"
-          initialDate={getInitialDate()}
+          initialDate={initialDate}
           headerToolbar={{
             left: "prev,next today",
             center: "title",

--- a/frontend/src/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/customers-dashboard/classCalendarForAdmin/CustomerDashboardClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import TabFunction from "@/components/admins-dashboard/TabFunction";
 import CustomerProfile from "@/components/customers-dashboard/profile/CustomerProfile";
 import ChildrenProfiles from "@/components/customers-dashboard/children-profiles/ChildrenProfiles";
@@ -23,12 +23,12 @@ function CustomerDashboardClient({
   customerProfile: CustomerProfile;
   childProfiles: Child[];
 }) {
-  const [previousListPage] = useState<string | null>(() => {
+  const previousListPage = useMemo(() => {
     if (typeof window === "undefined") {
       return null;
     }
     return localStorage.getItem("previousListPage");
-  });
+  }, []);
 
   const breadcrumb = useMemo(() => {
     switch (previousListPage) {

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import TabFunction from "@/components/admins-dashboard/TabFunction";
 import InstructorProfile from "@/components/instructors-dashboard/instructor-profile/InstructorProfile";
 import { useTabSelect } from "@/hooks/useTabSelect";
@@ -31,25 +33,31 @@ export default function InstructorTabs({
   classScheduleComponent: React.ReactNode;
 }) {
   const nickname = typeof instructor !== "string" ? instructor.nickname : null;
-  // Get the previous list page from local storage to set the breadcrumb.
-  const previousListPage = localStorage.getItem("previousListPage");
-  let breadcrumb: string[] = [];
-  switch (previousListPage) {
-    case "instructor-list":
-      breadcrumb = [
-        "Instructor List",
-        `/admins/${adminId}/instructor-list`,
-        `Instructor Page (${nickname || "Unknown"})`,
-      ];
-      break;
-    case "class-list":
-      breadcrumb = [
-        "Class List",
-        `/admins/${adminId}/class-list`,
-        `Instructor Page (${nickname || "Unknown"})`,
-      ];
-      break;
-  }
+  const previousListPage = useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return localStorage.getItem("previousListPage");
+  }, []);
+
+  const breadcrumb = useMemo(() => {
+    switch (previousListPage) {
+      case "instructor-list":
+        return [
+          "Instructor List",
+          `/admins/${adminId}/instructor-list`,
+          `Instructor Page (${nickname || "Unknown"})`,
+        ];
+      case "class-list":
+        return [
+          "Class List",
+          `/admins/${adminId}/class-list`,
+          `Instructor Page (${nickname || "Unknown"})`,
+        ];
+      default:
+        return [];
+    }
+  }, [adminId, nickname, previousListPage]);
   const activeTabName = "activeInstructorTab";
 
   // Get the active tab from the local storage.


### PR DESCRIPTION
### Motivation

- Prevent runtime errors during server-side rendering by avoiding direct `localStorage` access outside the browser environment.
- Improve performance and stability by memoizing values that derive from `localStorage` and expensive computations used by UI components.

### Description

- Replaced the `getInitialDate` function in `BusinessCalendarClient.tsx` with a `useMemo`-based `initialDate` and added a `typeof window === "undefined"` guard to avoid `localStorage` access during SSR, then wired `initialDate` into the `FullCalendar` `initialDate` prop.
- Added `useMemo` import to `BusinessCalendarClient.tsx` and updated initial date logic to return ISO date strings consistently for the calendar position cases.
- Replaced `useState` usage that read `localStorage` in `CustomerDashboardClient.tsx` with a `useMemo` hook to safely read `previousListPage` only on the client.
- In `InstructorDashboardClient.tsx`, added `useMemo` to safely read `previousListPage` from `localStorage` and wrapped breadcrumb computation in `useMemo` with proper dependencies to avoid recomputation and SSR issues.

### Testing

- Ran a TypeScript type-check (`tsc --noEmit`) and local build (`npm run build`) against the modified files, and both completed without type or build errors.
- Ran the test suite (`npm test`) and unit tests passed locally.