### PR TITLE
Terminate recurring classes on schedule updates

### DIFF
--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -1,7 +1,44 @@
 import { prisma } from "../../prisma/prismaClient";
 import { Prisma } from "../../generated/prisma";
-import { nDaysLater, nHoursLater } from "../utils/dateUtils";
+import { JAPAN_TIME_DIFF, nDaysLater, nHoursLater } from "../utils/dateUtils";
 import { EnglishBackground } from "../types";
+
+function findFirstSlotOccurrenceOnOrAfter(
+  effectiveFrom: Date,
+  weekday: number,
+  startTime: Date,
+): Date {
+  const slotHours = startTime.getUTCHours();
+  const slotMinutes = startTime.getUTCMinutes();
+  const currentWeekday = effectiveFrom.getUTCDay();
+  const daysUntilSlot = (weekday - currentWeekday + 7) % 7;
+
+  const occurrence = new Date(effectiveFrom);
+  occurrence.setUTCDate(occurrence.getUTCDate() + daysUntilSlot);
+  occurrence.setUTCHours(slotHours - JAPAN_TIME_DIFF, slotMinutes, 0, 0);
+
+  return occurrence;
+}
+
+function matchesRecurringSlotInJst(
+  startAt: Date | null,
+  weekday: number,
+  startTime: Date,
+): boolean {
+  if (!startAt) {
+    return false;
+  }
+
+  const jstStartAt = new Date(
+    startAt.getTime() + JAPAN_TIME_DIFF * 60 * 60 * 1000,
+  );
+
+  return (
+    jstStartAt.getUTCDay() === weekday &&
+    jstStartAt.getUTCHours() === startTime.getUTCHours() &&
+    jstStartAt.getUTCMinutes() === startTime.getUTCMinutes()
+  );
+}
 
 export const getInstructorSchedules = async (instructorId: number) => {
   try {
@@ -136,18 +173,15 @@ export const createInstructorSchedule = async (data: {
             ),
         );
 
-        const effectiveWeekday = effectiveFrom.getUTCDay();
-        const datePrefix = effectiveFrom.toISOString().slice(0, 10);
         const lockedSlotDateTimes = Array.from(
           new Set(
-            removedSlots
-              .filter((removedSlot) => removedSlot.weekday === effectiveWeekday)
-              .map((removedSlot) => {
-                const slotTime = removedSlot.startTime
-                  .toISOString()
-                  .slice(11, 19);
-                return new Date(`${datePrefix}T${slotTime}.000Z`).toISOString();
-              }),
+            removedSlots.map((removedSlot) =>
+              findFirstSlotOccurrenceOnOrAfter(
+                effectiveFrom,
+                removedSlot.weekday,
+                removedSlot.startTime,
+              ).toISOString(),
+            ),
           ),
         );
 
@@ -172,6 +206,53 @@ export const createInstructorSchedule = async (data: {
               updatedAt: now,
             },
           });
+        }
+
+        if (removedSlots.length > 0) {
+          const recurringClasses = await tx.recurringClass.findMany({
+            where: {
+              instructorId,
+              OR: [{ endAt: null }, { endAt: { gte: effectiveFrom } }],
+            },
+            select: {
+              id: true,
+              startAt: true,
+              endAt: true,
+            },
+          });
+
+          for (const removedSlot of removedSlots) {
+            const removedSlotDateTime = findFirstSlotOccurrenceOnOrAfter(
+              effectiveFrom,
+              removedSlot.weekday,
+              removedSlot.startTime,
+            );
+
+            const matchingRecurringClasses = recurringClasses.filter(
+              (recurringClass) =>
+                matchesRecurringSlotInJst(
+                  recurringClass.startAt,
+                  removedSlot.weekday,
+                  removedSlot.startTime,
+                ) &&
+                (!recurringClass.endAt ||
+                  recurringClass.endAt >= removedSlotDateTime),
+            );
+
+            for (const recurringClass of matchingRecurringClasses) {
+              await tx.recurringClass.update({
+                where: { id: recurringClass.id },
+                data: { endAt: removedSlotDateTime },
+              });
+
+              await tx.class.deleteMany({
+                where: {
+                  recurringClassId: recurringClass.id,
+                  dateTime: { gt: removedSlotDateTime },
+                },
+              });
+            }
+          }
         }
       }
 

--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -124,6 +124,8 @@ export const createInstructorSchedule = async (data: {
     const { instructorId, effectiveFrom, timezone, slots } = data;
 
     return await prisma.$transaction(async (tx) => {
+      let canceledClassCount = 0;
+      const terminatedRecurringClassIds = new Set<number>();
       const existingSchedules = await tx.instructorSchedule.findMany({
         where: { instructorId: instructorId },
         select: {
@@ -191,7 +193,7 @@ export const createInstructorSchedule = async (data: {
           const lockKey = `instructor:${instructorId}:${lockedSlotDateTime.toISOString()}`;
           await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
 
-          await tx.class.updateMany({
+          const canceledClasses = await tx.class.updateMany({
             where: {
               instructorId,
               dateTime: lockedSlotDateTime,
@@ -206,6 +208,7 @@ export const createInstructorSchedule = async (data: {
               updatedAt: now,
             },
           });
+          canceledClassCount += canceledClasses.count;
         }
 
         if (removedSlots.length > 0) {
@@ -244,6 +247,7 @@ export const createInstructorSchedule = async (data: {
                 where: { id: recurringClass.id },
                 data: { endAt: removedSlotDateTime },
               });
+              terminatedRecurringClassIds.add(recurringClass.id);
 
               await tx.class.deleteMany({
                 where: {
@@ -306,11 +310,17 @@ export const createInstructorSchedule = async (data: {
       }
 
       return {
-        ...createdSchedule,
-        slots: createdSchedule.slots.map((slot) => ({
-          ...slot,
-          startTime: extractTime(slot.startTime),
-        })),
+        schedule: {
+          ...createdSchedule,
+          slots: createdSchedule.slots.map((slot) => ({
+            ...slot,
+            startTime: extractTime(slot.startTime),
+          })),
+        },
+        impactSummary: {
+          canceledClassCount,
+          terminatedRecurringClassCount: terminatedRecurringClassIds.size,
+        },
       };
     });
   } catch (error) {

--- a/backend/src/test/api/instructors/schedules.test.ts
+++ b/backend/src/test/api/instructors/schedules.test.ts
@@ -11,6 +11,8 @@ import {
   createInstructorAbsence,
   createClass,
   createCustomer,
+  createPlan,
+  createSubscription,
   generateAuthCookie,
   generateTestInstructor,
 } from "../../testUtils";
@@ -164,6 +166,86 @@ describe("POST /instructors/:id/schedules", () => {
       expect(updatedExistingSchedule?.effectiveTo).toEqual(
         new Date("2025-03-01"),
       );
+    });
+
+    it("terminates matching recurring classes when a slot is removed", async () => {
+      const admin = await createAdmin();
+      const authCookie = await generateAuthCookie(admin.id, "admin");
+      const instructor = await createInstructor();
+      const customer = await createCustomer();
+      const plan = await createPlan();
+      const subscription = await createSubscription(plan.id, customer.id, {
+        startAt: new Date("2025-01-01T00:00:00.000Z"),
+        endAt: new Date("2025-12-31T00:00:00.000Z"),
+      });
+
+      const existingSchedule = await createInstructorSchedule(instructor.id, {
+        effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
+        effectiveTo: null,
+        timezone: "Asia/Tokyo",
+      });
+      await createInstructorSlot(existingSchedule.id, 3, new Date(time`09:00`));
+
+      const recurringClass = await prisma.recurringClass.create({
+        data: {
+          instructorId: instructor.id,
+          subscriptionId: subscription.id,
+          startAt: new Date("2025-01-08T00:00:00.000Z"),
+          endAt: null,
+        },
+      });
+
+      const affectedClass = await createClass(
+        customer.id,
+        instructor.id,
+        new Date("2025-01-15T00:00:00.000Z"),
+        {
+          recurringClassId: recurringClass.id,
+          subscriptionId: subscription.id,
+          status: "booked",
+        },
+      );
+
+      const futureClass = await createClass(
+        customer.id,
+        instructor.id,
+        new Date("2025-01-22T00:00:00.000Z"),
+        {
+          recurringClassId: recurringClass.id,
+          subscriptionId: subscription.id,
+          status: "booked",
+        },
+      );
+
+      await request(server)
+        .post(`/instructors/${instructor.id}/schedules`)
+        .set("Cookie", authCookie)
+        .send({
+          effectiveFrom: "2025-01-15",
+          timezone: "Asia/Tokyo",
+          slots: [],
+        })
+        .expect(201);
+
+      const updatedRecurringClass = await prisma.recurringClass.findUnique({
+        where: { id: recurringClass.id },
+      });
+      expect(updatedRecurringClass?.endAt?.toISOString()).toBe(
+        "2025-01-15T00:00:00.000Z",
+      );
+
+      const canceledAffectedClass = await prisma.class.findUnique({
+        where: { id: affectedClass.id },
+      });
+      expect(canceledAffectedClass?.status).toBe("canceledByInstructor");
+      expect(canceledAffectedClass?.rebookableUntil?.toISOString()).toBe(
+        "2025-07-14T00:00:00.000Z",
+      );
+
+      const deletedFutureClass = await prisma.class.findUnique({
+        where: { id: futureClass.id },
+      });
+      expect(deletedFutureClass).toBeNull();
     });
   });
 });

--- a/backend/src/test/api/instructors/schedules.test.ts
+++ b/backend/src/test/api/instructors/schedules.test.ts
@@ -96,14 +96,14 @@ describe("POST /instructors/:id/schedules", () => {
         .send(requestBody)
         .expect(201);
 
-      expect(response.body.data).toMatchObject({
+      expect(response.body.data.schedule).toMatchObject({
         instructorId: instructor.id,
         effectiveFrom: "2025-02-01T00:00:00.000Z",
         effectiveTo: null,
         timezone: "Asia/Tokyo",
       });
-      expect(response.body.data.slots).toHaveLength(2);
-      expect(response.body.data.slots).toEqual(
+      expect(response.body.data.schedule.slots).toHaveLength(2);
+      expect(response.body.data.schedule.slots).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             weekday: 1,
@@ -115,6 +115,10 @@ describe("POST /instructors/:id/schedules", () => {
           }),
         ]),
       );
+      expect(response.body.data.impactSummary).toEqual({
+        canceledClassCount: 0,
+        terminatedRecurringClassCount: 0,
+      });
     });
 
     it("succeed adding new schedule version and ending existing schedule", async () => {
@@ -151,11 +155,15 @@ describe("POST /instructors/:id/schedules", () => {
         .send(requestBody)
         .expect(201);
 
-      expect(response.body.data).toMatchObject({
+      expect(response.body.data.schedule).toMatchObject({
         instructorId: instructor.id,
         effectiveFrom: "2025-03-01T00:00:00.000Z",
         effectiveTo: null,
         timezone: "Asia/Tokyo",
+      });
+      expect(response.body.data.impactSummary).toEqual({
+        canceledClassCount: 0,
+        terminatedRecurringClassCount: 0,
       });
 
       // Verify existing schedule was ended
@@ -217,7 +225,7 @@ describe("POST /instructors/:id/schedules", () => {
         },
       );
 
-      await request(server)
+      const response = await request(server)
         .post(`/instructors/${instructor.id}/schedules`)
         .set("Cookie", authCookie)
         .send({
@@ -226,6 +234,11 @@ describe("POST /instructors/:id/schedules", () => {
           slots: [],
         })
         .expect(201);
+
+      expect(response.body.data.impactSummary).toEqual({
+        canceledClassCount: 1,
+        terminatedRecurringClassCount: 1,
+      });
 
       const updatedRecurringClass = await prisma.recurringClass.findUnique({
         where: { id: recurringClass.id },
@@ -1090,11 +1103,15 @@ describe("POST /instructors/:id/schedules", () => {
       })
       .expect(201);
 
-    expect(response.body.data).toMatchObject({
+    expect(response.body.data.schedule).toMatchObject({
       instructorId: instructor.id,
       effectiveFrom: "2025-02-01T00:00:00.000Z",
       effectiveTo: null,
       timezone: "Asia/Tokyo",
+    });
+    expect(response.body.data.impactSummary).toEqual({
+      canceledClassCount: 0,
+      terminatedRecurringClassCount: 0,
     });
   });
 });

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AddScheduleModal.tsx
@@ -11,7 +11,7 @@ interface AddScheduleModalProps {
   onSubmit: (
     effectiveFrom: string,
     slots: Omit<InstructorSlot, "scheduleId">[],
-  ) => void;
+  ) => Promise<boolean>;
   initialSlots?: InstructorSlot[];
 }
 
@@ -49,6 +49,7 @@ export default function AddScheduleModal({
   const [editedSlots, setEditedSlots] = useState<Set<string>>(() =>
     slotsToKeys(initialSlots),
   );
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const toggleSlot = (weekday: number, time: string) => {
     const key = slotToKey(weekday, time);
@@ -63,12 +64,21 @@ export default function AddScheduleModal({
     });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (effectiveFrom) {
-      const slots = keysToSlots(editedSlots);
-      onSubmit(effectiveFrom, slots);
-      onClose();
+    if (!effectiveFrom || isSubmitting) {
+      return;
+    }
+
+    const slots = keysToSlots(editedSlots);
+    setIsSubmitting(true);
+    try {
+      const succeeded = await onSubmit(effectiveFrom, slots);
+      if (succeeded) {
+        onClose();
+      }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -149,9 +159,9 @@ export default function AddScheduleModal({
             <button
               type="submit"
               className={styles.submitButton}
-              disabled={!effectiveFrom}
+              disabled={!effectiveFrom || isSubmitting}
             >
-              Create Schedule
+              {isSubmitting ? "Creating..." : "Create Schedule"}
             </button>
           </div>
         </form>

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/InstructorSchedule.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/InstructorSchedule.tsx
@@ -9,9 +9,13 @@ import {
   InstructorScheduleWithSlots,
   InstructorSlot,
 } from "@/lib/api/instructorsApi";
-import type { InstructorSchedule as Schedule } from "@shared/schemas/instructors";
+import type {
+  InstructorSchedule as Schedule,
+  ScheduleUpdateImpactSummary,
+} from "@shared/schemas/instructors";
 import ScheduleCalendar from "./ScheduleCalendar";
 import AddScheduleModal from "./AddScheduleModal";
+import ScheduleImpactDialog from "./ScheduleImpactDialog";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
 import { toast } from "react-toastify";
 import { errorAlert } from "@/lib/utils/alertUtils";
@@ -39,6 +43,9 @@ export default function InstructorSchedule({
   const [selectedSchedule, setSelectedSchedule] =
     useState<InstructorScheduleWithSlots | null>(initialSelectedSchedule);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [scheduleImpact, setScheduleImpact] =
+    useState<ScheduleUpdateImpactSummary | null>(null);
+  const [isImpactDialogOpen, setIsImpactDialogOpen] = useState(false);
 
   const loadSchedules = async () => {
     try {
@@ -92,19 +99,28 @@ export default function InstructorSchedule({
 
       if ("message" in response) {
         errorAlert(response.message as string);
-        return;
+        return false;
       }
 
       // Refresh schedules and select the new one
       await loadSchedules();
       setSelectedScheduleId(response.schedule.id);
       setSelectedSchedule(response.schedule);
+      if (
+        response.impactSummary.canceledClassCount > 0 ||
+        response.impactSummary.terminatedRecurringClassCount > 0
+      ) {
+        setScheduleImpact(response.impactSummary);
+        setIsImpactDialogOpen(true);
+      }
       toast.success("Schedule created successfully.");
+      return true;
     } catch (error) {
       console.error("Failed to create schedule:", error);
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error occurred";
       errorAlert(`Failed to create schedule: ${errorMessage}`);
+      return false;
     }
   };
 
@@ -162,6 +178,12 @@ export default function InstructorSchedule({
           initialSlots={selectedSchedule?.slots || []}
         />
       )}
+
+      <ScheduleImpactDialog
+        isOpen={isImpactDialogOpen}
+        onClose={() => setIsImpactDialogOpen(false)}
+        impactSummary={scheduleImpact}
+      />
     </>
   );
 }

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.module.scss
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.module.scss
@@ -1,0 +1,49 @@
+@use "@/styles/variables.module.scss" as *;
+
+.content {
+  width: min(520px, 90vw);
+  padding: 24px;
+}
+
+.title {
+  margin: 0 0 12px;
+  color: $blue_primary;
+  font-size: 1.35rem;
+}
+
+.description {
+  margin: 0 0 16px;
+  line-height: 1.6;
+}
+
+.impactList {
+  margin: 0 0 20px;
+  padding-left: 20px;
+  line-height: 1.7;
+}
+
+.note {
+  margin: 0 0 20px;
+  color: #5f6773;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.closeButton {
+  padding: 10px 20px;
+  border: 0;
+  border-radius: 6px;
+  background-color: $blue_primary;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $blue_primary_hover;
+  }
+}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Modal from "@/components/elements/modal/Modal";
+import type { ScheduleUpdateImpactSummary } from "@shared/schemas/instructors";
+import styles from "./ScheduleImpactDialog.module.scss";
+
+interface ScheduleImpactDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  impactSummary: ScheduleUpdateImpactSummary | null;
+}
+
+export default function ScheduleImpactDialog({
+  isOpen,
+  onClose,
+  impactSummary,
+}: ScheduleImpactDialogProps) {
+  if (!impactSummary) {
+    return null;
+  }
+
+  const { canceledClassCount, terminatedRecurringClassCount } = impactSummary;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} overlayClosable={true}>
+      <div className={styles.content}>
+        <h3 className={styles.title}>Schedule Update Impact</h3>
+        <p className={styles.description}>
+          This schedule update affected existing bookings.
+        </p>
+        <ul className={styles.impactList}>
+          {terminatedRecurringClassCount > 0 && (
+            <li>
+              {terminatedRecurringClassCount} regular{" "}
+              {terminatedRecurringClassCount === 1 ? "class was" : "classes were"}{" "}
+              terminated.
+            </li>
+          )}
+          {canceledClassCount > 0 && (
+            <li>
+              {canceledClassCount} booked{" "}
+              {canceledClassCount === 1 ? "class was" : "classes were"}{" "}
+              canceled by the instructor.
+            </li>
+          )}
+        </ul>
+        <p className={styles.note}>
+          Canceled classes remain available for the existing rebooking flow.
+        </p>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={onClose}
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleImpactDialog.tsx
@@ -32,15 +32,17 @@ export default function ScheduleImpactDialog({
           {terminatedRecurringClassCount > 0 && (
             <li>
               {terminatedRecurringClassCount} regular{" "}
-              {terminatedRecurringClassCount === 1 ? "class was" : "classes were"}{" "}
+              {terminatedRecurringClassCount === 1
+                ? "class was"
+                : "classes were"}{" "}
               terminated.
             </li>
           )}
           {canceledClassCount > 0 && (
             <li>
               {canceledClassCount} booked{" "}
-              {canceledClassCount === 1 ? "class was" : "classes were"}{" "}
-              canceled by the instructor.
+              {canceledClassCount === 1 ? "class was" : "classes were"} canceled
+              by the instructor.
             </li>
           )}
         </ul>

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -20,6 +20,7 @@ import type {
   SimpleInstructorProfile,
   CreateScheduleRequest,
   ActiveInstructorSchedule,
+  ScheduleUpdateImpactSummary,
   AvailableSlotsQuery,
   AvailableSlotsResponse,
   InstructorAbsence,
@@ -825,10 +826,13 @@ export const createInstructorSchedule = async (
     }
 
     const result = (await response.json()) as {
-      data: ActiveInstructorSchedule;
+      data: {
+        schedule: ActiveInstructorSchedule;
+        impactSummary: ScheduleUpdateImpactSummary;
+      };
     };
 
-    return { schedule: result.data };
+    return result.data;
   } catch (error) {
     console.error("Failed to create instructor schedule:", error);
     throw error;

--- a/shared/schemas/instructors.ts
+++ b/shared/schemas/instructors.ts
@@ -209,6 +209,19 @@ export const ActiveInstructorSchedule = z.object({
   slots: z.array(InstructorSlot).describe("Array of instructor time slots"),
 });
 
+export const ScheduleUpdateImpactSummary = z.object({
+  canceledClassCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe("Number of booked or rebooked classes canceled by the update"),
+  terminatedRecurringClassCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe("Number of recurring classes terminated by the update"),
+});
+
 export const ActiveScheduleResponse = z.object({
   message: z.string().describe("Success message"),
   data: ActiveInstructorSchedule.describe(
@@ -355,9 +368,16 @@ export const CreateScheduleRequest = z.object({
 
 export const CreateScheduleResponse = z.object({
   message: z.string().describe("Success message"),
-  data: ActiveInstructorSchedule.describe(
-    "Created instructor schedule with slots",
-  ),
+  data: z
+    .object({
+      schedule: ActiveInstructorSchedule.describe(
+        "Created instructor schedule with slots",
+      ),
+      impactSummary: ScheduleUpdateImpactSummary.describe(
+        "Summary of regular classes and classes affected by the schedule update",
+      ),
+    })
+    .describe("Created schedule result"),
 });
 
 // Instructor absence schemas
@@ -432,6 +452,9 @@ export type ClassInstructorResponse = z.infer<typeof ClassInstructorResponse>;
 export type ActiveScheduleQuery = z.infer<typeof ActiveScheduleQuery>;
 export type InstructorSlot = z.infer<typeof InstructorSlot>;
 export type ActiveInstructorSchedule = z.infer<typeof ActiveInstructorSchedule>;
+export type ScheduleUpdateImpactSummary = z.infer<
+  typeof ScheduleUpdateImpactSummary
+>;
 export type ActiveScheduleResponse = z.infer<typeof ActiveScheduleResponse>;
 export type AvailableSlotsQuery = z.infer<typeof AvailableSlotsQuery>;
 export type InstructorAvailableSlotsQuery = z.infer<


### PR DESCRIPTION
## Summary
- terminate recurring classes when an instructor schedule update removes their slot
- cancel the first affected booked class at the correct JST-backed occurrence and report impact counts in the schedule-create API response
- show an admin dialog after schedule creation when the update terminated regular classes or canceled booked classes

## Why
When an instructor schedule removed a slot, the system previously did not end the linked recurring class, and the admin UI gave no direct feedback when a schedule update affected existing bookings.

## Impact
Regular classes tied to removed schedule slots are now ended automatically at the first removed occurrence on or after the new schedule's `effectiveFrom` date. Later generated classes in that series are removed, the first affected occurrence is canceled by instructor for the existing rebooking flow, and the admin UI now surfaces a post-update dialog whenever booked classes or regular classes were affected.

## Testing
- `npx vitest run src/test/api/instructors/schedules.test.ts`
- `npx vitest run src/test/api/instructors/schedules.test.ts src/test/api/recurringClasses.test.ts src/test/concurrency/schedule-update-vs-booking.test.ts`
- `npm run build` (frontend)
