### PR TITLE
Add instructor fees to normalized import data

### DIFF
--- a/backend/src/seed/generateNormalizedImportFixture.ts
+++ b/backend/src/seed/generateNormalizedImportFixture.ts
@@ -90,6 +90,17 @@ type InstructorDef = {
   termination_at: string;
 };
 
+type InstructorFeeDef = {
+  instructor_ref: string;
+  currency: string;
+  effective_from: string;
+  effective_to: string;
+  trial_fee: string;
+  regular_fee: string;
+  cancel_fee: string;
+  cancel_without_notice_fee: string;
+};
+
 type InstructorScheduleDef = {
   instructor_ref: string;
   effective_from: string;
@@ -152,6 +163,7 @@ type RowMap = {
   "children.csv": ChildDef[];
   "subscriptions.csv": SubscriptionDef[];
   "instructors.csv": InstructorDef[];
+  "instructor_fees.csv": InstructorFeeDef[];
   "instructor_schedules.csv": InstructorScheduleDef[];
   "instructor_absences.csv": { instructor_ref: string; absent_at: string }[];
   "events.csv": EventDef[];
@@ -445,6 +457,23 @@ function instructorRows(fakerEn: FakerLike): InstructorDef[] {
 
 function slotsForInstructor(instructorIndexOneBased: number): SlotDef[] {
   return instructorIndexOneBased % 2 === 1 ? PATTERN_A_SLOTS : PATTERN_B_SLOTS;
+}
+
+function instructorFeeRows(from: string): InstructorFeeDef[] {
+  const rows: InstructorFeeDef[] = [];
+  for (let i = 1; i <= INSTRUCTOR_COUNT; i += 1) {
+    rows.push({
+      instructor_ref: ref("IN", i),
+      currency: "PHP",
+      effective_from: from,
+      effective_to: "",
+      trial_fee: "75",
+      regular_fee: "100",
+      cancel_fee: "50",
+      cancel_without_notice_fee: "100",
+    });
+  }
+  return rows;
 }
 
 function instructorScheduleRows(from: string): InstructorScheduleDef[] {
@@ -762,6 +791,7 @@ async function main(): Promise<void> {
     "children.csv": children,
     "subscriptions.csv": subscriptions,
     "instructors.csv": instructors,
+    "instructor_fees.csv": instructorFeeRows(args.from),
     "instructor_schedules.csv": instructorScheduleRows(args.from),
     "instructor_absences.csv": [],
     "events.csv": eventRows(),

--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -59,6 +59,17 @@ type RowByFile = {
     | "termination_at",
     string
   >;
+  "instructor_fees.csv": Record<
+    | "instructor_ref"
+    | "currency"
+    | "effective_from"
+    | "effective_to"
+    | "trial_fee"
+    | "regular_fee"
+    | "cancel_fee"
+    | "cancel_without_notice_fee",
+    string
+  >;
   "instructor_schedules.csv": Record<
     | "instructor_ref"
     | "effective_from"
@@ -164,6 +175,7 @@ const IMPORT_RESET_TABLES = [
   "InstructorAbsence",
   "InstructorSlot",
   "InstructorSchedule",
+  "InstructorFee",
   "Instructor",
   "Schedule",
   "Event",
@@ -186,6 +198,7 @@ type ParsedNormalizedRows = {
   "children.csv": RowEnvelope<RowByFile["children.csv"]>[];
   "subscriptions.csv": RowEnvelope<RowByFile["subscriptions.csv"]>[];
   "instructors.csv": RowEnvelope<RowByFile["instructors.csv"]>[];
+  "instructor_fees.csv": RowEnvelope<RowByFile["instructor_fees.csv"]>[];
   "instructor_schedules.csv": RowEnvelope<
     RowByFile["instructor_schedules.csv"]
   >[];
@@ -485,6 +498,11 @@ function parseNormalizedRows(
       files["instructors.csv"] ?? "",
       issues,
     ),
+    "instructor_fees.csv": parseFileRows(
+      "instructor_fees.csv",
+      files["instructor_fees.csv"] ?? "",
+      issues,
+    ),
     "instructor_schedules.csv": parseFileRows(
       "instructor_schedules.csv",
       files["instructor_schedules.csv"] ?? "",
@@ -575,6 +593,7 @@ export function validateNormalizedImportFiles(
     "children.csv": parsed["children.csv"].length,
     "subscriptions.csv": parsed["subscriptions.csv"].length,
     "instructors.csv": parsed["instructors.csv"].length,
+    "instructor_fees.csv": parsed["instructor_fees.csv"].length,
     "instructor_schedules.csv": parsed["instructor_schedules.csv"].length,
     "instructor_absences.csv": parsed["instructor_absences.csv"].length,
     "events.csv": parsed["events.csv"].length,
@@ -802,6 +821,104 @@ export function validateNormalizedImportFiles(
       "termination_at",
       row.data.termination_at,
     );
+  }
+
+  for (const row of parsed["instructor_fees.csv"]) {
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "instructor_ref",
+      row.data.instructor_ref,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "currency",
+      row.data.currency,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "effective_from",
+      row.data.effective_from,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "trial_fee",
+      row.data.trial_fee,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "regular_fee",
+      row.data.regular_fee,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "cancel_fee",
+      row.data.cancel_fee,
+    );
+    assertRequired(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "cancel_without_notice_fee",
+      row.data.cancel_without_notice_fee,
+    );
+    assertRefFormat(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "instructor_ref",
+      row.data.instructor_ref,
+    );
+    assertDate(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "effective_from",
+      row.data.effective_from,
+    );
+    assertDate(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "effective_to",
+      row.data.effective_to,
+    );
+    if (row.data.currency && !/^[A-Z]{3}$/.test(row.data.currency)) {
+      addIssue(
+        issues,
+        "instructor_fees.csv",
+        row.rowNumber,
+        "currency",
+        "currency must be a 3-letter uppercase code",
+      );
+    }
+    for (const [column, value] of [
+      ["trial_fee", row.data.trial_fee],
+      ["regular_fee", row.data.regular_fee],
+      ["cancel_fee", row.data.cancel_fee],
+      ["cancel_without_notice_fee", row.data.cancel_without_notice_fee],
+    ] as const) {
+      if (value && !/^\d+$/.test(value)) {
+        addIssue(
+          issues,
+          "instructor_fees.csv",
+          row.rowNumber,
+          column,
+          `${column} must be a non-negative integer`,
+        );
+      }
+    }
   }
 
   for (const row of parsed["instructor_schedules.csv"]) {
@@ -1260,6 +1377,13 @@ export function validateNormalizedImportFiles(
   );
   assertUnique(
     issues,
+    "instructor_fees.csv",
+    parsed["instructor_fees.csv"],
+    ["instructor_ref", "effective_from"],
+    "(instructor_ref,effective_from)",
+  );
+  assertUnique(
+    issues,
     "instructor_schedules.csv",
     parsed["instructor_schedules.csv"],
     [
@@ -1380,6 +1504,18 @@ export function validateNormalizedImportFiles(
       row.data.plan_ref,
       planRefs,
       "plans.csv",
+    );
+  }
+
+  for (const row of parsed["instructor_fees.csv"]) {
+    assertExists(
+      issues,
+      "instructor_fees.csv",
+      row.rowNumber,
+      "instructor_ref",
+      row.data.instructor_ref,
+      instructorRefs,
+      "instructors.csv",
     );
   }
 
@@ -1694,6 +1830,21 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       createdInstructors[index].id,
     );
   });
+
+  if (parsed["instructor_fees.csv"].length > 0) {
+    await tx.instructorFee.createMany({
+      data: parsed["instructor_fees.csv"].map((row) => ({
+        instructorId: instructorIdByRef.get(row.data.instructor_ref)!,
+        currency: row.data.currency,
+        effectiveFrom: parseOptionalDate(row.data.effective_from)!,
+        effectiveTo: parseOptionalDate(row.data.effective_to),
+        trialFee: Number(row.data.trial_fee),
+        regularFee: Number(row.data.regular_fee),
+        cancelFee: Number(row.data.cancel_fee),
+        cancelWithoutNoticeFee: Number(row.data.cancel_without_notice_fee),
+      })),
+    });
+  }
 
   const scheduleGroups = new Map<
     string,

--- a/backend/src/services/adminImport/normalize.ts
+++ b/backend/src/services/adminImport/normalize.ts
@@ -9,6 +9,7 @@ export type NormalizedFileName =
   | "children.csv"
   | "subscriptions.csv"
   | "instructors.csv"
+  | "instructor_fees.csv"
   | "instructor_schedules.csv"
   | "instructor_absences.csv"
   | "events.csv"
@@ -118,6 +119,17 @@ interface InstructorScheduleRow {
   start_time: string;
 }
 
+interface InstructorFeeRow {
+  instructor_ref: string;
+  currency: string;
+  effective_from: string;
+  effective_to: string;
+  trial_fee: string;
+  regular_fee: string;
+  cancel_fee: string;
+  cancel_without_notice_fee: string;
+}
+
 const RAW_COLUMN = {
   prefecture: 2,
   customerName: 4,
@@ -182,6 +194,16 @@ export const NORMALIZED_HEADERS = {
     "working_time",
     "is_native",
     "termination_at",
+  ],
+  "instructor_fees.csv": [
+    "instructor_ref",
+    "currency",
+    "effective_from",
+    "effective_to",
+    "trial_fee",
+    "regular_fee",
+    "cancel_fee",
+    "cancel_without_notice_fee",
   ],
   "instructor_schedules.csv": [
     "instructor_ref",
@@ -415,6 +437,7 @@ function toRecordSet(rows: RawClassRow[]): {
   children: ChildRow[];
   subscriptions: SubscriptionRow[];
   instructors: InstructorRow[];
+  instructorFees: InstructorFeeRow[];
   instructorSchedules: InstructorScheduleRow[];
   generatedCustomerEmails: GeneratedEmailReportItem[];
   warnings: string[];
@@ -430,6 +453,7 @@ function toRecordSet(rows: RawClassRow[]): {
   const children: ChildRow[] = [];
   const subscriptions: SubscriptionRow[] = [];
   const instructors: InstructorRow[] = [];
+  const instructorFees: InstructorFeeRow[] = [];
   const instructorSchedules: InstructorScheduleRow[] = [];
   const generatedCustomerEmails: GeneratedEmailReportItem[] = [];
   const warnings: string[] = [];
@@ -541,6 +565,16 @@ function toRecordSet(rows: RawClassRow[]): {
         };
         instructorsByName.set(row.instructorName, instructor);
         instructors.push(instructor);
+        instructorFees.push({
+          instructor_ref: instructorRef,
+          currency: "PHP",
+          effective_from: "2020-01-01",
+          effective_to: "",
+          trial_fee: "75",
+          regular_fee: "100",
+          cancel_fee: "50",
+          cancel_without_notice_fee: "100",
+        });
       }
 
       if (row.weekday === null) {
@@ -576,6 +610,7 @@ function toRecordSet(rows: RawClassRow[]): {
     children,
     subscriptions,
     instructors,
+    instructorFees,
     instructorSchedules,
     generatedCustomerEmails,
     warnings,
@@ -698,6 +733,10 @@ export function normalizeRawScheduleCsvToPackage(
       "instructors.csv",
       mapped.instructors,
     ),
+    "instructor_fees.csv": rowsToCsvWithHeaders(
+      "instructor_fees.csv",
+      mapped.instructorFees,
+    ),
     "instructor_schedules.csv": rowsToCsvWithHeaders(
       "instructor_schedules.csv",
       mapped.instructorSchedules,
@@ -726,6 +765,7 @@ export function normalizeRawScheduleCsvToPackage(
     "children.csv": mapped.children.length,
     "subscriptions.csv": mapped.subscriptions.length,
     "instructors.csv": mapped.instructors.length,
+    "instructor_fees.csv": mapped.instructorFees.length,
     "instructor_schedules.csv": mapped.instructorSchedules.length,
     "instructor_absences.csv": 0,
     "events.csv": 0,

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -29,6 +29,8 @@ function buildMinimalNormalizedFiles() {
       "subscription_ref,customer_ref,plan_ref,start_at,end_at\nSU0001,CU0001,PL0001,2025-01-01T00:00:00+09:00,2025-12-31T00:00:00+09:00\n",
     "instructors.csv":
       "instructor_ref,name,email,temp_password,class_url,icon,nickname,meeting_id,passcode,birthdate,favorite_food,hobby,life_history,message_for_children,skill,working_time,is_native,termination_at\nIN0001,Instructor One,instructor.one@example.com,TempPass456!,https://import.local/class/in0001,https://import.local/icon/in0001.png,instructor_in0001,11111111111,PASS0001,1990-01-01,Sushi,Reading,Life history,Message,Skill,Weekdays,false,\n",
+    "instructor_fees.csv":
+      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee\nIN0001,PHP,2025-01-01,,75,100,50,100\n",
     "instructor_schedules.csv":
       "instructor_ref,effective_from,effective_to,timezone,weekday,start_time\nIN0001,2025-01-01,2025-12-31,Asia/Tokyo,1,09:00\n",
     "instructor_absences.csv": "instructor_ref,absent_at\n",
@@ -147,6 +149,7 @@ describe("POST /admins/import/normalize", () => {
       "customers.csv",
       "events.csv",
       "instructor_absences.csv",
+      "instructor_fees.csv",
       "instructor_schedules.csv",
       "instructors.csv",
       "plans.csv",
@@ -168,6 +171,9 @@ describe("POST /admins/import/normalize", () => {
       3,
     );
     expect(
+      response.body.report.normalizedRowsByFile["instructor_fees.csv"],
+    ).toBe(3);
+    expect(
       response.body.report.normalizedRowsByFile["instructor_schedules.csv"],
     ).toBe(3);
     expect(response.body.report.generatedCustomerEmails).toHaveLength(1);
@@ -187,6 +193,14 @@ describe("POST /admins/import/normalize", () => {
     expect(plansCsv).toContain("plan_ref,name,description,weekly_class_times");
     expect(plansCsv).toContain("1980円（週1回25分）");
     expect(plansCsv).toContain("1480円（月2回25分）");
+
+    const instructorFeesCsv = response.body.files[
+      "instructor_fees.csv"
+    ] as string;
+    expect(instructorFeesCsv).toContain(
+      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee",
+    );
+    expect(instructorFeesCsv).toContain("PHP,2020-01-01,,75,100,50,100");
   });
 
   it("downloads normalized files as a zip bundle by jobId", async () => {
@@ -231,6 +245,7 @@ describe("POST /admins/import/normalize", () => {
       "customers.csv",
       "events.csv",
       "instructor_absences.csv",
+      "instructor_fees.csv",
       "instructor_schedules.csv",
       "instructors.csv",
       "plans.csv",
@@ -315,15 +330,18 @@ describe("POST /admins/import/execute", () => {
     expect(response.body.imported).toBe(true);
     expect(response.body.report.rowsByFile["system_status.csv"]).toBe(1);
 
-    const [customers, children, instructors, statuses] = await Promise.all([
-      prisma.customer.count(),
-      prisma.child.count(),
-      prisma.instructor.count(),
-      prisma.systemStatus.count(),
-    ]);
+    const [customers, children, instructors, instructorFees, statuses] =
+      await Promise.all([
+        prisma.customer.count(),
+        prisma.child.count(),
+        prisma.instructor.count(),
+        prisma.instructorFee.count(),
+        prisma.systemStatus.count(),
+      ]);
     expect(customers).toBe(0);
     expect(children).toBe(0);
     expect(instructors).toBe(0);
+    expect(instructorFees).toBe(0);
     expect(statuses).toBe(1);
   });
 
@@ -438,6 +456,7 @@ describe("POST /admins/import/execute", () => {
       children,
       subscriptions,
       instructors,
+      instructorFees,
       schedules,
       recurringClasses,
       classes,
@@ -450,6 +469,7 @@ describe("POST /admins/import/execute", () => {
       prisma.child.count(),
       prisma.subscription.count(),
       prisma.instructor.count(),
+      prisma.instructorFee.count(),
       prisma.schedule.count(),
       prisma.recurringClass.count(),
       prisma.class.count(),
@@ -463,6 +483,7 @@ describe("POST /admins/import/execute", () => {
     expect(children).toBe(1);
     expect(subscriptions).toBe(1);
     expect(instructors).toBe(1);
+    expect(instructorFees).toBe(1);
     expect(schedules).toBe(1);
     expect(recurringClasses).toBe(1);
     expect(classes).toBe(1);
@@ -488,6 +509,19 @@ describe("POST /admins/import/execute", () => {
     });
     expect(importedCustomer.password).not.toBe("TempPass123!");
     expect(importedCustomer.password.startsWith("$2")).toBe(true);
+
+    const importedInstructorFee = await prisma.instructorFee.findFirstOrThrow({
+      include: { instructor: true },
+    });
+    expect(importedInstructorFee.instructor.email).toBe(
+      "instructor.one@example.com",
+    );
+    expect(importedInstructorFee.currency).toBe("PHP");
+    expect(importedInstructorFee.effectiveTo).toBeNull();
+    expect(importedInstructorFee.trialFee).toBe(75);
+    expect(importedInstructorFee.regularFee).toBe(100);
+    expect(importedInstructorFee.cancelFee).toBe(50);
+    expect(importedInstructorFee.cancelWithoutNoticeFee).toBe(100);
   });
 
   it("accepts multiple slot rows that share the same instructor schedule key", async () => {

--- a/docs/data-import-normalization-plan.md
+++ b/docs/data-import-normalization-plan.md
@@ -45,22 +45,25 @@ Two-step workflow:
 3. `children.csv`
 4. `subscriptions.csv`
 5. `instructors.csv`
-6. `instructor_schedules.csv` (domain-combined: schedule + slot data)
-7. `instructor_absences.csv`
-8. `events.csv`
-9. `schedules.csv`
-10. `system_status.csv`
-11. `recurring_classes.csv`
-12. `recurring_class_attendance.csv`
-13. `classes.csv`
-14. `class_attendance.csv`
+6. `instructor_fees.csv`
+7. `instructor_schedules.csv` (domain-combined: schedule + slot data)
+8. `instructor_absences.csv`
+9. `events.csv`
+10. `schedules.csv`
+11. `system_status.csv`
+12. `recurring_classes.csv`
+13. `recurring_class_attendance.csv`
+14. `classes.csv`
+15. `class_attendance.csv`
 
 Notes:
 
 - `instructor_schedules.csv` is intentionally domain-combined and fans out internally to `InstructorSchedule` and `InstructorSlot`.
+- `instructor_fees.csv` imports `InstructorFee` history rows per instructor.
 - All mandatory files must exist even if empty (header-only allowed where applicable).
 - `customers.csv` and `instructors.csv` include `temp_password` columns in normalized outputs.
 - Importer must hash temporary passwords before database write; plain text is never stored in DB.
+- Raw schedule normalization does not have source fee history, so it emits one default active fee row per instructor with currency `PHP`, `trial_fee = 75`, `regular_fee = 100`, `cancel_fee = 50`, and `cancel_without_notice_fee = 100`. Admins must review and adjust imported fee history as needed.
 - Support both:
   - Import from normalized files generated in the same session.
   - Re-upload/import previously downloaded normalized bundles.
@@ -124,52 +127,57 @@ Notes:
    - Keys:
      - `instructor_ref` unique.
      - `email`, `class_url`, `icon`, `nickname`, `meeting_id`, `passcode` unique.
-6. `instructor_schedules.csv`
+6. `instructor_fees.csv`
+   - Required columns: `instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee`
+   - Keys:
+     - `instructor_ref` must exist in `instructors.csv`.
+     - `(instructor_ref,effective_from)` unique.
+7. `instructor_schedules.csv`
    - Required columns: `instructor_ref,effective_from,effective_to,timezone,weekday,start_time`
    - Keys:
      - `instructor_ref` must exist in `instructors.csv`.
      - `(instructor_ref,effective_from,effective_to,timezone)` defines one schedule.
      - `(instructor_ref,effective_from,effective_to,timezone,weekday,start_time)` unique for slots.
-7. `instructor_absences.csv`
+8. `instructor_absences.csv`
    - Required columns: `instructor_ref,absent_at`
    - Keys:
      - `instructor_ref` must exist in `instructors.csv`.
      - `(instructor_ref,absent_at)` unique.
-8. `events.csv`
+9. `events.csv`
    - Required columns: `event_ref,name,color`
    - Keys:
      - `event_ref` unique.
      - `name` unique.
      - `color` unique.
-9. `schedules.csv`
+10. `schedules.csv`
    - Required columns: `schedule_ref,date,event_ref`
    - Keys:
      - `schedule_ref` unique.
      - `date` unique.
      - `event_ref` must exist in `events.csv`.
-10. `system_status.csv`
+11. `system_status.csv`
    - Required columns: `status`
    - Rules:
      - Exactly one row required in v1.
-11. `recurring_classes.csv`
+12. `recurring_classes.csv`
    - Required columns: `recurring_class_ref,subscription_ref,instructor_ref,start_at,end_at`
    - Keys:
      - `recurring_class_ref` unique.
      - `subscription_ref` must exist in `subscriptions.csv` when provided.
      - `instructor_ref` must exist in `instructors.csv` when provided.
-12. `recurring_class_attendance.csv`
+13. `recurring_class_attendance.csv`
    - Required columns: `recurring_class_ref,child_ref`
    - Keys:
      - `recurring_class_ref` must exist in `recurring_classes.csv`.
      - `child_ref` must exist in `children.csv`.
      - `(recurring_class_ref,child_ref)` unique.
-13. `classes.csv`
+14. `classes.csv`
    - Required columns: `class_ref,customer_ref,instructor_ref,recurring_class_ref,subscription_ref,date_time,status,rebookable_until,class_code,is_free_trial`
    - Keys:
      - `class_ref` unique.
      - `customer_ref` must exist in `customers.csv`.
      - `instructor_ref`, `recurring_class_ref`, `subscription_ref` must exist in their files when provided.
-14. `class_attendance.csv`
+15. `class_attendance.csv`
    - Required columns: `class_ref,child_ref`
    - Keys:
      - `class_ref` must exist in `classes.csv`.
@@ -181,6 +189,8 @@ Notes:
 1. Date-only columns:
    - `children.birthdate`
    - `instructors.birthdate`
+   - `instructor_fees.effective_from`
+   - `instructor_fees.effective_to`
    - `instructor_schedules.effective_from`
    - `instructor_schedules.effective_to`
    - `schedules.date`
@@ -347,6 +357,7 @@ None at this stage.
 7. Normalization is all-or-nothing: any validation error fails the whole normalization and no partial outputs are produced.
 8. Import reference keys use uniform 2-letter + 4-digit format (e.g., `CU0001`).
 9. Temporary passwords are generated during normalization and included inline as plain text in `customers.csv` and `instructors.csv`.
+10. Raw schedule normalization also generates one default `instructor_fees.csv` row per imported instructor because the current source CSV does not carry fee history.
 10. Temporary passwords are regenerated on every normalization run.
 11. Import feature is always available to authenticated admins in v1 (no environment kill-switch).
 12. Missing emails are auto-generated during normalization (no toggle), and normalization output/report must list which rows were assigned generated emails.

--- a/docs/testing/data-import/README.md
+++ b/docs/testing/data-import/README.md
@@ -32,6 +32,7 @@ When normalized by `normalizeRawScheduleCsvToPackage`:
   - `children.csv`: 120
   - `subscriptions.csv`: 100
   - `instructors.csv`: 10
+  - `instructor_fees.csv`: 10
 
 ## Next Fixture Direction
 
@@ -59,3 +60,11 @@ npm run fixture:generate:normalized-import -- \
   - `--out-dir` (default: `../docs/testing/data-import/generated`)
 
 The generator creates all mandatory normalized CSV files and one deterministic zip file in the output directory.
+
+It also emits `instructor_fees.csv` with one active fee row per instructor using:
+
+- `currency = PHP`
+- `trial_fee = 75`
+- `regular_fee = 100`
+- `cancel_fee = 50`
+- `cancel_without_notice_fee = 100`

--- a/docs/testing/data-import/normalized-fixture-generator-spec.md
+++ b/docs/testing/data-import/normalized-fixture-generator-spec.md
@@ -88,6 +88,20 @@ Assignment:
 
 Sunday has no slots.
 
+## Instructor Fee Rules
+
+Emit one active `instructor_fees.csv` row per instructor.
+
+Field values:
+
+- `currency = PHP`
+- `effective_from = --from`
+- `effective_to = empty`
+- `trial_fee = 75`
+- `regular_fee = 100`
+- `cancel_fee = 50`
+- `cancel_without_notice_fee = 100`
+
 ## Instructor Assignment for Recurring Classes
 
 Recurring classes must be evenly distributed across instructors.


### PR DESCRIPTION
## Summary
- add `instructor_fees.csv` to normalized import validation and execution
- generate default PHP instructor fee rows during raw schedule normalization and fixture generation
- update import docs and tests to cover instructor fee data

## Testing
- cd backend && npm run test -- src/test/services/adminImportNormalize.test.ts src/test/api/admins/import-normalize.test.ts