### PR TITLE
Fix instructor payroll totals for cancellation fees

### DIFF
--- a/backend/src/services/instructorPayrollService.ts
+++ b/backend/src/services/instructorPayrollService.ts
@@ -182,6 +182,14 @@ const getCategoryFee = (fee: PayrollFeeRecord, category: PayrollCategory) => {
   }
 };
 
+const getCategoryTotalImpact = (
+  fee: PayrollFeeRecord,
+  category: PayrollCategory,
+) => {
+  const amount = getCategoryFee(fee, category);
+  return category === "trial" || category === "regular" ? amount : -amount;
+};
+
 const summarizePeriod = (
   periodName: "1-15" | "16-last",
   from: string,
@@ -207,10 +215,11 @@ const summarizePeriod = (
     const classDateInJst = formatDateInJst(payrollClass.dateTime);
     const fee = resolveApplicableFee(classDateInJst, feeRecords);
     const feeAmount = getCategoryFee(fee, category);
+    const totalImpact = getCategoryTotalImpact(fee, category);
 
     counts[category] += 1;
     subtotals[category] += feeAmount;
-    total += feeAmount;
+    total += totalImpact;
     currencies.add(fee.currency);
     appliedFeePeriods.set(
       `${fee.currency}:${fee.effectiveFrom}:${fee.effectiveTo ?? "open"}`,
@@ -226,7 +235,7 @@ const summarizePeriod = (
       total: 0,
     };
     daySummary.counts[category] += 1;
-    daySummary.total += feeAmount;
+    daySummary.total += totalImpact;
     dailyBreakdown.set(classDateInJst, daySummary);
   }
 

--- a/backend/src/test/api/admins/instructor-payroll.test.ts
+++ b/backend/src/test/api/admins/instructor-payroll.test.ts
@@ -123,7 +123,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
             cancel: 500,
             cancelWithoutNotice: 0,
           },
-          total: 3500,
+          total: 2500,
           dailyBreakdown: [
             {
               date: "2026-03-02",
@@ -153,7 +153,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
                 cancel: 1,
                 cancelWithoutNotice: 0,
               },
-              total: 500,
+              total: -500,
             },
           ],
           appliedFeePeriods: [
@@ -185,7 +185,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
             cancel: 0,
             cancelWithoutNotice: 300,
           },
-          total: 2800,
+          total: 2200,
           dailyBreakdown: [
             {
               date: "2026-03-16",
@@ -205,7 +205,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
                 cancel: 0,
                 cancelWithoutNotice: 1,
               },
-              total: 300,
+              total: -300,
             },
           ],
           appliedFeePeriods: [

--- a/docs/instructor-payroll-design.md
+++ b/docs/instructor-payroll-design.md
@@ -188,7 +188,7 @@ Rules:
 4. Classify each class into one payroll category or exclude it.
 5. For included classes, resolve the applicable fee by `dateTime`.
 6. Aggregate counts and subtotals by category.
-7. Sum the subtotals into the final total.
+7. Calculate the final total as `trial + regular - cancel - cancelWithoutNotice`.
 8. Calculate `sourceLastUpdatedAt` from used class rows only.
 9. Return both period summaries in a single response.
 
@@ -245,7 +245,7 @@ Query params:
         "cancel": 500,
         "cancelWithoutNotice": 0
       },
-      "total": 20500,
+      "total": 19500,
       "appliedFeePeriods": [
         {
           "currency": "JPY",
@@ -330,6 +330,7 @@ Current tab container:
 - unit fee information
 - subtotals by category
 - final total
+  - net of cancel fees
 - `sourceLastUpdatedAt`
 - applied fee period summary
 
@@ -506,4 +507,5 @@ Use this section to update progress during implementation.
 - Verified the payroll API test passes, frontend lint passes, and the payroll tab renders in Playwright.
 - Added deterministic dummy seed data for payroll UI verification and updated the seed reset flow to use `deleteMany()` instead of Prisma raw `TRUNCATE`.
 - Refined the payroll tab labels and layout with a month selector and compact daily breakdown tables.
+- Updated payroll totals so instructor cancel fees are subtracted from the displayed total.
 - Confirmed instructor fee create/edit management is not part of this scope and remains the next follow-up task.

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -223,7 +223,7 @@ export const InstructorPayrollDailyBreakdown = z.object({
     cancel: z.number().int().nonnegative(),
     cancelWithoutNotice: z.number().int().nonnegative(),
   }),
-  total: z.number().int().nonnegative(),
+  total: z.number().int(),
 });
 
 export const InstructorPayrollPeriod = z.object({
@@ -246,7 +246,7 @@ export const InstructorPayrollPeriod = z.object({
     cancel: z.number().int().nonnegative(),
     cancelWithoutNotice: z.number().int().nonnegative(),
   }),
-  total: z.number().int().nonnegative(),
+  total: z.number().int(),
   dailyBreakdown: z.array(InstructorPayrollDailyBreakdown),
   appliedFeePeriods: z.array(InstructorPayrollFeePeriod),
 });


### PR DESCRIPTION
## Summary
- subtract instructor cancellation fees from payroll period totals and daily totals
- allow payroll total values in the shared schema to be negative when cancellations exceed earnings
- update payroll API tests and design notes to match the net-total behavior

## Testing
- cd backend && npm run test -- src/test/api/admins/instructor-payroll.test.ts