### PR TITLE
Fix instructor registration field error mapping

### DIFF
--- a/frontend/src/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/components/features/registerForm/RegisterForm.tsx
@@ -135,7 +135,7 @@ const RegisterForm = ({
                 placeholder="e.g., John"
                 icon={<UserCircleIcon className={styles.icon} />}
                 inputRequired
-                error={localMessages.name}
+                error={localMessages.nickname}
                 onChange={() => clearErrorMessage("nickname")}
               />
 
@@ -222,6 +222,7 @@ const RegisterForm = ({
                 placeholder="e.g., https://zoom.us/j/..."
                 icon={<LinkIcon className={styles.icon} />}
                 inputRequired
+                error={localMessages.classURL}
                 onChange={() => clearErrorMessage("classURL")}
               />
 
@@ -235,6 +236,7 @@ const RegisterForm = ({
                 placeholder="e.g., 123 456 7890"
                 icon={<IdentificationIcon className={styles.icon} />}
                 inputRequired
+                error={localMessages.meetingId}
                 onChange={() => clearErrorMessage("meetingId")}
               />
 
@@ -248,6 +250,7 @@ const RegisterForm = ({
                 placeholder="e.g., 123456"
                 icon={<KeyIcon className={styles.icon} />}
                 inputRequired
+                error={localMessages.passcode}
                 onChange={() => clearErrorMessage("passcode")}
               />
 

--- a/frontend/src/lib/types.d.ts
+++ b/frontend/src/lib/types.d.ts
@@ -228,9 +228,13 @@ type ForgotPasswordFormState = {
 type RegisterFormState = {
   password?: string;
   name?: string;
+  nickname?: string;
   englishBackground?: EnglishBackground;
   email?: string;
   passConfirmation?: string;
+  classURL?: string;
+  meetingId?: string;
+  passcode?: string;
   prefecture?: string;
   isAgreed?: string;
   weeklyClassTimes?: string;


### PR DESCRIPTION
## Summary
- fix the instructor registration nickname field to show nickname validation errors instead of name errors
- surface existing field-level validation messages for class URL, meeting ID, and passcode in the instructor registration form

## Why
The form already returned validation errors for these instructor fields, but the nickname input was wired to the wrong error key and the URL/meeting/passcode inputs did not render their field-level errors at all. That made registration failures harder to understand and forced users to rely on generic form feedback.

## Impact
Admins registering instructors now see validation feedback directly under the field that failed, which makes correction faster and reduces ambiguity in the modal flow.

## Root Cause
`RegisterForm` mapped the nickname input to `localMessages.name` instead of `localMessages.nickname`, and the other instructor-only fields were missing `error` props even though the server action and schema already produced those messages.

## Testing
- `cd frontend && npm run lint`