### PR TITLE
Center SweetAlert content and fix multiline alignment

### DIFF
--- a/frontend/src/lib/utils/alertUtils.ts
+++ b/frontend/src/lib/utils/alertUtils.ts
@@ -1,14 +1,18 @@
 import Swal from "sweetalert2";
 
+const buildAlertHtml = (text: string): string => `
+  <div style="text-align:center;">
+    <div style="display:inline-block; text-align:left; margin:0 auto;">
+      ${text}
+    </div>
+  </div>
+`;
+
 export const confirmAlert: (text: string) => Promise<boolean> = (
   text: string,
 ) => {
   const result = Swal.fire({
-    html: `
-      <div style="display:block; text-align:left;">
-        ${text}
-      </div>
-    `,
+    html: buildAlertHtml(text),
     icon: "warning",
     confirmButtonText: "OK",
     cancelButtonText: "Cancel",
@@ -32,11 +36,7 @@ export const successAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: `
-      <div style="display:block; text-align:left;">
-        ${text}
-      </div>
-    `,
+    html: buildAlertHtml(text),
     icon: "success",
     confirmButtonText: "OK",
     showConfirmButton: true,
@@ -51,11 +51,7 @@ export const errorAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: `
-      <div style="display:block; text-align:left;">
-        ${text}
-      </div>
-    `,
+    html: buildAlertHtml(text),
     icon: "error",
     confirmButtonText: "OK",
     showConfirmButton: true,
@@ -70,11 +66,7 @@ export const warningAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: `
-      <div style="display:block; text-align:left;">
-        ${text}
-      </div>
-    `,
+    html: buildAlertHtml(text),
     icon: "warning",
     confirmButtonText: "OK",
     showConfirmButton: true,


### PR DESCRIPTION
### Motivation
- Fix SweetAlert message layout so the alert block is centered while multiline text lines start at the same left position, matching the provided screenshots.

### Description
- Added `buildAlertHtml` in `frontend/src/lib/utils/alertUtils.ts` that wraps text in a `text-align:center` container with an `inline-block` inner div using `text-align:left`, and updated `confirmAlert`, `successAlert`, `errorAlert`, and `warningAlert` to use it.

### Testing
- Ran `cd frontend && npm run format`, `cd frontend && npm run lint`, and `cd frontend && npm run lint:unused`, which all completed successfully.
- Attempted an automated Playwright screenshot to validate visual rendering, but the browser run timed out in this environment.