### PR TITLE
Remove redundant instructor tab prefixes

### DIFF
--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
@@ -73,7 +73,7 @@ export default function InstructorTabs({
       content: classScheduleComponent,
     },
     {
-      label: "Instructor's Profile",
+      label: "Profile",
       content: (
         <InstructorProfile
           instructor={instructor}
@@ -83,11 +83,11 @@ export default function InstructorTabs({
       ),
     },
     {
-      label: "Instructor's Availability",
+      label: "Availability",
       content: <AvailabilityCalendar instructorId={instructorId} />,
     },
     {
-      label: "Instructor's Schedule",
+      label: "Schedule",
       content: (
         <InstructorSchedule
           instructorId={instructorId}


### PR DESCRIPTION
## Summary
- remove the repeated "Instructor's" prefix from admin instructor dashboard tab labels
- keep existing "Class Schedule" and "Payroll" labels unchanged

## Testing
- not run