### PR TITLE
Resolve calendar display issues

### DIFF
--- a/frontend/src/components/customers-dashboard/regular-classes/RegularClasses.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/RegularClasses.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import styles from "./RegularClasses.module.scss";
 import { PlusIcon } from "@heroicons/react/24/outline";
 import { getSubscriptionsByCustomerId } from "@/lib/api/subscriptionsApi";
@@ -21,6 +22,7 @@ function RegularClasses({
   userSessionType?: UserType;
 }) {
   const { language } = useLanguage();
+  const router = useRouter();
   const [subscriptionsData, setSubscriptionsData] =
     useState<Subscriptions | null>(null);
   const [showAddPlan, setShowAddPlan] = useState(false);
@@ -35,7 +37,8 @@ function RegularClasses({
   };
 
   const handleUpdateSubscription = () => {
-    setUpdateCount(updateCount + 1);
+    setUpdateCount((count) => count + 1);
+    router.refresh();
   };
 
   useEffect(() => {

--- a/frontend/src/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -3,6 +3,7 @@
 import { getRecurringClassesBySubscriptionId } from "@/lib/api/recurringClassesApi";
 import { getChildrenByCustomerId } from "@/lib/api/childrenApi";
 import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import styles from "./RegularClassesTable.module.scss";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import RegularClassCard from "./RegularClassCard";
@@ -38,6 +39,7 @@ function RegularClassesTable({
   plan?: Plan;
   refreshKey?: number;
 }) {
+  const router = useRouter();
   const [activeRecurringClasses, setActiveRecurringClasses] = useState<
     RecurringClass[]
   >([]);
@@ -138,7 +140,8 @@ function RegularClassesTable({
   };
 
   const handleEditSuccess = () => {
-    setUpdateCount(updateCount + 1);
+    setUpdateCount((count) => count + 1);
+    router.refresh();
     handleCloseEditModal();
   };
 


### PR DESCRIPTION
### Overview
- Add `useRouter` to the following files to call `router.refresh()` after regular class registeration and edit, ensuring calendar data is refreshed immediately, even in admin dashboard:

`frontend/src/components/customers-dashboard/regular-classes/RegularClasses.tsx`
`frontend/src/components/customers-dashboard/regular-classes/RegularClassesTable.tsx`

<img width="600" height="104" alt="Screenshot 2026-03-24 at 1 37 00" src="https://github.com/user-attachments/assets/4f9ca071-626a-42cf-8d21-625615b6b288" />
<img width="600" height="524" alt="Screenshot 2026-03-24 at 1 37 11" src="https://github.com/user-attachments/assets/b65d5633-2a27-43d5-9e24-d5e654b4bf5f" />
