### PR TITLE
Fix instructor payroll period typing

### DIFF
--- a/backend/src/services/instructorPayrollService.ts
+++ b/backend/src/services/instructorPayrollService.ts
@@ -1,5 +1,8 @@
 import { prisma } from "../../prisma/prismaClient";
-import type { InstructorPayrollResponse } from "../../../shared/schemas/admins";
+import type {
+  InstructorPayrollPeriod,
+  InstructorPayrollResponse,
+} from "../../../shared/schemas/admins";
 import type { Status } from "../../generated/prisma";
 
 const PAYROLL_TIMEZONE = "Asia/Tokyo";
@@ -21,7 +24,7 @@ type PayrollClass = {
   isFreeTrial: boolean;
 };
 
-type PayrollPeriodSummary = InstructorPayrollResponse["periods"][number];
+type PayrollPeriodSummary = InstructorPayrollPeriod;
 type PayrollClassWithDateTime = PayrollClass & { dateTime: Date };
 type PayrollTotals = {
   trial: number;


### PR DESCRIPTION
## Summary
- use the explicit shared payroll period type in instructor payroll service
- avoid deriving the period item type through the payroll response tuple
- fix the isolated TypeScript error seen in Vercel for instructor payroll periods

## Testing
- 
