### PR TITLE
Improve Announcements section

### DIFF
--- a/frontend/src/components/admins-dashboard/dashboard/DashboardClient.module.scss
+++ b/frontend/src/components/admins-dashboard/dashboard/DashboardClient.module.scss
@@ -204,7 +204,7 @@
 }
 
 .instructorPickerScrollableArea {
-  max-height: 430px;
+  height: 300px;
   overflow-y: auto;
   padding-right: 0.2rem;
 }

--- a/frontend/src/components/customers-dashboard/classes/ClassCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/ClassCalendar.tsx
@@ -55,6 +55,8 @@ export default async function ClassCalendar({
       <MessageBoardPanel
         posts={visiblePosts}
         storageKey="customerClassCalendarMessageBoardOpenState"
+        readMessageStorageKey={`readMessageNumber:customer:${customerId}`}
+        adminId={adminId}
       />
 
       <ClassActions

--- a/frontend/src/components/features/messageBoardPanel/MessageBoardPanel.module.scss
+++ b/frontend/src/components/features/messageBoardPanel/MessageBoardPanel.module.scss
@@ -59,17 +59,55 @@
     color: #7f7d9d;
     font-size: 0.8rem;
   }
+}
 
-  button {
-    align-self: flex-start;
-    border: 1px solid $blue_primary;
-    background: white;
-    color: $blue_primary;
-    border-radius: 8px;
-    padding: 0.35rem 0.6rem;
-    cursor: pointer;
-    font-weight: 600;
+.footerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.newMessageNotification {
+  color: #d50000;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.readReactionButton {
+  width: fit-content;
+  background: transparent;
+  border: none;
+  color: $blue_primary;
+  cursor: pointer;
+  transform: translateY(6px);
+  margin: 0 0.1rem 0 0.5rem;
+  line-height: 0;
+
+  svg {
+    width: 25px;
+    height: 25px;
   }
+}
+
+.markAsRead {
+  font-size: 12px;
+  color: $blue_primary;
+}
+
+.hasRead {
+  font-size: 12px;
+  color: #9998ac;
+}
+
+.pastMessagesButton {
+  align-self: flex-start;
+  border: 1px solid $blue_primary;
+  background: white;
+  color: $blue_primary;
+  border-radius: 8px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  font-weight: 600;
 }
 
 .messageModalContent {

--- a/frontend/src/components/features/messageBoardPanel/MessageBoardPanel.tsx
+++ b/frontend/src/components/features/messageBoardPanel/MessageBoardPanel.tsx
@@ -4,23 +4,46 @@ import { useEffect, useState } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import Modal from "@/components/elements/modal/Modal";
 import styles from "./MessageBoardPanel.module.scss";
-import { MegaphoneIcon } from "@heroicons/react/24/outline";
+import { HandThumbUpIcon, MegaphoneIcon } from "@heroicons/react/24/outline";
 
 type MessageBoardPanelProps = {
   posts: MessageBoardPostItem[];
   storageKey: string;
+  readMessageStorageKey: string;
+  adminId?: number;
 };
 
 export default function MessageBoardPanel({
   posts,
   storageKey,
+  readMessageStorageKey,
+  adminId,
 }: MessageBoardPanelProps) {
   const [isOpen, setIsOpen] = useState(() => {
     if (typeof window === "undefined") return true;
     return localStorage.getItem(storageKey) !== "closed";
   });
+  const [readMessageNumber, setReadMessageNumber] = useState<number | null>(
+    () => {
+      if (typeof window === "undefined") return null;
+
+      const storedReadMessageNumber = localStorage.getItem(
+        readMessageStorageKey,
+      );
+      if (!storedReadMessageNumber) return null;
+
+      const parsedReadMessageNumber = Number(storedReadMessageNumber);
+      return Number.isNaN(parsedReadMessageNumber)
+        ? null
+        : parsedReadMessageNumber;
+    },
+  );
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const latestPost = posts[0] ?? null;
+  const hasReadLatestMessage =
+    latestPost !== null &&
+    readMessageNumber !== null &&
+    readMessageNumber >= latestPost.id;
   const { language } = useLanguage();
   const formatDate = (value: string) => {
     const date = new Date(value);
@@ -40,6 +63,13 @@ export default function MessageBoardPanel({
     localStorage.setItem(storageKey, isOpen ? "open" : "closed");
   }, [isOpen, storageKey]);
 
+  const handleReadReactionClick = () => {
+    if (!latestPost) return;
+
+    localStorage.setItem(readMessageStorageKey, String(latestPost.id));
+    setReadMessageNumber(latestPost.id);
+  };
+
   if (!latestPost) return null;
 
   return (
@@ -48,8 +78,14 @@ export default function MessageBoardPanel({
         <div className={styles.headerRow}>
           <h3>
             <MegaphoneIcon className={styles.icon} />
-            {language === "en" ? "Announcements" : "お知らせ"}
+            {language === "en" ? "Announcements" : "お知らせ"}{" "}
+            {!hasReadLatestMessage ? (
+              <span className={styles.newMessageNotification}>
+                ({language === "en" ? "New message" : "新着メッセージ"})
+              </span>
+            ) : null}
           </h3>
+
           <button
             type="button"
             className={styles.toggleButton}
@@ -64,14 +100,46 @@ export default function MessageBoardPanel({
         {isOpen ? (
           <div className={styles.body}>
             <p>{latestPost.body}</p>
-            <time>{formatDate(latestPost.createdAt)}</time>
-            {posts.length > 1 ? (
-              <button type="button" onClick={() => setIsHistoryOpen(true)}>
-                {language === "en"
-                  ? "View past messages"
-                  : "過去のメッセージを表示"}
-              </button>
-            ) : null}
+            <div className={styles.footerRow}>
+              <div>
+                <time>{formatDate(latestPost.createdAt)}</time>
+                <button
+                  type="button"
+                  disabled={adminId !== undefined}
+                  className={`${styles.readReactionButton} ${
+                    hasReadLatestMessage ? styles.hasRead : ""
+                  }`}
+                  onClick={handleReadReactionClick}
+                  aria-label={
+                    language === "en"
+                      ? "Mark newest announcement as read"
+                      : "最新のお知らせを既読にする"
+                  }
+                >
+                  <HandThumbUpIcon />
+                </button>
+                {!hasReadLatestMessage ? (
+                  <span className={styles.markAsRead}>
+                    ({language === "en" ? "Mark as read" : "既読にする"})
+                  </span>
+                ) : (
+                  <span className={styles.hasRead}>
+                    ({language === "en" ? "Has read" : "既読"})
+                  </span>
+                )}
+              </div>
+              {posts.length > 1 ? (
+                <button
+                  type="button"
+                  className={styles.pastMessagesButton}
+                  onClick={() => setIsHistoryOpen(true)}
+                >
+                  {language === "en"
+                    ? "View past messages"
+                    : "過去のメッセージを表示"}
+                </button>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </section>

--- a/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
+++ b/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
@@ -79,6 +79,8 @@ const InstructorCalendarClient = ({
       <MessageBoardPanel
         posts={visiblePosts}
         storageKey="instructorClassScheduleMessageBoardOpenState"
+        readMessageStorageKey={`readMessageNumber:instructor:${instructorId}`}
+        adminId={adminId}
       />
       <div className={styles.mobileToolbar}>
         <div className={styles.navGroup}>

--- a/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
+++ b/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient.tsx
@@ -80,7 +80,7 @@ const InstructorCalendarClient = ({
         posts={visiblePosts}
         storageKey="instructorClassScheduleMessageBoardOpenState"
         readMessageStorageKey={`readMessageNumber:instructor:${instructorId}`}
-        adminId={adminId}
+        adminId={adminId ?? undefined}
       />
       <div className={styles.mobileToolbar}>
         <div className={styles.navGroup}>


### PR DESCRIPTION
### Overview
- Add reaction icon to Announcements section
- If a new message is posted, the section is highlighted with red color message
- Once the reaction is clicked, the new message is marked as "has read"

### Screenshots
[English version]
<img width="800" height="142" alt="Screenshot 2026-04-01 at 23 13 38" src="https://github.com/user-attachments/assets/396c2af3-98cb-47ec-9db5-bc12fc436b0b" />
<img width="800" height="139" alt="Screenshot 2026-04-01 at 23 13 49" src="https://github.com/user-attachments/assets/7b0c22ef-cabc-4f0d-9b16-797366115b70" />

###
[Japanese version]
<img width="800" height="142" alt="Screenshot 2026-04-01 at 23 13 10" src="https://github.com/user-attachments/assets/a6eeaa10-9c81-43e5-818a-924e6191074d" />
<img width="800" height="146" alt="Screenshot 2026-04-01 at 23 12 58" src="https://github.com/user-attachments/assets/13ed8ec6-de62-4b20-b6a2-e6ceca90854e" />