### PR TITLE
Revert from Prisma Postgres to Neon DB

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -55,7 +55,7 @@ jobs:
           --health-retries 10
     env:
       TEST_DATABASE_URL: postgresql://postgres:summer@localhost:5432/postgres?schema=public
-      AMS_PRISMA_DATABASE_URL: postgresql://postgres:summer@localhost:5432/postgres?schema=public
+      POSTGRES_PRISMA_URL: postgresql://postgres:summer@localhost:5432/postgres?schema=public
       FRONTEND_ORIGIN: http://localhost:3000
       RESEND_API_KEY: re_test_dummy
     steps:

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -9,10 +9,10 @@ export default {
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("AMS_PRISMA_DATABASE_URL"),
+    url: env("POSTGRES_PRISMA_URL"),
   },
 } satisfies PrismaConfig;
 
 export const adapter = new PrismaPg({
-  connectionString: process.env.AMS_PRISMA_DATABASE_URL,
+  connectionString: process.env.POSTGRES_PRISMA_URL,
 });

--- a/backend/prisma/prismaClient.ts
+++ b/backend/prisma/prismaClient.ts
@@ -11,7 +11,7 @@ const globalForPrisma = globalThis as unknown as {
 const pool =
   globalForPrisma.pool ??
   new Pool({
-    connectionString: process.env.AMS_PRISMA_DATABASE_URL,
+    connectionString: process.env.POSTGRES_PRISMA_URL,
     max: 2,
     idleTimeoutMillis: 30000, // 30 seconds idle timeout
     connectionTimeoutMillis: 2000, // 2 seconds connection timeout

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -3,7 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient, Prisma } from "../../generated/prisma/client";
 
 const adapter = new PrismaPg({
-  connectionString: process.env.AMS_PRISMA_DATABASE_URL,
+  connectionString: process.env.POSTGRES_PRISMA_URL,
 });
 export const prisma = new PrismaClient({ adapter });
 

--- a/backend/src/test/globalSetup.ts
+++ b/backend/src/test/globalSetup.ts
@@ -68,8 +68,7 @@ export default async function globalSetup() {
 
   const baseDatabaseUrl = await (async () => {
     if (process.env.TEST_DATABASE_URL) return process.env.TEST_DATABASE_URL;
-    if (process.env.AMS_PRISMA_DATABASE_URL)
-      return process.env.AMS_PRISMA_DATABASE_URL;
+    if (process.env.POSTGRES_PRISMA_URL) return process.env.POSTGRES_PRISMA_URL;
     if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
 
     try {
@@ -87,7 +86,7 @@ export default async function globalSetup() {
           "No test database connection is configured.",
           "Testcontainers PostgreSQL startup failed.",
           message,
-          "Fix: start a container runtime (e.g. Docker), set TEST_DATABASE_URL, or set AMS_PRISMA_DATABASE_URL/DATABASE_URL in `backend/.env`.",
+          "Fix: start a container runtime (e.g. Docker), set TEST_DATABASE_URL, or set POSTGRES_PRISMA_URL/DATABASE_URL in `backend/.env`.",
         ].join("\n"),
         { cause: error },
       );

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -25,13 +25,13 @@ await (async () => {
 
     const workerDatabaseUrl = withDatabase(baseDatabaseUrl, workerDbName);
     process.env.DATABASE_URL = workerDatabaseUrl;
-    process.env.AMS_PRISMA_DATABASE_URL = workerDatabaseUrl;
+    process.env.POSTGRES_PRISMA_URL = workerDatabaseUrl;
 
     await ensureDatabaseExists(baseDatabaseUrl, workerDbName);
 
     // Initialize Prisma client (engineType="client" requires a driver adapter)
     const adapter = new PrismaPg({
-      connectionString: process.env.AMS_PRISMA_DATABASE_URL,
+      connectionString: process.env.POSTGRES_PRISMA_URL,
     });
     prisma = new PrismaClient({ adapter });
 


### PR DESCRIPTION
### Overview
- Update database URL to replace Neon DB with Prisma Postgres because it's not cost-effective