### PR TITLE
Add admin instructor fee rate management UI

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -27,6 +27,12 @@ import {
   getInstructorPayroll,
   InstructorPayrollError,
 } from "../services/instructorPayrollService";
+import {
+  createInstructorFee,
+  deleteLatestInstructorFee,
+  getInstructorFees,
+  InstructorFeeError,
+} from "../services/instructorFeeService";
 import { getClassesWithinPeriod } from "../services/classesService";
 import {
   getAllCustomers,
@@ -58,6 +64,7 @@ import type {
   CustomerIdParams,
   InstructorIdParams,
   InstructorPayrollQuery,
+  CreateInstructorFeeRequest,
   PlanIdParams,
   EventIdParams,
   RegisterAdminRequest,
@@ -375,6 +382,82 @@ export const getInstructorPayrollController = async (
       error,
       instructorId: req.params.id,
       month: req.query.month,
+    });
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const getInstructorFeesController = async (
+  req: RequestWithParams<InstructorIdParams>,
+  res: Response,
+) => {
+  try {
+    const fees = await getInstructorFees(req.params.id);
+    return res.status(200).json(fees);
+  } catch (error) {
+    if (error instanceof InstructorFeeError) {
+      return res.status(error.statusCode).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    console.error("Failed to fetch instructor fees", {
+      error,
+      instructorId: req.params.id,
+    });
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const createInstructorFeeController = async (
+  req: RequestWith<InstructorIdParams, CreateInstructorFeeRequest>,
+  res: Response,
+) => {
+  try {
+    const fee = await createInstructorFee(req.params.id, req.body);
+    return res.status(201).json({
+      message: "Instructor fee rate created successfully",
+      fee,
+    });
+  } catch (error) {
+    if (error instanceof InstructorFeeError) {
+      return res.status(error.statusCode).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    console.error("Failed to create instructor fee", {
+      error,
+      instructorId: req.params.id,
+      body: req.body,
+    });
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const deleteLatestInstructorFeeController = async (
+  req: RequestWithParams<InstructorIdParams>,
+  res: Response,
+) => {
+  try {
+    const result = await deleteLatestInstructorFee(req.params.id);
+    return res.status(200).json({
+      message: "Latest instructor fee rate deleted successfully",
+      ...result,
+    });
+  } catch (error) {
+    if (error instanceof InstructorFeeError) {
+      return res.status(error.statusCode).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    console.error("Failed to delete latest instructor fee", {
+      error,
+      instructorId: req.params.id,
     });
     return res.status(500).json({ message: "Internal server error" });
   }

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -16,6 +16,9 @@ import {
   getAllAdminsController,
   getAllInstructorsController,
   getInstructorPayrollController,
+  getInstructorFeesController,
+  createInstructorFeeController,
+  deleteLatestInstructorFeeController,
   getAllPastInstructorsController,
   getAllCustomersController,
   getAllPastCustomersController,
@@ -44,8 +47,13 @@ import {
   CustomerIdParams,
   InstructorIdParams,
   InstructorPayrollQuery,
+  CreateInstructorFeeRequest,
   InstructorPayrollResponse,
   InstructorPayrollErrorResponse,
+  InstructorFeeRatesResponse,
+  CreateInstructorFeeResponse,
+  DeleteLatestInstructorFeeResponse,
+  InstructorFeeErrorResponse,
   PlanIdParams,
   EventIdParams,
   RegisterAdminRequest,
@@ -420,6 +428,106 @@ const getInstructorPayrollConfig = {
       422: {
         description: "Payroll data cannot be resolved",
         schema: InstructorPayrollErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: ErrorResponse,
+      },
+    },
+  },
+} as const;
+
+const getInstructorFeesConfig = {
+  method: "get" as const,
+  paramsSchema: InstructorIdParams,
+  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  handler: getInstructorFeesController,
+  openapi: {
+    summary: "Get instructor fee history",
+    description: "Get fee history for one instructor",
+    responses: {
+      200: {
+        description: "Instructor fee history retrieved successfully",
+        schema: InstructorFeeRatesResponse,
+      },
+      401: {
+        description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Instructor not found",
+        schema: MessageErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: ErrorResponse,
+      },
+    },
+  },
+} as const;
+
+const createInstructorFeeConfig = {
+  method: "post" as const,
+  paramsSchema: InstructorIdParams,
+  bodySchema: CreateInstructorFeeRequest,
+  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  handler: createInstructorFeeController,
+  openapi: {
+    summary: "Create instructor fee rate",
+    description: "Create a new latest instructor fee rate",
+    responses: {
+      201: {
+        description: "Instructor fee rate created successfully",
+        schema: CreateInstructorFeeResponse,
+      },
+      400: {
+        description: "Invalid request data",
+        schema: MessageErrorResponse,
+      },
+      401: {
+        description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Instructor not found",
+        schema: MessageErrorResponse,
+      },
+      409: {
+        description: "Fee rate cannot be created",
+        schema: InstructorFeeErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: ErrorResponse,
+      },
+    },
+  },
+} as const;
+
+const deleteLatestInstructorFeeConfig = {
+  method: "delete" as const,
+  paramsSchema: InstructorIdParams,
+  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  handler: deleteLatestInstructorFeeController,
+  openapi: {
+    summary: "Delete latest instructor fee rate",
+    description: "Delete the latest instructor fee rate and reopen the previous one",
+    responses: {
+      200: {
+        description: "Latest instructor fee rate deleted successfully",
+        schema: DeleteLatestInstructorFeeResponse,
+      },
+      401: {
+        description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Instructor not found",
+        schema: MessageErrorResponse,
+      },
+      409: {
+        description: "Latest fee rate cannot be deleted",
+        schema: InstructorFeeErrorResponse,
       },
       500: {
         description: "Internal server error",
@@ -970,6 +1078,8 @@ const validatedRouteConfigs = {
   "/event-list/register": [registerEventConfig],
   "/event-list/update/:id": [updateEventConfig],
   "/instructor-list": [getAllInstructorsConfig],
+  "/instructors/:id/fees": [getInstructorFeesConfig, createInstructorFeeConfig],
+  "/instructors/:id/fees/latest": [deleteLatestInstructorFeeConfig],
   "/instructors/:id/payroll": [getInstructorPayrollConfig],
   "/instructor-list/past": [getAllPastInstructorsConfig],
   "/instructor-list/register": [registerInstructorConfig],

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -511,7 +511,8 @@ const deleteLatestInstructorFeeConfig = {
   handler: deleteLatestInstructorFeeController,
   openapi: {
     summary: "Delete latest instructor fee rate",
-    description: "Delete the latest instructor fee rate and reopen the previous one",
+    description:
+      "Delete the latest instructor fee rate and reopen the previous one",
     responses: {
       200: {
         description: "Latest instructor fee rate deleted successfully",

--- a/backend/src/services/instructorFeeService.ts
+++ b/backend/src/services/instructorFeeService.ts
@@ -1,0 +1,174 @@
+import { prisma } from "../../prisma/prismaClient";
+import type {
+  CreateInstructorFeeRequest,
+  InstructorFeeRate,
+  InstructorFeeRatesResponse,
+} from "../../../shared/schemas/admins";
+
+const JST_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+export class InstructorFeeError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const formatDateInJst = (date: Date) => {
+  const parts = JST_DATE_FORMATTER.formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+
+  if (!year || !month || !day) {
+    throw new Error("Failed to format JST date");
+  }
+
+  return `${year}-${month}-${day}`;
+};
+
+const toDateOnlyUtc = (value: string) => new Date(`${value}T00:00:00.000Z`);
+
+const mapFeeRate = (fee: {
+  id: number;
+  currency: string;
+  effectiveFrom: Date;
+  effectiveTo: Date | null;
+  trialFee: number;
+  regularFee: number;
+  cancelFee: number;
+  cancelWithoutNoticeFee: number;
+}): InstructorFeeRate => ({
+  id: fee.id,
+  currency: fee.currency,
+  effectiveFrom: formatDateInJst(fee.effectiveFrom),
+  effectiveTo: fee.effectiveTo ? formatDateInJst(fee.effectiveTo) : null,
+  trialFee: fee.trialFee,
+  regularFee: fee.regularFee,
+  cancelFee: fee.cancelFee,
+  cancelWithoutNoticeFee: fee.cancelWithoutNoticeFee,
+});
+
+const assertInstructorExists = async (instructorId: number) => {
+  const instructor = await prisma.instructor.findUnique({
+    where: { id: instructorId },
+    select: { id: true },
+  });
+
+  if (!instructor) {
+    throw new InstructorFeeError(
+      404,
+      "INSTRUCTOR_NOT_FOUND",
+      "Instructor not found",
+    );
+  }
+};
+
+export const getInstructorFees = async (
+  instructorId: number,
+): Promise<InstructorFeeRatesResponse> => {
+  await assertInstructorExists(instructorId);
+
+  const fees = await prisma.instructorFee.findMany({
+    where: { instructorId },
+    orderBy: [{ effectiveFrom: "desc" }, { id: "desc" }],
+  });
+
+  return {
+    instructorId,
+    fees: fees.map(mapFeeRate),
+  };
+};
+
+export const createInstructorFee = async (
+  instructorId: number,
+  data: CreateInstructorFeeRequest,
+) => {
+  await assertInstructorExists(instructorId);
+
+  const effectiveFrom = toDateOnlyUtc(data.effectiveFrom);
+
+  return await prisma.$transaction(async (tx) => {
+    const latestFee = await tx.instructorFee.findFirst({
+      where: { instructorId },
+      orderBy: [{ effectiveFrom: "desc" }, { id: "desc" }],
+    });
+
+    if (
+      latestFee &&
+      effectiveFrom.getTime() <= latestFee.effectiveFrom.getTime()
+    ) {
+      throw new InstructorFeeError(
+        409,
+        "INVALID_EFFECTIVE_FROM",
+        "effectiveFrom must be later than the latest fee rate",
+      );
+    }
+
+    if (latestFee) {
+      await tx.instructorFee.update({
+        where: { id: latestFee.id },
+        data: { effectiveTo: effectiveFrom },
+      });
+    }
+
+    const createdFee = await tx.instructorFee.create({
+      data: {
+        instructorId,
+        currency: data.currency,
+        effectiveFrom,
+        effectiveTo: null,
+        trialFee: data.trialFee,
+        regularFee: data.regularFee,
+        cancelFee: data.cancelFee,
+        cancelWithoutNoticeFee: data.cancelWithoutNoticeFee,
+      },
+    });
+
+    return mapFeeRate(createdFee);
+  });
+};
+
+export const deleteLatestInstructorFee = async (instructorId: number) => {
+  await assertInstructorExists(instructorId);
+
+  return await prisma.$transaction(async (tx) => {
+    const fees = await tx.instructorFee.findMany({
+      where: { instructorId },
+      orderBy: [{ effectiveFrom: "desc" }, { id: "desc" }],
+      take: 2,
+    });
+
+    const [latestFee, previousFee] = fees;
+
+    if (!latestFee || !previousFee) {
+      throw new InstructorFeeError(
+        409,
+        "LATEST_FEE_DELETE_NOT_ALLOWED",
+        "At least two fee rates are required to delete the latest rate",
+      );
+    }
+
+    await tx.instructorFee.delete({
+      where: { id: latestFee.id },
+    });
+
+    await tx.instructorFee.update({
+      where: { id: previousFee.id },
+      data: { effectiveTo: null },
+    });
+
+    return {
+      deletedFeeId: latestFee.id,
+      reactivatedFeeId: previousFee.id,
+    };
+  });
+};

--- a/backend/src/test/api/admins/instructor-fees.test.ts
+++ b/backend/src/test/api/admins/instructor-fees.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { server } from "../../../server";
+import {
+  createAdmin,
+  createInstructor,
+  createInstructorFee,
+  generateAuthCookie,
+} from "../../testUtils";
+import { prisma } from "../../setup";
+
+describe("GET /admins/instructors/:id/fees", () => {
+  it("returns instructor fee history in descending effective order", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+
+    const olderFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-02-01T00:00:00.000Z"),
+      regularFee: 1800,
+    });
+    const latestFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-02-01T00:00:00.000Z"),
+      effectiveTo: null,
+      regularFee: 2000,
+    });
+
+    const response = await request(server)
+      .get(`/admins/instructors/${instructor.id}/fees`)
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      instructorId: instructor.id,
+      fees: [
+        expect.objectContaining({
+          id: latestFee.id,
+          effectiveFrom: "2026-02-01",
+          effectiveTo: null,
+          regularFee: 2000,
+        }),
+        expect.objectContaining({
+          id: olderFee.id,
+          effectiveFrom: "2026-01-01",
+          effectiveTo: "2026-02-01",
+          regularFee: 1800,
+        }),
+      ],
+    });
+  });
+});
+
+describe("POST /admins/instructors/:id/fees", () => {
+  it("creates a new latest fee rate and ends the previous rate", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+
+    const previousFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: null,
+      regularFee: 1900,
+    });
+
+    const response = await request(server)
+      .post(`/admins/instructors/${instructor.id}/fees`)
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .send({
+        currency: "JPY",
+        effectiveFrom: "2026-03-01",
+        trialFee: 1200,
+        regularFee: 2200,
+        cancelFee: 600,
+        cancelWithoutNoticeFee: 300,
+      })
+      .expect(201);
+
+    expect(response.body).toEqual({
+      message: "Instructor fee rate created successfully",
+      fee: {
+        id: expect.any(Number),
+        currency: "JPY",
+        effectiveFrom: "2026-03-01",
+        effectiveTo: null,
+        trialFee: 1200,
+        regularFee: 2200,
+        cancelFee: 600,
+        cancelWithoutNoticeFee: 300,
+      },
+    });
+
+    const updatedPreviousFee = await prisma.instructorFee.findUniqueOrThrow({
+      where: { id: previousFee.id },
+    });
+
+    expect(updatedPreviousFee.effectiveTo?.toISOString()).toBe(
+      "2026-03-01T00:00:00.000Z",
+    );
+  });
+
+  it("returns 409 when effectiveFrom is not later than the latest fee rate", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+
+    await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
+      effectiveTo: null,
+    });
+
+    const response = await request(server)
+      .post(`/admins/instructors/${instructor.id}/fees`)
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .send({
+        currency: "JPY",
+        effectiveFrom: "2026-02-28",
+        trialFee: 1000,
+        regularFee: 1000,
+        cancelFee: 500,
+        cancelWithoutNoticeFee: 0,
+      })
+      .expect(409);
+
+    expect(response.body).toEqual({
+      code: "INVALID_EFFECTIVE_FROM",
+      message: "effectiveFrom must be later than the latest fee rate",
+    });
+  });
+});
+
+describe("DELETE /admins/instructors/:id/fees/latest", () => {
+  it("deletes the latest fee rate and reopens the previous one", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+
+    const previousFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-02-01T00:00:00.000Z"),
+    });
+    const latestFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-02-01T00:00:00.000Z"),
+      effectiveTo: null,
+    });
+
+    const response = await request(server)
+      .delete(`/admins/instructors/${instructor.id}/fees/latest`)
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      message: "Latest instructor fee rate deleted successfully",
+      deletedFeeId: latestFee.id,
+      reactivatedFeeId: previousFee.id,
+    });
+
+    const reloadedPreviousFee = await prisma.instructorFee.findUniqueOrThrow({
+      where: { id: previousFee.id },
+    });
+    const deletedFee = await prisma.instructorFee.findUnique({
+      where: { id: latestFee.id },
+    });
+
+    expect(reloadedPreviousFee.effectiveTo).toBeNull();
+    expect(deletedFee).toBeNull();
+  });
+
+  it("returns 409 when there is no previous fee rate to reopen", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+
+    await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: null,
+    });
+
+    const response = await request(server)
+      .delete(`/admins/instructors/${instructor.id}/fees/latest`)
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .expect(409);
+
+    expect(response.body).toEqual({
+      code: "LATEST_FEE_DELETE_NOT_ALLOWED",
+      message: "At least two fee rates are required to delete the latest rate",
+    });
+  });
+});

--- a/docs/instructor-payroll-design.md
+++ b/docs/instructor-payroll-design.md
@@ -43,6 +43,7 @@ The feature must show not only the total amount to pay, but also the reasoning b
 6. `canceledAt` is used only to classify instructor cancellations as normal cancel vs cancel without notice.
 7. `canceledByCustomer` does not contribute to instructor pay.
 8. Payroll boundaries and cancellation deadline use Japan time (`Asia/Tokyo`).
+9. Fee history editing may change historical payroll inputs. v1 does not guarantee payroll consistency after fee edits; admins are responsible for reviewing and correcting any downstream impact.
 
 ## Business Rules
 
@@ -138,6 +139,13 @@ Proposed constraints:
 - no overlapping fee periods for the same instructor
 - open-ended active period allowed via `effectiveTo = null`
 - every payable class must match exactly one fee record
+
+Editing behavior:
+
+- admins can add a new fee record with a new `effectiveFrom`
+- admins can delete only the latest fee record as an undo operation
+- deleting the latest fee record reopens the previous fee record by setting its `effectiveTo` back to `null`
+- v1 does not block fee edits or deletes based on payroll impact; admins are responsible for maintaining payroll consistency after changes
 
 Currency behavior:
 
@@ -451,6 +459,26 @@ Status:
 
 - [x] completed
 
+### Phase 7: Fee Rate Management UI
+
+Goal:
+
+- allow admins to manage instructor fee history from the instructor admin page
+
+Tasks:
+
+- show the current active fee rate in the `Instructor's Profile` tab
+- show fee rate history with effective periods in a collapsed-by-default section
+- add a compact form to create a new fee rate with a new `effectiveFrom`
+- add latest-rate delete as an undo operation
+- when deleting the latest fee rate, set the previous rate `effectiveTo` back to `null`
+- show loading, success, and error states for fee rate mutations
+- document that admins are responsible for any payroll consistency impact caused by fee edits
+
+Status:
+
+- [x] completed
+
 ## Task Log
 
 Use this section to update progress during implementation.
@@ -460,6 +488,10 @@ Use this section to update progress during implementation.
 - Drafted v1 design and agreed product decisions.
 - Clarified that cancel penalties apply only to `canceledByInstructor`.
 - Confirmed current cancellation deadline rule is based on JST same-day boundary, not rolling 24 hours.
+- Added Phase 7 for fee rate management in the admin instructor profile.
+- Implemented admin instructor fee history endpoints for list, create-latest, and delete-latest undo flows.
+- Added the fee rate section to the admin `Instructor's Profile` tab with current rate, collapsed history, and compact mutation UI.
+- Verified instructor fee API tests, existing payroll API tests, and frontend lint pass.
 - Agreed that fee record selection uses class `dateTime`.
 - Agreed to add `Class.canceledAt`.
 - Added fee `currency` to the payroll design. No conversion in v1.

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { toast } from "react-toastify";
+import ActionButton from "../../elements/buttons/actionButton/ActionButton";
+import {
+  createInstructorFee,
+  deleteLatestInstructorFee,
+  getInstructorFees,
+} from "@/lib/api/adminsApi";
+import { confirmAlert, errorAlert } from "@/lib/utils/alertUtils";
+import type { InstructorFeeRate } from "@shared/schemas/admins";
+import styles from "./InstructorProfile.module.scss";
+
+const DEFAULT_CURRENCY = "JPY";
+
+const formatMoney = (amount: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toLocaleString("en-US")}`;
+  }
+};
+
+const formatPeriod = (fee: InstructorFeeRate) =>
+  `${fee.effectiveFrom} to ${fee.effectiveTo ?? "Onwards"}`;
+
+const createFormState = (fee?: InstructorFeeRate | null) => ({
+  currency: fee?.currency ?? DEFAULT_CURRENCY,
+  effectiveFrom: "",
+  trialFee: String(fee?.trialFee ?? 0),
+  regularFee: String(fee?.regularFee ?? 0),
+  cancelFee: String(fee?.cancelFee ?? 0),
+  cancelWithoutNoticeFee: String(fee?.cancelWithoutNoticeFee ?? 0),
+});
+
+function FeeRateCard({
+  fee,
+}: {
+  fee: InstructorFeeRate;
+}) {
+  return (
+    <article className={styles.feeCard}>
+      <div className={styles.feeCardHeader}>
+        <div>
+          <strong>{formatPeriod(fee)}</strong>
+        </div>
+        <span className={styles.feeCurrency}>{fee.currency}</span>
+      </div>
+      <dl className={styles.feeGrid}>
+        <div>
+          <dt>Trial</dt>
+          <dd>{formatMoney(fee.trialFee, fee.currency)}</dd>
+        </div>
+        <div>
+          <dt>Regular</dt>
+          <dd>{formatMoney(fee.regularFee, fee.currency)}</dd>
+        </div>
+        <div>
+          <dt>Cancel</dt>
+          <dd>{formatMoney(fee.cancelFee, fee.currency)}</dd>
+        </div>
+        <div>
+          <dt>Cancel Without Notice</dt>
+          <dd>{formatMoney(fee.cancelWithoutNoticeFee, fee.currency)}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export default function InstructorFeeRates({
+  instructorId,
+}: {
+  instructorId: number;
+}) {
+  const [fees, setFees] = useState<InstructorFeeRate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [formState, setFormState] = useState(createFormState());
+
+  const applyFees = (nextFees: InstructorFeeRate[]) => {
+    setFees(nextFees);
+    setFormState(createFormState(nextFees[0] ?? null));
+  };
+
+  const loadFees = async () => {
+    setIsLoading(true);
+    const response = await getInstructorFees(instructorId);
+    if ("status" in response) {
+      setIsLoading(false);
+      await errorAlert(response.message);
+      return;
+    }
+
+    applyFees(response.fees);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    let isMounted = true;
+
+    getInstructorFees(instructorId).then(async (response) => {
+      if (!isMounted) {
+        return;
+      }
+
+      if ("status" in response) {
+        setIsLoading(false);
+        await errorAlert(response.message);
+        return;
+      }
+
+      applyFees(response.fees);
+      setIsLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [instructorId]);
+
+  const activeFee = fees.find((fee) => fee.effectiveTo === null) ?? fees[0];
+  const historicalFees = activeFee
+    ? fees.filter((fee) => fee.id !== activeFee.id)
+    : [];
+
+  const handleFormChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCreateFee = async () => {
+    const trialFee = Number(formState.trialFee);
+    const regularFee = Number(formState.regularFee);
+    const cancelFee = Number(formState.cancelFee);
+    const cancelWithoutNoticeFee = Number(formState.cancelWithoutNoticeFee);
+
+    if (
+      !formState.effectiveFrom ||
+      [trialFee, regularFee, cancelFee, cancelWithoutNoticeFee].some(
+        (value) => !Number.isInteger(value) || value < 0,
+      )
+    ) {
+      await errorAlert(
+        "Enter an effective date and non-negative integer amounts for all fee fields.",
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+    const response = await createInstructorFee(instructorId, {
+      currency: formState.currency,
+      effectiveFrom: formState.effectiveFrom,
+      trialFee,
+      regularFee,
+      cancelFee,
+      cancelWithoutNoticeFee,
+    });
+    setIsSubmitting(false);
+
+    if ("status" in response) {
+      await errorAlert(response.message);
+      return;
+    }
+
+    toast.success(response.message);
+    setIsFormOpen(false);
+    await loadFees();
+  };
+
+  const handleDeleteLatest = async () => {
+    if (!activeFee || fees.length < 2) {
+      return;
+    }
+
+    const confirmed = await confirmAlert(
+      `Delete the latest fee rate for ${formatPeriod(activeFee)}?<br /><br />This may change payroll results.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    const response = await deleteLatestInstructorFee(instructorId);
+    setIsSubmitting(false);
+
+    if ("status" in response) {
+      await errorAlert(response.message);
+      return;
+    }
+
+    toast.success(response.message);
+    await loadFees();
+  };
+
+  return (
+    <div className={styles.insideContainer}>
+      <BanknotesIcon className={styles.icon} />
+      <div className={styles.userInfo}>
+        <p>Fee Rates</p>
+        <div className={styles.feeSection}>
+          {isLoading ? (
+            <p className={styles.feeMutedText}>Loading fee rates...</p>
+          ) : activeFee ? (
+            <FeeRateCard fee={activeFee} />
+          ) : (
+            <p className={styles.feeMutedText}>No fee rates registered yet.</p>
+          )}
+
+          <div className={styles.feeActions}>
+            <ActionButton
+              type="button"
+              onClick={() => setIsFormOpen((prev) => !prev)}
+              btnText={isFormOpen ? "Cancel new rate" : "Change fee rate"}
+              className={isFormOpen ? "cancelBtn" : "addBtn"}
+              disabled={isSubmitting}
+            />
+            <ActionButton
+              type="button"
+              onClick={handleDeleteLatest}
+              btnText="Delete latest rate"
+              className="deleteBtn"
+              disabled={isSubmitting || fees.length < 2}
+            />
+          </div>
+
+          {isFormOpen && (
+            <div className={styles.feeForm}>
+              <div className={styles.feeFormGrid}>
+                <label>
+                  Currency
+                  <input
+                    name="currency"
+                    value={formState.currency}
+                    onChange={handleFormChange}
+                    maxLength={3}
+                    placeholder="JPY"
+                  />
+                  <span className={styles.feeFieldHint}>
+                    Use a 3-letter currency code, for example "JPY".
+                  </span>
+                </label>
+                <label>
+                  Effective From
+                  <input
+                    type="date"
+                    name="effectiveFrom"
+                    value={formState.effectiveFrom}
+                    onChange={handleFormChange}
+                  />
+                </label>
+                <label>
+                  Trial Fee
+                  <input
+                    type="number"
+                    name="trialFee"
+                    min="0"
+                    step="1"
+                    value={formState.trialFee}
+                    onChange={handleFormChange}
+                  />
+                </label>
+                <label>
+                  Regular Fee
+                  <input
+                    type="number"
+                    name="regularFee"
+                    min="0"
+                    step="1"
+                    value={formState.regularFee}
+                    onChange={handleFormChange}
+                  />
+                </label>
+                <label>
+                  Cancel Fee
+                  <input
+                    type="number"
+                    name="cancelFee"
+                    min="0"
+                    step="1"
+                    value={formState.cancelFee}
+                    onChange={handleFormChange}
+                  />
+                </label>
+                <label>
+                  Cancel Without Notice Fee
+                  <input
+                    type="number"
+                    name="cancelWithoutNoticeFee"
+                    min="0"
+                    step="1"
+                    value={formState.cancelWithoutNoticeFee}
+                    onChange={handleFormChange}
+                  />
+                </label>
+              </div>
+              <div className={styles.feeActions}>
+                <ActionButton
+                  type="button"
+                  onClick={handleCreateFee}
+                  btnText={isSubmitting ? "Saving..." : "Save"}
+                  className="saveBtn"
+                  disabled={isSubmitting}
+                />
+              </div>
+            </div>
+          )}
+
+          <details className={styles.feeHistory}>
+            <summary>Rate history</summary>
+            <div className={styles.feeHistoryList}>
+              {historicalFees.length > 0 ? (
+                historicalFees.map((fee) => <FeeRateCard key={fee.id} fee={fee} />)
+              ) : (
+                <p className={styles.feeMutedText}>No past fee rates.</p>
+              )}
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -355,7 +355,9 @@ export default function InstructorFeeRates({
             <summary>Rate history</summary>
             <div className={styles.feeHistoryList}>
               {historicalFees.length > 0 ? (
-                historicalFees.map((fee) => <FeeRateCard key={fee.id} fee={fee} />)
+                historicalFees.map((fee) => (
+                  <FeeRateCard key={fee.id} fee={fee} />
+                ))
               ) : (
                 <p className={styles.feeMutedText}>No past fee rates.</p>
               )}

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -41,8 +41,14 @@ const createFormState = (fee?: InstructorFeeRate | null) => ({
 
 function FeeRateCard({
   fee,
+  isLatest = false,
+  onDelete,
+  isDeleteDisabled = false,
 }: {
   fee: InstructorFeeRate;
+  isLatest?: boolean;
+  onDelete?: () => void;
+  isDeleteDisabled?: boolean;
 }) {
   return (
     <article className={styles.feeCard}>
@@ -50,7 +56,17 @@ function FeeRateCard({
         <div>
           <strong>{formatPeriod(fee)}</strong>
         </div>
-        <span className={styles.feeCurrency}>{fee.currency}</span>
+        <div className={styles.feeCardActions}>
+          {isLatest && onDelete && (
+            <ActionButton
+              type="button"
+              onClick={onDelete}
+              btnText="Delete"
+              className="deleteBtn"
+              disabled={isDeleteDisabled}
+            />
+          )}
+        </div>
       </div>
       <dl className={styles.feeGrid}>
         <div>
@@ -138,6 +154,16 @@ export default function InstructorFeeRates({
     setFormState((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleOpenForm = () => {
+    setFormState(createFormState(activeFee ?? null));
+    setIsFormOpen(true);
+  };
+
+  const handleCancelForm = () => {
+    setFormState(createFormState(activeFee ?? null));
+    setIsFormOpen(false);
+  };
+
   const handleCreateFee = async () => {
     const trialFee = Number(formState.trialFee);
     const regularFee = Number(formState.regularFee);
@@ -212,30 +238,19 @@ export default function InstructorFeeRates({
           {isLoading ? (
             <p className={styles.feeMutedText}>Loading fee rates...</p>
           ) : activeFee ? (
-            <FeeRateCard fee={activeFee} />
+            <FeeRateCard
+              fee={activeFee}
+              isLatest={true}
+              onDelete={handleDeleteLatest}
+              isDeleteDisabled={isSubmitting || fees.length < 2}
+            />
           ) : (
             <p className={styles.feeMutedText}>No fee rates registered yet.</p>
           )}
 
-          <div className={styles.feeActions}>
-            <ActionButton
-              type="button"
-              onClick={() => setIsFormOpen((prev) => !prev)}
-              btnText={isFormOpen ? "Cancel new rate" : "Change fee rate"}
-              className={isFormOpen ? "cancelBtn" : "addBtn"}
-              disabled={isSubmitting}
-            />
-            <ActionButton
-              type="button"
-              onClick={handleDeleteLatest}
-              btnText="Delete latest rate"
-              className="deleteBtn"
-              disabled={isSubmitting || fees.length < 2}
-            />
-          </div>
-
           {isFormOpen && (
             <div className={styles.feeForm}>
+              <h4 className={styles.feeFormTitle}>New fee rate</h4>
               <div className={styles.feeFormGrid}>
                 <label>
                   Currency
@@ -247,7 +262,7 @@ export default function InstructorFeeRates({
                     placeholder="JPY"
                   />
                   <span className={styles.feeFieldHint}>
-                    Use a 3-letter currency code, for example "JPY".
+                    Use a 3-letter currency code, for example &quot;JPY&quot;.
                   </span>
                 </label>
                 <label>
@@ -304,7 +319,19 @@ export default function InstructorFeeRates({
                   />
                 </label>
               </div>
-              <div className={styles.feeActions}>
+            </div>
+          )}
+
+          <div className={styles.feeActions}>
+            {isFormOpen ? (
+              <>
+                <ActionButton
+                  type="button"
+                  onClick={handleCancelForm}
+                  btnText="Cancel"
+                  className="cancelBtn"
+                  disabled={isSubmitting}
+                />
                 <ActionButton
                   type="button"
                   onClick={handleCreateFee}
@@ -312,9 +339,17 @@ export default function InstructorFeeRates({
                   className="saveBtn"
                   disabled={isSubmitting}
                 />
-              </div>
-            </div>
-          )}
+              </>
+            ) : (
+              <ActionButton
+                type="button"
+                onClick={handleOpenForm}
+                btnText="Change fee rate"
+                className="addBtn"
+                disabled={isSubmitting}
+              />
+            )}
+          </div>
 
           <details className={styles.feeHistory}>
             <summary>Rate history</summary>

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
@@ -69,6 +69,129 @@
   font-size: 0.8rem;
 }
 
+.feeSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.feeMutedText {
+  font-size: 0.85rem;
+  color: #4b5563;
+  margin: 0;
+}
+
+.feeActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.feeForm > .feeActions {
+  margin-top: 0.5rem;
+}
+
+.feeCard {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  padding: 0.9rem;
+}
+
+.feeCardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  align-items: flex-start;
+}
+
+.feeCurrency {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba($blue_primary, 0.1);
+  color: $blue_primary;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.feeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+
+  div {
+    background: #f9fafb;
+    border-radius: 0.4rem;
+    padding: 0.65rem 0.75rem;
+  }
+
+  dt {
+    margin-bottom: 0.25rem;
+    font-size: 0.8rem;
+    color: #6b7280;
+  }
+
+  dd {
+    margin: 0;
+    font-weight: 600;
+  }
+}
+
+.feeForm {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.9rem;
+  background: #ffffff;
+}
+
+.feeFormGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    color: #374151;
+  }
+
+  input {
+    border: 1px solid #cbd5e1;
+    border-radius: 0.4rem;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.95rem;
+  }
+}
+
+.feeFieldHint {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.feeHistory {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 0.75rem;
+
+  summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: $blue_primary;
+  }
+}
+
+.feeHistoryList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
 // name
 .instructorName {
   display: flex;
@@ -311,6 +434,16 @@
     align-items: stretch;
     gap: 12px;
   }
+
+  .feeActions,
+  .feeCardHeader {
+    flex-direction: column;
+  }
+
+  .feeGrid,
+  .feeFormGrid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (min-width: 641px) and (max-width: 1024px) {
@@ -337,5 +470,10 @@
   .messageForChildren__inputField,
   .skill__inputField {
     margin-right: 0;
+  }
+
+  .feeGrid,
+  .feeFormGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.module.scss
@@ -87,8 +87,9 @@
   gap: 0.75rem;
 }
 
-.feeForm > .feeActions {
-  margin-top: 0.5rem;
+.feeFormTitle {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
 }
 
 .feeCard {
@@ -106,15 +107,9 @@
   align-items: flex-start;
 }
 
-.feeCurrency {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  background: rgba($blue_primary, 0.1);
-  color: $blue_primary;
-  font-size: 0.8rem;
-  font-weight: 600;
+.feeCardActions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .feeGrid {
@@ -438,6 +433,11 @@
   .feeActions,
   .feeCardHeader {
     flex-direction: column;
+  }
+
+  .feeCardActions {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .feeGrid,

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -31,6 +31,7 @@ import Uploader from "../../features/registerForm/uploadImages/Uploader";
 import { defaultUserImageUrl } from "@/lib/data/data";
 import Image from "next/image";
 import { confirmAlert } from "@/lib/utils/alertUtils";
+import InstructorFeeRates from "./InstructorFeeRates";
 
 // Define the specific string fields that are editable in this component
 type EditableInstructorFields =
@@ -612,6 +613,10 @@ function InstructorProfile({
                   </div>
                 </div>
               </div>
+            )}
+
+            {userSessionType === "admin" && latestInstructor && (
+              <InstructorFeeRates instructorId={latestInstructor.id} />
             )}
 
             {/* Instructor introduction URL */}

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -7,6 +7,11 @@ import { ERROR_PAGE_MESSAGE_EN } from "../messages/generalMessages";
 import {
   type AdminResponse,
   type AdminsListResponse,
+  type CreateInstructorFeeRequest,
+  type CreateInstructorFeeResponse,
+  type DeleteLatestInstructorFeeResponse,
+  type InstructorFeeErrorResponse,
+  type InstructorFeeRatesResponse,
   type InstructorPayrollErrorResponse,
   type InstructorPayrollResponse,
   type InstructorsListResponse,
@@ -31,6 +36,9 @@ const BASE_URL = `${BACKEND_ORIGIN}/admins`;
 
 type Response<T> = T | { message: string };
 export type InstructorPayrollApiError = InstructorPayrollErrorResponse & {
+  status: number;
+};
+export type InstructorFeeApiError = InstructorFeeErrorResponse & {
   status: number;
 };
 
@@ -639,6 +647,143 @@ export const getInstructorPayroll = async (
     return {
       status: 500,
       code: "INSTRUCTOR_PAYROLL_ERROR",
+      message: GENERAL_ERROR_MESSAGE,
+    };
+  }
+};
+
+export const getInstructorFees = async (
+  instructorId: number,
+  cookie?: string,
+): Promise<InstructorFeeRatesResponse | InstructorFeeApiError> => {
+  try {
+    let apiURL;
+    let headers;
+    let response;
+    const method = "GET";
+    const backendEndpoint = `/admins/instructors/${instructorId}/fees`;
+
+    if (cookie) {
+      apiURL = `${BACKEND_ORIGIN}${backendEndpoint}`;
+      headers = { "Content-Type": "application/json", Cookie: cookie };
+      response = await fetch(apiURL, {
+        method,
+        headers,
+        cache: "no-store",
+      });
+    } else {
+      apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
+      headers = {
+        "Content-Type": "application/json",
+        "backend-endpoint": backendEndpoint,
+        "no-cache": "true",
+      };
+      response = await fetch(apiURL, {
+        method,
+        headers,
+      });
+    }
+
+    const data = await response.json();
+
+    if (response.status !== 200) {
+      return {
+        status: response.status,
+        code:
+          typeof data?.code === "string" ? data.code : "INSTRUCTOR_FEE_ERROR",
+        message:
+          typeof data?.message === "string"
+            ? data.message
+            : `HTTP error! status: ${response.status}`,
+      };
+    }
+
+    return data as InstructorFeeRatesResponse;
+  } catch (error) {
+    console.error("Failed to fetch instructor fees:", error);
+    return {
+      status: 500,
+      code: "INSTRUCTOR_FEE_ERROR",
+      message: GENERAL_ERROR_MESSAGE,
+    };
+  }
+};
+
+export const createInstructorFee = async (
+  instructorId: number,
+  feeData: CreateInstructorFeeRequest,
+): Promise<CreateInstructorFeeResponse | InstructorFeeApiError> => {
+  try {
+    const backendEndpoint = `/admins/instructors/${instructorId}/fees`;
+    const apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
+    const response = await fetch(apiURL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "backend-endpoint": backendEndpoint,
+      },
+      body: JSON.stringify(feeData),
+    });
+
+    const data = await response.json();
+
+    if (response.status !== 201) {
+      return {
+        status: response.status,
+        code:
+          typeof data?.code === "string" ? data.code : "INSTRUCTOR_FEE_ERROR",
+        message:
+          typeof data?.message === "string"
+            ? data.message
+            : `HTTP error! status: ${response.status}`,
+      };
+    }
+
+    return data as CreateInstructorFeeResponse;
+  } catch (error) {
+    console.error("Failed to create instructor fee:", error);
+    return {
+      status: 500,
+      code: "INSTRUCTOR_FEE_ERROR",
+      message: GENERAL_ERROR_MESSAGE,
+    };
+  }
+};
+
+export const deleteLatestInstructorFee = async (
+  instructorId: number,
+): Promise<DeleteLatestInstructorFeeResponse | InstructorFeeApiError> => {
+  try {
+    const backendEndpoint = `/admins/instructors/${instructorId}/fees/latest`;
+    const apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
+    const response = await fetch(apiURL, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "backend-endpoint": backendEndpoint,
+      },
+    });
+
+    const data = await response.json();
+
+    if (response.status !== 200) {
+      return {
+        status: response.status,
+        code:
+          typeof data?.code === "string" ? data.code : "INSTRUCTOR_FEE_ERROR",
+        message:
+          typeof data?.message === "string"
+            ? data.message
+            : `HTTP error! status: ${response.status}`,
+      };
+    }
+
+    return data as DeleteLatestInstructorFeeResponse;
+  } catch (error) {
+    console.error("Failed to delete latest instructor fee:", error);
+    return {
+      status: 500,
+      code: "INSTRUCTOR_FEE_ERROR",
       message: GENERAL_ERROR_MESSAGE,
     };
   }

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -38,7 +38,7 @@ type Response<T> = T | { message: string };
 export type InstructorPayrollApiError = InstructorPayrollErrorResponse & {
   status: number;
 };
-export type InstructorFeeApiError = InstructorFeeErrorResponse & {
+type InstructorFeeApiError = InstructorFeeErrorResponse & {
   status: number;
 };
 

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -27,6 +27,17 @@ export const InstructorPayrollQuery = z.object({
     .regex(/^\d{4}-(0[1-9]|1[0-2])$/, "month must be in YYYY-MM format"),
 });
 
+export const CreateInstructorFeeRequest = z.object({
+  currency: z.string().regex(/^[A-Z]{3}$/, "currency must be a 3-letter code"),
+  effectiveFrom: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "effectiveFrom must be in YYYY-MM-DD format"),
+  trialFee: z.number().int().nonnegative(),
+  regularFee: z.number().int().nonnegative(),
+  cancelFee: z.number().int().nonnegative(),
+  cancelWithoutNoticeFee: z.number().int().nonnegative(),
+});
+
 export const PlanIdParams = z.object({
   id: z
     .string()
@@ -248,6 +259,41 @@ export const InstructorPayrollResponse = z.object({
 });
 
 export const InstructorPayrollErrorResponse = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+
+export const InstructorFeeRate = z.object({
+  id: z.number().int().positive(),
+  currency: z.string().regex(/^[A-Z]{3}$/),
+  effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  effectiveTo: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable(),
+  trialFee: z.number().int().nonnegative(),
+  regularFee: z.number().int().nonnegative(),
+  cancelFee: z.number().int().nonnegative(),
+  cancelWithoutNoticeFee: z.number().int().nonnegative(),
+});
+
+export const InstructorFeeRatesResponse = z.object({
+  instructorId: z.number().int().positive(),
+  fees: z.array(InstructorFeeRate),
+});
+
+export const CreateInstructorFeeResponse = z.object({
+  message: z.string(),
+  fee: InstructorFeeRate,
+});
+
+export const DeleteLatestInstructorFeeResponse = z.object({
+  message: z.string(),
+  deletedFeeId: z.number().int().positive(),
+  reactivatedFeeId: z.number().int().positive(),
+});
+
+export const InstructorFeeErrorResponse = z.object({
   code: z.string(),
   message: z.string(),
 });
@@ -502,6 +548,9 @@ export type AdminIdParams = z.infer<typeof AdminIdParams>;
 export type CustomerIdParams = z.infer<typeof CustomerIdParams>;
 export type InstructorIdParams = z.infer<typeof InstructorIdParams>;
 export type InstructorPayrollQuery = z.infer<typeof InstructorPayrollQuery>;
+export type CreateInstructorFeeRequest = z.infer<
+  typeof CreateInstructorFeeRequest
+>;
 export type PlanIdParams = z.infer<typeof PlanIdParams>;
 export type EventIdParams = z.infer<typeof EventIdParams>;
 
@@ -535,6 +584,19 @@ export type InstructorPayrollResponse = z.infer<
 >;
 export type InstructorPayrollErrorResponse = z.infer<
   typeof InstructorPayrollErrorResponse
+>;
+export type InstructorFeeRate = z.infer<typeof InstructorFeeRate>;
+export type InstructorFeeRatesResponse = z.infer<
+  typeof InstructorFeeRatesResponse
+>;
+export type CreateInstructorFeeResponse = z.infer<
+  typeof CreateInstructorFeeResponse
+>;
+export type DeleteLatestInstructorFeeResponse = z.infer<
+  typeof DeleteLatestInstructorFeeResponse
+>;
+export type InstructorFeeErrorResponse = z.infer<
+  typeof InstructorFeeErrorResponse
 >;
 export type PastInstructorsListResponse = z.infer<
   typeof PastInstructorsListResponse


### PR DESCRIPTION
## Summary
- add admin instructor fee rate history endpoints and profile-tab UI
- support create latest fee rate and delete latest fee rate undo flow
- refine the fee rate editor so delete lives in the latest card and change/save/cancel actions are clearer

## Testing
- cd backend && npm run test -- src/test/api/admins/instructor-fees.test.ts src/test/api/admins/instructor-payroll.test.ts
- cd frontend && npm run lint
- verified the updated fee rate UI in Playwright against localhost:3000
