### PR TITLE
[codex] Show canceled classes after absence registration

### DIFF
--- a/backend/src/controllers/instructorAbsenceController.ts
+++ b/backend/src/controllers/instructorAbsenceController.ts
@@ -44,14 +44,14 @@ export const addInstructorAbsenceController = async (
     const { absentAt } = req.body;
 
     const absentAtDate = new Date(absentAt);
-    const absence = await addInstructorAbsence({
+    const result = await addInstructorAbsence({
       instructorId,
       absentAt: absentAtDate,
     });
 
     res.status(201).json({
       message: "Instructor absence added successfully",
-      data: absence,
+      data: result,
     });
   } catch (error) {
     console.error("Error adding instructor absence:", error);

--- a/backend/src/services/instructorAbsenceService.ts
+++ b/backend/src/services/instructorAbsenceService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "../../generated/prisma";
 import { prisma } from "../../prisma/prismaClient";
 import { nHoursLater } from "../utils/dateUtils";
 
@@ -23,23 +24,41 @@ export const addInstructorAbsence = async (data: {
       const lockKey = `instructor:${data.instructorId}:${data.absentAt.toISOString()}`;
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
 
-      await tx.class.updateMany({
-        where: {
-          instructorId: data.instructorId,
-          dateTime: data.absentAt,
-          status: {
-            in: ["booked", "rebooked"],
+      const classWhere: Prisma.ClassWhereInput = {
+        instructorId: data.instructorId,
+        dateTime: data.absentAt,
+        status: {
+          in: ["booked", "rebooked"],
+        },
+      };
+      const rebookableUntil = nHoursLater(180 * 24, data.absentAt);
+
+      const canceledClasses = await tx.class.findMany({
+        where: classWhere,
+        select: {
+          id: true,
+          classCode: true,
+          dateTime: true,
+          customer: {
+            select: {
+              id: true,
+              name: true,
+            },
           },
         },
+      });
+
+      await tx.class.updateMany({
+        where: classWhere,
         data: {
           status: "canceledByInstructor",
           canceledAt: now,
-          rebookableUntil: nHoursLater(180 * 24, data.absentAt),
+          rebookableUntil,
           updatedAt: now,
         },
       });
 
-      return await tx.instructorAbsence.upsert({
+      const absence = await tx.instructorAbsence.upsert({
         where: {
           instructorId_absentAt: {
             instructorId: data.instructorId,
@@ -52,6 +71,17 @@ export const addInstructorAbsence = async (data: {
         },
         update: {},
       });
+
+      return {
+        absence,
+        canceledClasses: canceledClasses.map((classItem) => ({
+          id: classItem.id,
+          classCode: classItem.classCode,
+          dateTime: classItem.dateTime!.toISOString(),
+          rebookableUntil: rebookableUntil.toISOString(),
+          customer: classItem.customer,
+        })),
+      };
     });
   } catch (error) {
     console.error("Database Error:", error);

--- a/backend/src/test/api/instructors/absences.test.ts
+++ b/backend/src/test/api/instructors/absences.test.ts
@@ -35,11 +35,17 @@ describe("POST /instructors/:id/absences", () => {
     const instructor = await createInstructor();
     const absenceDate = "2024-07-01T00:00:00.000Z";
 
-    await request(server)
+    const response = await request(server)
       .post(`/instructors/${instructor.id}/absences`)
       .set("Cookie", authCookie)
       .send({ absentAt: absenceDate })
       .expect(201);
+
+    expect(response.body.data.absence).toEqual({
+      instructorId: instructor.id,
+      absentAt: absenceDate,
+    });
+    expect(response.body.data.canceledClasses).toEqual([]);
 
     // Verify absence was created
     const absence = await prisma.instructorAbsence.findUnique({
@@ -65,7 +71,7 @@ describe("POST /instructors/:id/absences", () => {
       absentAt,
     );
 
-    await request(server)
+    const response = await request(server)
       .post(`/instructors/${instructor.id}/absences`)
       .set("Cookie", authCookie)
       .send({ absentAt: absentAt.toISOString() })
@@ -76,6 +82,21 @@ describe("POST /instructors/:id/absences", () => {
     });
     expect(updatedClass?.status).toBe("canceledByInstructor");
     expect(updatedClass?.canceledAt).toBeTruthy();
+    expect(updatedClass?.rebookableUntil?.toISOString()).toBe(
+      response.body.data.canceledClasses[0].rebookableUntil,
+    );
+    expect(response.body.data.canceledClasses).toEqual([
+      {
+        id: scheduledClass.id,
+        classCode: scheduledClass.classCode,
+        dateTime: absentAt.toISOString(),
+        rebookableUntil: updatedClass?.rebookableUntil?.toISOString(),
+        customer: {
+          id: customer.id,
+          name: customer.name,
+        },
+      },
+    ]);
   });
 
   it("fail for unauthenticated request", async () => {

--- a/frontend/src/app/actions/instructorAbsence.ts
+++ b/frontend/src/app/actions/instructorAbsence.ts
@@ -7,6 +7,7 @@ import {
   deleteInstructorAbsence,
 } from "@/lib/api/instructorsApi";
 import { formatYearDateTime } from "@/lib/utils/dateUtils";
+import type { AbsenceCanceledClassSummary } from "@shared/schemas/instructors";
 
 export type AbsenceChange = {
   dateTime: string;
@@ -17,6 +18,7 @@ export type AbsenceChange = {
 type BatchAbsenceResult = {
   success: boolean;
   successCount: { add: number; remove: number };
+  canceledClasses: AbsenceCanceledClassSummary[];
   errors: string[];
   message?: string;
 };
@@ -29,13 +31,19 @@ export async function batchUpdateInstructorAbsences(
     const cookie = await getCookie();
     const errors: string[] = [];
     const successCount = { add: 0, remove: 0 };
+    const canceledClasses: AbsenceCanceledClassSummary[] = [];
 
     // Process all pending changes
     for (const change of changes) {
       try {
         switch (change.action) {
           case "add": {
-            await addInstructorAbsence(instructorId, change.dateTime, cookie);
+            const result = await addInstructorAbsence(
+              instructorId,
+              change.dateTime,
+              cookie,
+            );
+            canceledClasses.push(...result.canceledClasses);
             successCount.add++;
             break;
           }
@@ -97,6 +105,7 @@ export async function batchUpdateInstructorAbsences(
     return {
       success: errors.length === 0,
       successCount,
+      canceledClasses,
       errors,
       message,
     };
@@ -105,6 +114,7 @@ export async function batchUpdateInstructorAbsences(
     return {
       success: false,
       successCount: { add: 0, remove: 0 },
+      canceledClasses: [],
       errors: [
         `Failed to process changes: ${error instanceof Error ? error.message : String(error)}`,
       ],

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.module.scss
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.module.scss
@@ -123,3 +123,69 @@
     background-color: #a2b098;
   }
 }
+
+.summaryModal {
+  width: min(880px, 85vw);
+  padding: 32px;
+}
+
+.summaryHeader {
+  margin-bottom: 20px;
+
+  h2 {
+    margin: 0 0 8px;
+    font-size: 22px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    color: #4b5563;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+}
+
+.summaryTableWrapper {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: auto;
+  max-height: 50vh;
+}
+
+.summaryTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+
+  th,
+  td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+    font-size: 14px;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    background: #f8fafc;
+    color: #374151;
+    font-weight: 600;
+  }
+
+  td {
+    color: #111827;
+    background: #fff;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.summaryActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AvailabilityCalendar.tsx
@@ -9,7 +9,10 @@ import {
   batchUpdateInstructorAbsences,
   type AbsenceChange,
 } from "@/app/actions/instructorAbsence";
-import type { InstructorAbsence } from "@shared/schemas/instructors";
+import type {
+  AbsenceCanceledClassSummary,
+  InstructorAbsence,
+} from "@shared/schemas/instructors";
 import Calendar from "@/components/features/calendar/Calendar";
 import Modal from "@/components/elements/modal/Modal";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
@@ -17,6 +20,7 @@ import { EventSourceFuncArg, EventClickArg } from "@fullcalendar/core";
 import { toast } from "react-toastify";
 import styles from "./AvailabilityCalendar.module.scss";
 import { errorAlert } from "@/lib/utils/alertUtils";
+import { formatYearDateTime } from "@/lib/utils/dateUtils";
 
 // Define proper event type for FullCalendar events
 interface CalendarEvent {
@@ -45,6 +49,9 @@ export default function AvailabilityCalendar({
     Map<string, AbsenceChange>
   >(new Map());
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [canceledClasses, setCanceledClasses] = useState<
+    AbsenceCanceledClassSummary[]
+  >([]);
 
   const formatJSTDate = (date: Date) => {
     const year = date.getFullYear();
@@ -160,6 +167,7 @@ export default function AvailabilityCalendar({
       if (result.success) {
         // All changes successful
         setPendingChanges(new Map());
+        setCanceledClasses(result.canceledClasses);
         refreshCalendars();
         setIsEditModalOpen(false);
         // Show success message only if there were actual changes
@@ -172,6 +180,7 @@ export default function AvailabilityCalendar({
       ) {
         // Partial success
         setPendingChanges(new Map());
+        setCanceledClasses(result.canceledClasses);
         refreshCalendars();
         setIsEditModalOpen(false);
 
@@ -341,6 +350,58 @@ export default function AvailabilityCalendar({
                   ? "Submitting..."
                   : `Submit (${pendingChanges.size})`
               }
+            />
+          </div>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={canceledClasses.length > 0}
+        onClose={() => setCanceledClasses([])}
+        overlayClosable={true}
+        maxHeight="90vh"
+        padding="40px"
+      >
+        <div className={styles.summaryModal}>
+          <div className={styles.summaryHeader}>
+            <h2>Classes Canceled</h2>
+            <p>
+              {canceledClasses.length} classes were canceled for the registered
+              absence and are now rebookable.
+            </p>
+          </div>
+
+          <div className={styles.summaryTableWrapper}>
+            <table className={styles.summaryTable}>
+              <thead>
+                <tr>
+                  <th>Customer</th>
+                  <th>Class Time</th>
+                  <th>Class Code</th>
+                  <th>Rebookable Until</th>
+                </tr>
+              </thead>
+              <tbody>
+                {canceledClasses.map((classItem) => (
+                  <tr key={classItem.id}>
+                    <td>{classItem.customer.name}</td>
+                    <td>{formatYearDateTime(new Date(classItem.dateTime))}</td>
+                    <td>{classItem.classCode}</td>
+                    <td>
+                      {formatYearDateTime(new Date(classItem.rebookableUntil))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className={styles.summaryActions}>
+            <ActionButton
+              type="button"
+              onClick={() => setCanceledClasses([])}
+              className="submitBtn"
+              btnText="Close"
             />
           </div>
         </div>

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -1079,7 +1079,7 @@ export const addInstructorAbsence = async (
 
     const result: CreateAbsenceResponse = await response.json();
 
-    return { absence: result.data };
+    return result.data;
   } catch (error) {
     console.error("Failed to add instructor absence:", error);
     throw error;

--- a/shared/schemas/instructors.ts
+++ b/shared/schemas/instructors.ts
@@ -378,6 +378,19 @@ export const InstructorAbsence = z.object({
   absentAt: z.string().describe("Absence date in ISO format"),
 });
 
+export const AbsenceCanceledClassSummary = z.object({
+  id: z.number().int().positive().describe("Canceled class ID"),
+  classCode: z.string().describe("Class code"),
+  dateTime: z.string().describe("Canceled class date/time in ISO format"),
+  rebookableUntil: z
+    .string()
+    .describe("Rebookable until date/time in ISO format"),
+  customer: z.object({
+    id: z.number().int().positive().describe("Customer ID"),
+    name: z.string().describe("Customer name"),
+  }),
+});
+
 export const InstructorAbsencesResponse = z.object({
   message: z.string().describe("Success message"),
   data: z.array(InstructorAbsence).describe("Array of instructor absences"),
@@ -385,7 +398,14 @@ export const InstructorAbsencesResponse = z.object({
 
 export const CreateAbsenceResponse = z.object({
   message: z.string().describe("Success message"),
-  data: InstructorAbsence.describe("Created instructor absence"),
+  data: z.object({
+    absence: InstructorAbsence.describe("Created instructor absence"),
+    canceledClasses: z
+      .array(AbsenceCanceledClassSummary)
+      .describe(
+        "Classes canceled because they matched the instructor absence slot",
+      ),
+  }),
 });
 
 export const DeleteAbsenceResponse = z.object({
@@ -455,6 +475,9 @@ export type CreateScheduleResponse = z.infer<typeof CreateScheduleResponse>;
 export type InstructorAbsenceParams = z.infer<typeof InstructorAbsenceParams>;
 export type CreateAbsenceRequest = z.infer<typeof CreateAbsenceRequest>;
 export type InstructorAbsence = z.infer<typeof InstructorAbsence>;
+export type AbsenceCanceledClassSummary = z.infer<
+  typeof AbsenceCanceledClassSummary
+>;
 export type InstructorAbsencesResponse = z.infer<
   typeof InstructorAbsencesResponse
 >;


### PR DESCRIPTION
## Summary
- return canceled class summaries from instructor absence creation
- show an admin-facing "Classes Canceled" dialog after absence registration
- cover the new response shape in backend absence API tests

## Why
Registering an instructor absence already canceled overlapping classes and made them rebookable, but the admin UI gave no immediate feedback about which customers were affected. Returning the canceled classes from the API lets the frontend show an accurate post-submit summary without a refetch-and-diff flow.

## Impact
- Admins can immediately see which classes were canceled by an absence registration
- The dialog shows the affected customer, class code, and rebookable-until time
- The frontend uses the server-confirmed cancellation result instead of guessing from a follow-up fetch

## Validation
- `npx vitest run src/test/api/instructors/absences.test.ts`
- Playwright browser verification of the admin absence flow and canceled-classes dialog
- `npm run lint` in `frontend`
