### PR TITLE
Add JPN version for some items in Instructor Profile page

### DIFF
--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/api/adminsApi";
 import { confirmAlert, errorAlert } from "@/lib/utils/alertUtils";
 import type { InstructorFeeRate } from "@shared/schemas/admins";
+import { useLanguage } from "@/contexts/LanguageContext";
 import styles from "./InstructorProfile.module.scss";
 
 const DEFAULT_CURRENCY = "JPY";
@@ -110,6 +111,7 @@ export default function InstructorFeeRates({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [formState, setFormState] = useState(createFormState());
+  const { language } = useLanguage();
 
   const applyFees = (nextFees: InstructorFeeRate[]) => {
     setFees(nextFees);
@@ -243,7 +245,7 @@ export default function InstructorFeeRates({
     <div className={styles.insideContainer}>
       <BanknotesIcon className={styles.icon} />
       <div className={styles.userInfo}>
-        <p>Fee Rates</p>
+        <p>{language === "en" ? "Fee Rates" : "給料レート"}</p>
         <div className={styles.feeSection}>
           {isLoading ? (
             <p className={styles.feeMutedText}>Loading fee rates...</p>

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -567,7 +567,7 @@ function InstructorProfile({
               <div className={styles.insideContainer}>
                 <EnvelopeIcon className={styles.icon} />
                 <div className={styles.userInfo}>
-                  <p>Email</p>
+                  <p>{language === "en" ? "Email" : "メール"}</p>
                   {isEditing ? (
                     <InputField
                       name="email"
@@ -599,7 +599,7 @@ function InstructorProfile({
               <div className={styles.insideContainer}>
                 <VideoCameraIcon className={styles.icon} />
                 <div className={styles.userInfo}>
-                  <p>Class URL</p>
+                  <p>{language === "en" ? "Class URL" : "クラスURL"}</p>
                   {isEditing ? (
                     <InputField
                       name="classURL"
@@ -637,7 +637,10 @@ function InstructorProfile({
                   )}
 
                   <div className={styles.urlInfo}>
-                    <p>Meeting ID&nbsp;:&nbsp;</p>
+                    <p>
+                      {language === "en" ? "Meeting ID" : "ミーティングID"}
+                      &nbsp;:&nbsp;
+                    </p>
                     {isEditing ? (
                       <InputField
                         name="meetingId"
@@ -664,7 +667,10 @@ function InstructorProfile({
                     )}
                   </div>
                   <div className={styles.urlInfo}>
-                    <p>Passcode&nbsp;&nbsp;:&nbsp;</p>
+                    <p>
+                      {language === "en" ? "Passcode" : "パスコード"}
+                      &nbsp;&nbsp;:&nbsp;
+                    </p>
                     {isEditing ? (
                       <InputField
                         name="passcode"


### PR DESCRIPTION
### Overview
- Add Japanese expression in some items to Instructor Profile page in admin dashboard

[Before]
<img width="800" height="726" alt="Screenshot 2026-03-28 at 18 07 36" src="https://github.com/user-attachments/assets/747813dd-add6-49b9-b8de-5852837b9288" />


[After]
<img width="800" height="740" alt="Screenshot 2026-03-28 at 18 17 45" src="https://github.com/user-attachments/assets/5a6da2bc-9a85-4d22-9315-955e62ed7d17" />