### PR TITLE
Use exclusive instructor fee end dates

### DIFF
--- a/backend/src/services/instructorPayrollService.ts
+++ b/backend/src/services/instructorPayrollService.ts
@@ -149,7 +149,7 @@ const resolveApplicableFee = (
   const matches = feeRecords.filter(
     (fee) =>
       fee.effectiveFrom <= classDateInJst &&
-      (fee.effectiveTo === null || fee.effectiveTo >= classDateInJst),
+      (fee.effectiveTo === null || fee.effectiveTo > classDateInJst),
   );
 
   if (matches.length !== 1) {
@@ -306,7 +306,7 @@ export const getInstructorPayroll = async (
         OR: [
           { effectiveTo: null },
           {
-            effectiveTo: { gte: new Date(`${bounds.firstDay}T00:00:00.000Z`) },
+            effectiveTo: { gt: new Date(`${bounds.firstDay}T00:00:00.000Z`) },
           },
         ],
       },

--- a/backend/src/test/api/admins/instructor-payroll.test.ts
+++ b/backend/src/test/api/admins/instructor-payroll.test.ts
@@ -20,7 +20,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
 
     await createInstructorFee(instructor.id, {
       effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-03-15T00:00:00.000Z"),
+      effectiveTo: new Date("2026-03-16T00:00:00.000Z"),
       trialFee: 1000,
       regularFee: 2000,
       cancelFee: 500,
@@ -160,7 +160,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
             {
               currency: "JPY",
               effectiveFrom: "2026-03-01",
-              effectiveTo: "2026-03-15",
+              effectiveTo: "2026-03-16",
               trialFee: 1000,
               regularFee: 2000,
               cancelFee: 500,
@@ -244,7 +244,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
 
     await createInstructorFee(instructor.id, {
       effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-03-07T00:00:00.000Z"),
+      effectiveTo: new Date("2026-03-08T00:00:00.000Z"),
       trialFee: 1000,
       regularFee: 2000,
       cancelFee: 500,
@@ -252,7 +252,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     });
     await createInstructorFee(instructor.id, {
       effectiveFrom: new Date("2026-03-08T00:00:00.000Z"),
-      effectiveTo: new Date("2026-03-15T00:00:00.000Z"),
+      effectiveTo: new Date("2026-03-16T00:00:00.000Z"),
       trialFee: 1200,
       regularFee: 2200,
       cancelFee: 600,
@@ -338,7 +338,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
         {
           currency: "JPY",
           effectiveFrom: "2026-03-01",
-          effectiveTo: "2026-03-07",
+          effectiveTo: "2026-03-08",
           trialFee: 1000,
           regularFee: 2000,
           cancelFee: 500,
@@ -347,7 +347,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
         {
           currency: "JPY",
           effectiveFrom: "2026-03-08",
-          effectiveTo: "2026-03-15",
+          effectiveTo: "2026-03-16",
           trialFee: 1200,
           regularFee: 2200,
           cancelFee: 600,
@@ -357,6 +357,56 @@ describe("GET /admins/instructors/:id/payroll", () => {
     });
     expect(response.body.periods[1].dailyBreakdown).toEqual([]);
     expect(response.body.periods[1].appliedFeePeriods).toEqual([]);
+  });
+
+  it("uses the new fee rate on the effectiveTo boundary date", async () => {
+    const admin = await createAdmin();
+    const instructor = await createInstructor();
+    const customer = await createCustomer();
+
+    await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-03-16T00:00:00.000Z"),
+      regularFee: 2000,
+    });
+    await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-03-16T00:00:00.000Z"),
+      effectiveTo: null,
+      regularFee: 2500,
+    });
+
+    await createClass(
+      customer.id,
+      instructor.id,
+      jstDateTime("2026-03-16T10:00:00+09:00"),
+      {
+        status: "completed",
+        isFreeTrial: false,
+      },
+    );
+
+    const response = await request(server)
+      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .query({ month: "2026-03" })
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .expect(200);
+
+    expect(response.body.periods[1]).toEqual(
+      expect.objectContaining({
+        currency: "JPY",
+        subtotals: expect.objectContaining({
+          regular: 2500,
+        }),
+        total: 2500,
+        appliedFeePeriods: [
+          expect.objectContaining({
+            effectiveFrom: "2026-03-16",
+            effectiveTo: null,
+            regularFee: 2500,
+          }),
+        ],
+      }),
+    );
   });
 
   it("returns 404 when instructor does not exist", async () => {
@@ -403,7 +453,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     await createInstructorFee(instructor.id, {
       currency: "JPY",
       effectiveFrom: new Date("2026-03-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-03-10T00:00:00.000Z"),
+      effectiveTo: new Date("2026-03-11T00:00:00.000Z"),
     });
     await createInstructorFee(instructor.id, {
       currency: "USD",

--- a/docs/instructor-payroll-design.md
+++ b/docs/instructor-payroll-design.md
@@ -137,12 +137,14 @@ Proposed constraints:
 
 - one currency per fee record
 - no overlapping fee periods for the same instructor
+- `effectiveTo` is exclusive
 - open-ended active period allowed via `effectiveTo = null`
 - every payable class must match exactly one fee record
 
 Editing behavior:
 
 - admins can add a new fee record with a new `effectiveFrom`
+- creating a new fee record sets the previous latest record `effectiveTo` to the same date as the new `effectiveFrom`
 - admins can delete only the latest fee record as an undo operation
 - deleting the latest fee record reopens the previous fee record by setting its `effectiveTo` back to `null`
 - v1 does not block fee edits or deletes based on payroll impact; admins are responsible for maintaining payroll consistency after changes

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -100,6 +100,16 @@ const formatPeriodLabel = (from: string, to: string) => {
   return `${from} to ${to}`;
 };
 
+const formatFeeCoverageEnd = (value: string | null) => {
+  if (!value) {
+    return "Onwards";
+  }
+
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+};
+
 function DailyBreakdownTable({
   rows,
   currency,
@@ -215,7 +225,8 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
               >
                 <div className={styles.feeCardHeader}>
                   <strong>
-                    {fee.effectiveFrom} to {fee.effectiveTo ?? "Onwards"}
+                    {fee.effectiveFrom} to{" "}
+                    {formatFeeCoverageEnd(fee.effectiveTo)}
                   </strong>
                 </div>
                 <dl className={styles.feeGrid}>

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -15,6 +15,16 @@ import styles from "./InstructorProfile.module.scss";
 
 const DEFAULT_CURRENCY = "JPY";
 
+const formatExclusiveEndDate = (value: string | null) => {
+  if (!value) {
+    return "Onwards";
+  }
+
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+};
+
 const formatMoney = (amount: number, currency: string) => {
   try {
     return new Intl.NumberFormat("en-US", {
@@ -28,7 +38,7 @@ const formatMoney = (amount: number, currency: string) => {
 };
 
 const formatPeriod = (fee: InstructorFeeRate) =>
-  `${fee.effectiveFrom} to ${fee.effectiveTo ?? "Onwards"}`;
+  `${fee.effectiveFrom} to ${formatExclusiveEndDate(fee.effectiveTo)}`;
 
 const createFormState = (fee?: InstructorFeeRate | null) => ({
   currency: fee?.currency ?? DEFAULT_CURRENCY,


### PR DESCRIPTION
## Summary
- treat InstructorFee.effectiveTo as an exclusive boundary so adjacent fee rates can share the same switchover date without overlap
- update payroll fee matching and applied fee period expectations for the exclusive end-date model
- render fee periods in the admin UI as covered-through dates by showing the previous day for non-null exclusive end dates

## Testing
- cd shared && npm run format-check
- cd frontend && npm run format-check
- cd frontend && npm run lint
- cd frontend && npm run lint:unused
- cd frontend && npm run build
- cd backend && npm run format-check
- cd backend && npm run lint:unused
- cd backend && npm run test -- src/test/api/admins/instructor-fees.test.ts src/test/api/admins/instructor-payroll.test.ts
- full cd backend && npm run test was started multiple times and progressed with Docker/Postgres running, but I did not capture a complete uninterrupted final pass in this CLI session