### PR TITLE
Add admin instructor payroll view

### DIFF
--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -1593,11 +1593,52 @@ async function insertAdmins() {
   });
 }
 
+async function insertInstructorFees() {
+  const helen = await getInstructor("Helen");
+
+  await prisma.instructorFee.createMany({
+    data: [
+      {
+        instructorId: helen.id,
+        currency: "JPY",
+        effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
+        effectiveTo: new Date("2026-03-15T00:00:00.000Z"),
+        trialFee: 1000,
+        regularFee: 2000,
+        cancelFee: 500,
+        cancelWithoutNoticeFee: 250,
+      },
+      {
+        instructorId: helen.id,
+        currency: "JPY",
+        effectiveFrom: new Date("2026-03-16T00:00:00.000Z"),
+        effectiveTo: null,
+        trialFee: 1500,
+        regularFee: 2500,
+        cancelFee: 600,
+        cancelWithoutNoticeFee: 300,
+      },
+    ],
+  });
+}
+
 async function insertClasses() {
   const alice = await getCustomer("Alice");
   const bob = await getCustomer("Bob");
   const helen = await getInstructor("Helen");
   const elian = await getInstructor("Elian");
+  const aliceHelenRecurringClass = await prisma.recurringClass.findFirst({
+    where: {
+      subscriptionId: alice.subscription[0].id,
+      instructorId: helen.id,
+      endAt: null,
+    },
+    select: { id: true },
+  });
+
+  if (!aliceHelenRecurringClass) {
+    throw new Error("Active recurring class for Alice and Helen not found");
+  }
 
   await prisma.class.createMany({
     data: [
@@ -1695,7 +1736,7 @@ async function insertClasses() {
         dateTime: "2026-01-06T07:00:00Z",
         status: "booked",
         subscriptionId: alice.subscription[0].id,
-        recurringClassId: 1,
+        recurringClassId: aliceHelenRecurringClass.id,
         rebookableUntil: "2026-04-30T09:00:00Z",
         createdAt: "2025-05-20T07:00:00Z",
         updatedAt: "2025-05-20T07:00:00Z",
@@ -1708,7 +1749,7 @@ async function insertClasses() {
         dateTime: "2026-01-06T08:00:00Z",
         status: "rebooked",
         subscriptionId: alice.subscription[0].id,
-        recurringClassId: 1,
+        recurringClassId: aliceHelenRecurringClass.id,
         rebookableUntil: "2026-04-30T09:00:00Z",
         createdAt: "2025-05-20T07:00:00Z",
         updatedAt: "2025-05-20T07:00:00Z",
@@ -1721,7 +1762,7 @@ async function insertClasses() {
         dateTime: "2026-01-06T09:00:00Z",
         status: "canceledByCustomer",
         subscriptionId: alice.subscription[0].id,
-        recurringClassId: 1,
+        recurringClassId: aliceHelenRecurringClass.id,
         rebookableUntil: "2026-04-30T09:00:00Z",
         createdAt: "2025-05-20T07:00:00Z",
         updatedAt: "2025-05-20T07:00:00Z",
@@ -1734,7 +1775,7 @@ async function insertClasses() {
         dateTime: "2026-01-06T10:00:00Z",
         status: "canceledByInstructor",
         subscriptionId: alice.subscription[0].id,
-        recurringClassId: 1,
+        recurringClassId: aliceHelenRecurringClass.id,
         rebookableUntil: "2026-04-30T09:00:00Z",
         createdAt: "2025-05-20T07:00:00Z",
         updatedAt: "2025-05-20T07:00:00Z",
@@ -1747,7 +1788,7 @@ async function insertClasses() {
         dateTime: "2026-01-06T06:00:00Z",
         status: "completed",
         subscriptionId: alice.subscription[0].id,
-        recurringClassId: 1,
+        recurringClassId: aliceHelenRecurringClass.id,
         rebookableUntil: "2026-04-30T09:00:00Z",
         createdAt: "2025-05-20T07:00:00Z",
         updatedAt: "2025-05-20T07:00:00Z",
@@ -1773,6 +1814,63 @@ async function insertClasses() {
         updatedAt: "2025-05-20T07:00:00Z",
         classCode: "ft-0-2",
         isFreeTrial: true,
+      },
+      {
+        instructorId: helen.id,
+        customerId: alice.id,
+        dateTime: "2026-03-02T01:00:00Z",
+        status: "completed",
+        subscriptionId: alice.subscription[0].id,
+        createdAt: "2026-03-02T01:00:00Z",
+        updatedAt: "2026-03-05T10:00:00.000Z",
+        classCode: "payroll-1",
+        isFreeTrial: true,
+      },
+      {
+        instructorId: helen.id,
+        customerId: alice.id,
+        dateTime: "2026-03-10T03:00:00Z",
+        status: "completed",
+        subscriptionId: alice.subscription[0].id,
+        createdAt: "2026-03-10T03:00:00Z",
+        updatedAt: "2026-03-12T10:00:00.000Z",
+        classCode: "payroll-2",
+        isFreeTrial: false,
+      },
+      {
+        instructorId: helen.id,
+        customerId: alice.id,
+        dateTime: "2026-03-14T00:00:00Z",
+        status: "canceledByInstructor",
+        canceledAt: "2026-03-13T14:00:00Z",
+        subscriptionId: alice.subscription[0].id,
+        createdAt: "2026-03-13T14:00:00Z",
+        updatedAt: "2026-03-15T09:12:00.000Z",
+        classCode: "payroll-3",
+        isFreeTrial: false,
+      },
+      {
+        instructorId: helen.id,
+        customerId: alice.id,
+        dateTime: "2026-03-16T00:00:00Z",
+        status: "completed",
+        subscriptionId: alice.subscription[0].id,
+        createdAt: "2026-03-16T00:00:00Z",
+        updatedAt: "2026-03-20T03:00:00.000Z",
+        classCode: "payroll-4",
+        isFreeTrial: false,
+      },
+      {
+        instructorId: helen.id,
+        customerId: alice.id,
+        dateTime: "2026-03-19T23:00:00Z",
+        status: "canceledByInstructor",
+        canceledAt: "2026-03-19T15:30:00Z",
+        subscriptionId: alice.subscription[0].id,
+        createdAt: "2026-03-19T15:30:00Z",
+        updatedAt: "2026-03-28T03:00:00.000Z",
+        classCode: "payroll-5",
+        isFreeTrial: false,
       },
       // {
       //   instructorId: helen.id,
@@ -2706,6 +2804,32 @@ async function insertEvents() {
 }
 
 async function insertSchedules() {
+  const [noClassEvent, noClassRebookableEvent, themeClassWeekEvent] =
+    await Promise.all([
+      prisma.event.findFirst({
+        where: { name: "お休み / No Class" },
+        select: { id: true },
+      }),
+      prisma.event.findFirst({
+        where: { name: "お休み振替対象日 / No Class (Rebookable)" },
+        select: { id: true },
+      }),
+      prisma.event.findFirst({
+        where: { name: "テーマクラスウィーク / Theme Class Week" },
+        select: { id: true },
+      }),
+    ]);
+
+  if (!noClassEvent || !noClassRebookableEvent || !themeClassWeekEvent) {
+    throw new Error("Required events for business schedules were not found");
+  }
+
+  const legacyEventIdMap: Record<number, number> = {
+    2: noClassEvent.id,
+    3: noClassRebookableEvent.id,
+    4: themeClassWeekEvent.id,
+  };
+
   await prisma.schedule.createMany({
     data: [
       {
@@ -3332,7 +3456,10 @@ async function insertSchedules() {
         date: new Date("2025-12-31T00:00:00Z"),
         eventId: 2,
       },
-    ],
+    ].map((schedule) => ({
+      ...schedule,
+      eventId: legacyEventIdMap[schedule.eventId],
+    })),
   });
 }
 
@@ -3384,11 +3511,61 @@ async function getPlan(
 }
 
 async function deleteAll(table: Uncapitalize<Prisma.ModelName>) {
-  // Use raw SQL TRUNCATE to reset auto-increment sequences
-  const tableName = table.charAt(0).toUpperCase() + table.slice(1);
-  await prisma.$executeRawUnsafe(
-    `TRUNCATE TABLE "${tableName}" RESTART IDENTITY CASCADE`,
-  );
+  switch (table) {
+    case "admin":
+      await prisma.admin.deleteMany();
+      return;
+    case "child":
+      await prisma.child.deleteMany();
+      return;
+    case "class":
+      await prisma.class.deleteMany();
+      return;
+    case "classAttendance":
+      await prisma.classAttendance.deleteMany();
+      return;
+    case "customer":
+      await prisma.customer.deleteMany();
+      return;
+    case "event":
+      await prisma.event.deleteMany();
+      return;
+    case "instructor":
+      await prisma.instructor.deleteMany();
+      return;
+    case "instructorAbsence":
+      await prisma.instructorAbsence.deleteMany();
+      return;
+    case "instructorFee":
+      await prisma.instructorFee.deleteMany();
+      return;
+    case "instructorSchedule":
+      await prisma.instructorSchedule.deleteMany();
+      return;
+    case "instructorSlot":
+      await prisma.instructorSlot.deleteMany();
+      return;
+    case "plan":
+      await prisma.plan.deleteMany();
+      return;
+    case "recurringClass":
+      await prisma.recurringClass.deleteMany();
+      return;
+    case "recurringClassAttendance":
+      await prisma.recurringClassAttendance.deleteMany();
+      return;
+    case "schedule":
+      await prisma.schedule.deleteMany();
+      return;
+    case "subscription":
+      await prisma.subscription.deleteMany();
+      return;
+    case "systemStatus":
+      await prisma.systemStatus.deleteMany();
+      return;
+    default:
+      throw new Error(`Unsupported table for seed cleanup: ${table}`);
+  }
 }
 
 async function main() {
@@ -3406,6 +3583,7 @@ async function main() {
     await deleteAll("child");
     await deleteAll("subscription");
     await deleteAll("instructorSchedule");
+    await deleteAll("instructorFee");
     await deleteAll("schedule");
     await deleteAll("instructorAbsence");
 
@@ -3427,6 +3605,7 @@ async function main() {
     await insertSystemStatus();
 
     // Dependant on the above
+    await insertInstructorFees();
     await insertInstructorSchedules();
     await insertSubscriptions();
     await insertChildren();

--- a/backend/src/services/instructorPayrollService.ts
+++ b/backend/src/services/instructorPayrollService.ts
@@ -1,8 +1,6 @@
 import { prisma } from "../../prisma/prismaClient";
-import type {
-  InstructorPayrollResponse,
-  InstructorPayrollPeriod,
-} from "../../../shared/schemas/admins";
+import type { InstructorPayrollResponse } from "../../../shared/schemas/admins";
+import type { Status } from "../../generated/prisma";
 
 const PAYROLL_TIMEZONE = "Asia/Tokyo";
 const MONTH_FORMATTER = new Intl.DateTimeFormat("en-CA", {
@@ -16,11 +14,20 @@ type PayrollCategory = "trial" | "regular" | "cancel" | "cancelWithoutNotice";
 
 type PayrollClass = {
   id: number;
-  dateTime: Date;
+  dateTime: Date | null;
   updatedAt: Date;
   canceledAt: Date | null;
-  status: string;
+  status: Status;
   isFreeTrial: boolean;
+};
+
+type PayrollPeriodSummary = InstructorPayrollResponse["periods"][number];
+type PayrollClassWithDateTime = PayrollClass & { dateTime: Date };
+type PayrollTotals = {
+  trial: number;
+  regular: number;
+  cancel: number;
+  cancelWithoutNotice: number;
 };
 
 type PayrollFeeRecord = {
@@ -89,7 +96,7 @@ const getMonthBounds = (month: string) => {
 };
 
 const classifyPayrollCategory = (
-  payrollClass: PayrollClass,
+  payrollClass: PayrollClassWithDateTime,
 ): PayrollCategory | null => {
   if (payrollClass.status === "completed") {
     return payrollClass.isFreeTrial ? "trial" : "regular";
@@ -160,6 +167,8 @@ const emptyPeriodTotals = () => ({
   cancelWithoutNotice: 0,
 });
 
+const cloneTotals = (totals: PayrollTotals): PayrollTotals => ({ ...totals });
+
 const getCategoryFee = (fee: PayrollFeeRecord, category: PayrollCategory) => {
   switch (category) {
     case "trial":
@@ -177,12 +186,16 @@ const summarizePeriod = (
   periodName: "1-15" | "16-last",
   from: string,
   to: string,
-  classes: PayrollClass[],
+  classes: PayrollClassWithDateTime[],
   feeRecords: PayrollFeeRecord[],
-): InstructorPayrollPeriod => {
+): PayrollPeriodSummary => {
   const counts = emptyPeriodTotals();
   const subtotals = emptyPeriodTotals();
   const appliedFeePeriods = new Map<string, PayrollFeeRecord>();
+  const dailyBreakdown = new Map<
+    string,
+    { counts: PayrollTotals; total: number }
+  >();
   const currencies = new Set<string>();
   let total = 0;
   let sourceLastUpdatedAt: Date | null = null;
@@ -207,6 +220,14 @@ const summarizePeriod = (
     if (!sourceLastUpdatedAt || payrollClass.updatedAt > sourceLastUpdatedAt) {
       sourceLastUpdatedAt = payrollClass.updatedAt;
     }
+
+    const daySummary = dailyBreakdown.get(classDateInJst) ?? {
+      counts: emptyPeriodTotals(),
+      total: 0,
+    };
+    daySummary.counts[category] += 1;
+    daySummary.total += feeAmount;
+    dailyBreakdown.set(classDateInJst, daySummary);
   }
 
   if (currencies.size > 1) {
@@ -225,6 +246,13 @@ const summarizePeriod = (
     counts,
     subtotals,
     total,
+    dailyBreakdown: Array.from(dailyBreakdown.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([date, day]) => ({
+        date,
+        counts: cloneTotals(day.counts),
+        total: day.total,
+      })),
     appliedFeePeriods: Array.from(appliedFeePeriods.values()).sort((a, b) =>
       a.effectiveFrom.localeCompare(b.effectiveFrom),
     ),
@@ -292,14 +320,11 @@ export const getInstructorPayroll = async (
   }
 
   const feeRecords = fees.map(formatFeeRecord);
-  const payableClasses = classes
-    .filter(
-      (payrollClass): payrollClass is PayrollClass & { dateTime: Date } =>
-        payrollClass.dateTime !== null,
-    )
+  const payableClasses: PayrollClassWithDateTime[] = classes
+    .filter((payrollClass) => payrollClass.dateTime instanceof Date)
     .map((payrollClass) => ({
       ...payrollClass,
-      dateTime: payrollClass.dateTime,
+      dateTime: payrollClass.dateTime as Date,
     }));
 
   const firstHalfClasses = payableClasses.filter(

--- a/backend/src/test/api/admins/instructor-payroll.test.ts
+++ b/backend/src/test/api/admins/instructor-payroll.test.ts
@@ -124,6 +124,38 @@ describe("GET /admins/instructors/:id/payroll", () => {
             cancelWithoutNotice: 0,
           },
           total: 3500,
+          dailyBreakdown: [
+            {
+              date: "2026-03-02",
+              counts: {
+                trial: 1,
+                regular: 0,
+                cancel: 0,
+                cancelWithoutNotice: 0,
+              },
+              total: 1000,
+            },
+            {
+              date: "2026-03-10",
+              counts: {
+                trial: 0,
+                regular: 1,
+                cancel: 0,
+                cancelWithoutNotice: 0,
+              },
+              total: 2000,
+            },
+            {
+              date: "2026-03-14",
+              counts: {
+                trial: 0,
+                regular: 0,
+                cancel: 1,
+                cancelWithoutNotice: 0,
+              },
+              total: 500,
+            },
+          ],
           appliedFeePeriods: [
             {
               currency: "JPY",
@@ -154,6 +186,28 @@ describe("GET /admins/instructors/:id/payroll", () => {
             cancelWithoutNotice: 300,
           },
           total: 2800,
+          dailyBreakdown: [
+            {
+              date: "2026-03-16",
+              counts: {
+                trial: 0,
+                regular: 1,
+                cancel: 0,
+                cancelWithoutNotice: 0,
+              },
+              total: 2500,
+            },
+            {
+              date: "2026-03-20",
+              counts: {
+                trial: 0,
+                regular: 0,
+                cancel: 0,
+                cancelWithoutNotice: 1,
+              },
+              total: 300,
+            },
+          ],
           appliedFeePeriods: [
             {
               currency: "JPY",
@@ -258,6 +312,28 @@ describe("GET /admins/instructors/:id/payroll", () => {
         cancelWithoutNotice: 0,
       },
       total: 4200,
+      dailyBreakdown: [
+        {
+          date: "2026-03-05",
+          counts: {
+            trial: 0,
+            regular: 1,
+            cancel: 0,
+            cancelWithoutNotice: 0,
+          },
+          total: 2000,
+        },
+        {
+          date: "2026-03-12",
+          counts: {
+            trial: 0,
+            regular: 1,
+            cancel: 0,
+            cancelWithoutNotice: 0,
+          },
+          total: 2200,
+        },
+      ],
       appliedFeePeriods: [
         {
           currency: "JPY",
@@ -279,6 +355,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
         },
       ],
     });
+    expect(response.body.periods[1].dailyBreakdown).toEqual([]);
     expect(response.body.periods[1].appliedFeePeriods).toEqual([]);
   });
 

--- a/docs/instructor-payroll-design.md
+++ b/docs/instructor-payroll-design.md
@@ -342,7 +342,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 1: Data model
 
@@ -360,7 +360,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 2: Cancellation timestamp propagation
 
@@ -377,7 +377,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 3: Payroll backend
 
@@ -397,7 +397,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 4: Admin API
 
@@ -414,7 +414,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 5: Admin UI
 
@@ -432,7 +432,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ### Phase 6: Verification and cleanup
 
@@ -449,7 +449,7 @@ Tasks:
 
 Status:
 
-- [ ] not started
+- [x] completed
 
 ## Task Log
 
@@ -472,3 +472,6 @@ Use this section to update progress during implementation.
 - Added payroll loading and error states plus summary rendering for both payroll halves.
 - Fixed the instructor page tab container to tolerate missing breadcrumb context.
 - Verified the payroll API test passes, frontend lint passes, and the payroll tab renders in Playwright.
+- Added deterministic dummy seed data for payroll UI verification and updated the seed reset flow to use `deleteMany()` instead of Prisma raw `TRUNCATE`.
+- Refined the payroll tab labels and layout with a month selector and compact daily breakdown tables.
+- Confirmed instructor fee create/edit management is not part of this scope and remains the next follow-up task.

--- a/docs/instructor-payroll-design.md
+++ b/docs/instructor-payroll-design.md
@@ -467,3 +467,8 @@ Use this section to update progress during implementation.
 - Decided `422` errors return a short `code` and `message`.
 - Decided currency is stored as a string validated by `^[A-Z]{3}$`.
 - Decided no backfill is needed for missing `canceledAt` because the app is not yet released.
+- Merged backend payroll API work and fixed follow-up TypeScript issues in `instructorPayrollService`.
+- Added the admin instructor `Payroll` tab and frontend payroll fetch integration.
+- Added payroll loading and error states plus summary rendering for both payroll halves.
+- Fixed the instructor page tab container to tolerate missing breadcrumb context.
+- Verified the payroll API test passes, frontend lint passes, and the payroll tab renders in Playwright.

--- a/frontend/src/components/admins-dashboard/TabFunction.tsx
+++ b/frontend/src/components/admins-dashboard/TabFunction.tsx
@@ -33,6 +33,7 @@ const TabFunction: React.FC<{
   initialActiveTab?: number;
 }> = ({ tabs, breadcrumb, activeTabName, initialActiveTab = 0 }) => {
   const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTab);
+  const hasBreadcrumb = breadcrumb.length >= 3;
 
   const handleTabClick = (index: number, activeTabName: string) => {
     setActiveTabIndex(index);
@@ -41,17 +42,19 @@ const TabFunction: React.FC<{
 
   return (
     <>
-      <nav className={styles.breadcrumb}>
-        <ul className={styles.breadcrumb__list}>
-          <li className={styles.breadcrumb__item}>
-            <Link href={breadcrumb[1]} passHref>
-              {breadcrumb[0]}{" "}
-            </Link>
-          </li>
-          <li className={styles.breadcrumb__separator}>{" >> "}</li>
-          <li className={styles.breadcrumb__item}>{breadcrumb[2]}</li>
-        </ul>
-      </nav>
+      {hasBreadcrumb && (
+        <nav className={styles.breadcrumb}>
+          <ul className={styles.breadcrumb__list}>
+            <li className={styles.breadcrumb__item}>
+              <Link href={breadcrumb[1]} passHref>
+                {breadcrumb[0]}{" "}
+              </Link>
+            </li>
+            <li className={styles.breadcrumb__separator}>{" >> "}</li>
+            <li className={styles.breadcrumb__item}>{breadcrumb[2]}</li>
+          </ul>
+        </nav>
+      )}
       <div className={styles.tabWrapper}>
         <div className={styles.tabContainer}>
           {tabs.map((tab, index) => (

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
@@ -8,6 +8,7 @@ import { useTabSelect } from "@/hooks/useTabSelect";
 import InstructorSchedule from "./instructor-schedule/InstructorSchedule";
 import AvailabilityCalendar from "./instructor-schedule/AvailabilityCalendar";
 import Loading from "@/components/elements/loading/Loading";
+import InstructorPayroll from "./InstructorPayroll";
 import type { InstructorSchedule as InstructorScheduleType } from "@shared/schemas/instructors";
 import type { InstructorScheduleWithSlots } from "@/lib/api/instructorsApi";
 
@@ -95,6 +96,10 @@ export default function InstructorTabs({
           initialSelectedSchedule={initialSelectedSchedule}
         />
       ),
+    },
+    {
+      label: "Payroll",
+      content: <InstructorPayroll instructorId={instructorId} />,
     },
   ];
 

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.module.scss
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.module.scss
@@ -1,0 +1,196 @@
+@use "@/styles/variables.module.scss" as *;
+
+.container {
+  display: grid;
+  gap: 1rem;
+}
+
+.pageHeader {
+  display: flex;
+  justify-content: flex-start;
+  align-items: start;
+  gap: 1rem;
+}
+
+.monthInput {
+  min-width: 9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  background: #fff;
+}
+
+.pendingMessage {
+  margin: 0;
+  color: #475569;
+}
+
+.periodGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.periodCard {
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.periodSummary {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+  margin-bottom: 0.85rem;
+
+  h3 {
+    margin: 0;
+    font-size: 1.125rem;
+    color: #0f172a;
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    color: #475569;
+  }
+}
+
+.summaryStats {
+  display: grid;
+  justify-items: end;
+
+  strong {
+    font-size: 1.05rem;
+    color: #0f172a;
+  }
+}
+
+.breakdownSection,
+.feePeriodsSection {
+  h4 {
+    margin: 0 0 0.75rem;
+    color: #0f172a;
+  }
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.dailyBreakdownTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+
+  th,
+  td {
+    padding: 0.7rem;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+    vertical-align: top;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: #f8fafc;
+    color: #334155;
+    font-size: 0.95rem;
+  }
+
+  tbody th,
+  tfoot th {
+    color: #0f172a;
+    font-weight: 600;
+  }
+
+  tfoot th,
+  tfoot td {
+    border-bottom: none;
+    font-weight: 700;
+  }
+}
+
+.feePeriodsList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feeCard {
+  border: 1px solid #dbeafe;
+  border-radius: 0.75rem;
+  background: linear-gradient(180deg, #f8fbff 0%, #eff6ff 100%);
+  padding: 0.9rem;
+}
+
+.feeCardHeader {
+  display: grid;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  color: #1e3a8a;
+}
+
+.feeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+
+  dt {
+    font-size: 0.85rem;
+    color: #475569;
+  }
+
+  dd {
+    margin: 0.2rem 0 0;
+    font-weight: 600;
+    color: #0f172a;
+  }
+}
+
+.emptyMessage {
+  margin: 0 0 1rem;
+  color: #475569;
+}
+
+.errorBox {
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #9f1239;
+  border-radius: 0.75rem;
+  padding: 1rem;
+
+  strong {
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .pageHeader,
+  .periodSummary {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .summaryStats {
+    justify-items: start;
+  }
+
+  .feeGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1200px) {
+  .periodGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -47,7 +47,10 @@ const formatMoney = (amount: number, currency: string | null) => {
   }
 };
 
-const formatMoneyWithCurrencyCode = (amount: number, currency: string | null) => {
+const formatMoneyWithCurrencyCode = (
+  amount: number,
+  currency: string | null,
+) => {
   const formattedAmount = formatMoney(amount, currency);
 
   if (!currency) {
@@ -174,11 +177,7 @@ function DailyBreakdownTable({
   );
 }
 
-function PeriodCard({
-  period,
-}: {
-  period: InstructorPayrollPeriod;
-}) {
+function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
   return (
     <section className={styles.periodCard}>
       <div className={styles.periodSummary}>

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import Loading from "@/components/elements/loading/Loading";
+import {
+  getInstructorPayroll,
+  type InstructorPayrollApiError,
+} from "@/lib/api/adminsApi";
+import styles from "./InstructorPayroll.module.scss";
+import type {
+  InstructorPayrollDailyBreakdown,
+  InstructorPayrollPeriod,
+  InstructorPayrollResponse,
+} from "@shared/schemas/admins";
+
+const getCurrentJstMonth = () => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(new Date());
+
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+
+  if (!year || !month) {
+    throw new Error("Failed to determine current JST month");
+  }
+
+  return `${year}-${month}`;
+};
+
+const formatMoney = (amount: number, currency: string | null) => {
+  if (!currency) {
+    return amount.toLocaleString("en-US");
+  }
+
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toLocaleString("en-US")}`;
+  }
+};
+
+const formatMoneyWithCurrencyCode = (amount: number, currency: string | null) => {
+  const formattedAmount = formatMoney(amount, currency);
+
+  if (!currency) {
+    return formattedAmount;
+  }
+
+  return `${formattedAmount} (${currency})`;
+};
+
+const formatLastUpdatedLabel = (value: string | null) => {
+  if (!value) {
+    return "No payroll classes";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(value));
+};
+
+const formatDayLabel = (date: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Tokyo",
+    day: "2-digit",
+    weekday: "short",
+  })
+    .formatToParts(new Date(`${date}T00:00:00+09:00`))
+    .reduce(
+      (formatted, part) => {
+        if (part.type === "day") {
+          formatted.day = part.value;
+        }
+        if (part.type === "weekday") {
+          formatted.weekday = part.value;
+        }
+        return formatted;
+      },
+      { day: "", weekday: "" },
+    );
+
+const formatPeriodLabel = (from: string, to: string) => {
+  return `${from} to ${to}`;
+};
+
+function DailyBreakdownTable({
+  rows,
+  currency,
+}: {
+  rows: InstructorPayrollDailyBreakdown[];
+  currency: string | null;
+}) {
+  if (rows.length === 0) {
+    return (
+      <p className={styles.emptyMessage}>No payable classes in this period.</p>
+    );
+  }
+
+  const totals = rows.reduce(
+    (summary, row) => ({
+      trial: summary.trial + row.counts.trial,
+      regular: summary.regular + row.counts.regular,
+      cancel: summary.cancel + row.counts.cancel,
+      cancelWithoutNotice:
+        summary.cancelWithoutNotice + row.counts.cancelWithoutNotice,
+      total: summary.total + row.total,
+    }),
+    {
+      trial: 0,
+      regular: 0,
+      cancel: 0,
+      cancelWithoutNotice: 0,
+      total: 0,
+    },
+  );
+
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.dailyBreakdownTable}>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Trial</th>
+            <th>Regular</th>
+            <th>Cancel</th>
+            <th>Cancel Without Notice</th>
+            <th>Day Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const dayLabel = formatDayLabel(row.date);
+
+            return (
+              <tr key={row.date}>
+                <th scope="row">
+                  {dayLabel.day} ({dayLabel.weekday})
+                </th>
+                <td>{row.counts.trial}</td>
+                <td>{row.counts.regular}</td>
+                <td>{row.counts.cancel}</td>
+                <td>{row.counts.cancelWithoutNotice}</td>
+                <td>{formatMoney(row.total, currency)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+        <tfoot>
+          <tr>
+            <th scope="row">Total</th>
+            <td>{totals.trial}</td>
+            <td>{totals.regular}</td>
+            <td>{totals.cancel}</td>
+            <td>{totals.cancelWithoutNotice}</td>
+            <td>{formatMoney(totals.total, currency)}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
+function PeriodCard({
+  period,
+}: {
+  period: InstructorPayrollPeriod;
+}) {
+  return (
+    <section className={styles.periodCard}>
+      <div className={styles.periodSummary}>
+        <div>
+          <h3>{formatPeriodLabel(period.from, period.to)}</h3>
+        </div>
+        <div className={styles.summaryStats}>
+          <strong>
+            {formatMoneyWithCurrencyCode(period.total, period.currency)}
+          </strong>
+        </div>
+      </div>
+
+      <div className={styles.breakdownSection}>
+        <h4>
+          Daily Breakdown (Last Update at{" "}
+          {formatLastUpdatedLabel(period.sourceLastUpdatedAt)})
+        </h4>
+        <DailyBreakdownTable
+          rows={period.dailyBreakdown}
+          currency={period.currency}
+        />
+      </div>
+
+      <div className={styles.feePeriodsSection}>
+        <h4>Applied Fee Periods</h4>
+        {period.appliedFeePeriods.length === 0 ? (
+          <p className={styles.emptyMessage}>No fee periods used.</p>
+        ) : (
+          <div className={styles.feePeriodsList}>
+            {period.appliedFeePeriods.map((fee) => (
+              <article
+                key={`${fee.currency}-${fee.effectiveFrom}-${fee.effectiveTo ?? "open"}`}
+                className={styles.feeCard}
+              >
+                <div className={styles.feeCardHeader}>
+                  <strong>
+                    {fee.effectiveFrom} to {fee.effectiveTo ?? "Onwards"}
+                  </strong>
+                </div>
+                <dl className={styles.feeGrid}>
+                  <div>
+                    <dt>Trial</dt>
+                    <dd>{formatMoney(fee.trialFee, fee.currency)}</dd>
+                  </div>
+                  <div>
+                    <dt>Regular</dt>
+                    <dd>{formatMoney(fee.regularFee, fee.currency)}</dd>
+                  </div>
+                  <div>
+                    <dt>Cancel</dt>
+                    <dd>{formatMoney(fee.cancelFee, fee.currency)}</dd>
+                  </div>
+                  <div>
+                    <dt>Cancel Without Notice</dt>
+                    <dd>
+                      {formatMoney(fee.cancelWithoutNoticeFee, fee.currency)}
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default function InstructorPayroll({
+  instructorId,
+}: {
+  instructorId: number;
+}) {
+  const [selectedMonth, setSelectedMonth] = useState(() =>
+    getCurrentJstMonth(),
+  );
+  const [requestedMonth, setRequestedMonth] = useState(() =>
+    getCurrentJstMonth(),
+  );
+  const [payroll, setPayroll] = useState<InstructorPayrollResponse | null>(
+    null,
+  );
+  const [error, setError] = useState<InstructorPayrollApiError | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadPayroll = async () => {
+      setIsLoading(true);
+      const response = await getInstructorPayroll(instructorId, requestedMonth);
+
+      if (!isMounted) {
+        return;
+      }
+
+      if ("status" in response) {
+        setPayroll(null);
+        setError(response);
+      } else {
+        setPayroll(response);
+        setError(null);
+      }
+
+      setIsLoading(false);
+    };
+
+    loadPayroll();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [instructorId, requestedMonth]);
+
+  const handleMonthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedMonth(event.target.value);
+    startTransition(() => {
+      setRequestedMonth(event.target.value);
+    });
+  };
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <section className={styles.container}>
+      <header className={styles.pageHeader}>
+        <input
+          type="month"
+          value={selectedMonth}
+          onChange={handleMonthChange}
+          className={styles.monthInput}
+          aria-label="Select payroll month"
+        />
+      </header>
+
+      {isPending && <p className={styles.pendingMessage}>Loading payroll…</p>}
+
+      {error ? (
+        <div className={styles.errorBox}>
+          <strong>{error.code}</strong>
+          <p>{error.message}</p>
+        </div>
+      ) : payroll ? (
+        <div className={styles.periodGrid}>
+          {payroll.periods.map((period) => (
+            <PeriodCard key={`${period.from}-${period.to}`} period={period} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -7,6 +7,8 @@ import { ERROR_PAGE_MESSAGE_EN } from "../messages/generalMessages";
 import {
   type AdminResponse,
   type AdminsListResponse,
+  type InstructorPayrollErrorResponse,
+  type InstructorPayrollResponse,
   type InstructorsListResponse,
   type PastInstructorsListResponse,
   type CustomersListResponse,
@@ -28,6 +30,9 @@ const BACKEND_ORIGIN =
 const BASE_URL = `${BACKEND_ORIGIN}/admins`;
 
 type Response<T> = T | { message: string };
+export type InstructorPayrollApiError = InstructorPayrollErrorResponse & {
+  status: number;
+};
 
 export const getAdminById = async (
   id: number,
@@ -576,6 +581,66 @@ export const getAllBusinessSchedules = async (
   } catch (error) {
     console.error("Failed to fetch schedules:", error);
     throw error;
+  }
+};
+
+export const getInstructorPayroll = async (
+  instructorId: number,
+  month: string,
+  cookie?: string,
+): Promise<InstructorPayrollResponse | InstructorPayrollApiError> => {
+  try {
+    let apiURL;
+    let headers;
+    let response;
+    const method = "GET";
+    const backendEndpoint = `/admins/instructors/${instructorId}/payroll?month=${month}`;
+
+    if (cookie) {
+      apiURL = `${BACKEND_ORIGIN}${backendEndpoint}`;
+      headers = { "Content-Type": "application/json", Cookie: cookie };
+      response = await fetch(apiURL, {
+        method,
+        headers,
+        cache: "no-store",
+      });
+    } else {
+      apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
+      headers = {
+        "Content-Type": "application/json",
+        "backend-endpoint": backendEndpoint,
+        "no-cache": "true",
+      };
+      response = await fetch(apiURL, {
+        method,
+        headers,
+      });
+    }
+
+    const data = await response.json();
+
+    if (response.status !== 200) {
+      return {
+        status: response.status,
+        code:
+          typeof data?.code === "string"
+            ? data.code
+            : "INSTRUCTOR_PAYROLL_ERROR",
+        message:
+          typeof data?.message === "string"
+            ? data.message
+            : `HTTP error! status: ${response.status}`,
+      };
+    }
+
+    return data as InstructorPayrollResponse;
+  } catch (error) {
+    console.error("Failed to fetch instructor payroll:", error);
+    return {
+      status: 500,
+      code: "INSTRUCTOR_PAYROLL_ERROR",
+      message: GENERAL_ERROR_MESSAGE,
+    };
   }
 };
 

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -523,6 +523,13 @@ export type AdminProfile = z.infer<typeof AdminProfile>;
 export type AdminResponse = z.infer<typeof AdminResponse>;
 export type AdminsListResponse = z.infer<typeof AdminsListResponse>;
 export type InstructorsListResponse = z.infer<typeof InstructorsListResponse>;
+export type InstructorPayrollFeePeriod = z.infer<
+  typeof InstructorPayrollFeePeriod
+>;
+export type InstructorPayrollDailyBreakdown = z.infer<
+  typeof InstructorPayrollDailyBreakdown
+>;
+export type InstructorPayrollPeriod = z.infer<typeof InstructorPayrollPeriod>;
 export type InstructorPayrollResponse = z.infer<
   typeof InstructorPayrollResponse
 >;

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -204,6 +204,17 @@ export const InstructorPayrollFeePeriod = z.object({
   cancelWithoutNoticeFee: z.number().int(),
 });
 
+export const InstructorPayrollDailyBreakdown = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  counts: z.object({
+    trial: z.number().int().nonnegative(),
+    regular: z.number().int().nonnegative(),
+    cancel: z.number().int().nonnegative(),
+    cancelWithoutNotice: z.number().int().nonnegative(),
+  }),
+  total: z.number().int().nonnegative(),
+});
+
 export const InstructorPayrollPeriod = z.object({
   from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
@@ -225,6 +236,7 @@ export const InstructorPayrollPeriod = z.object({
     cancelWithoutNotice: z.number().int().nonnegative(),
   }),
   total: z.number().int().nonnegative(),
+  dailyBreakdown: z.array(InstructorPayrollDailyBreakdown),
   appliedFeePeriods: z.array(InstructorPayrollFeePeriod),
 });
 


### PR DESCRIPTION
## Summary
- add the admin instructor payroll tab with month-based fetching, compact daily breakdown tables, and applied fee period summaries
- finalize the backend payroll response shape and tests, plus seed deterministic dummy payroll data for UI verification
- document the implemented payroll phases and note that fee create/edit management remains follow-up scope

## Testing
- cd backend && npm run test -- src/test/api/admins/instructor-payroll.test.ts
- cd frontend && npm run format
- cd frontend && npm run lint