### PR TITLE
Enhance security level based on ZAP report (2026-03-12-zap-security-report.html)

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,3 +1,27 @@
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value:
+      "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://localhost:4000 https:; object-src 'none'; upgrade-insecure-requests",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 const nextConfig = {
   turbopack: {
     resolveAlias: {
@@ -10,6 +34,14 @@ const nextConfig = {
         pathname: "/instructors/**",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Motivation

- Harden the frontend by adding common HTTP security headers including a Content Security Policy, Referrer Policy, X-Content-Type-Options, X-Frame-Options, and Permissions-Policy to mitigate XSS, clickjacking, and information leakage.

## Description

- Added a `securityHeaders` array in `frontend/next.config.mjs` defining:
  - `Content-Security-Policy`
  - `Referrer-Policy`
  - `X-Content-Type-Options`
  - `X-Frame-Options`
  - `Permissions-Policy`
- Added an `async headers()` function to `nextConfig` that applies `securityHeaders` to all routes using `source: "/(.*)"`.
- Kept existing `turbopack.resolveAlias` and `images.localPatterns` configuration unchanged.