### PR TITLE
[codex] Prevent absences on completed class slots

### DIFF
--- a/backend/src/controllers/instructorAbsenceController.ts
+++ b/backend/src/controllers/instructorAbsenceController.ts
@@ -3,6 +3,7 @@ import {
   getInstructorAbsences,
   addInstructorAbsence,
   removeInstructorAbsence,
+  CompletedClassAbsenceConflictError,
 } from "../services/instructorAbsenceService";
 import {
   RequestWithParams,
@@ -55,6 +56,12 @@ export const addInstructorAbsenceController = async (
     });
   } catch (error) {
     console.error("Error adding instructor absence:", error);
+
+    if (error instanceof CompletedClassAbsenceConflictError) {
+      return res.status(409).json({
+        message: error.message,
+      });
+    }
 
     res.status(500).json({
       message: "Failed to add instructor absence",

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -540,6 +540,10 @@ const createAbsenceConfig = {
         description: "Unauthorized - authentication required",
         schema: MessageErrorResponse,
       },
+      409: {
+        description: "Conflict with completed class at the target slot",
+        schema: MessageErrorResponse,
+      },
       500: {
         description: "Internal server error",
         schema: MessageErrorResponse,

--- a/backend/src/services/instructorAbsenceService.ts
+++ b/backend/src/services/instructorAbsenceService.ts
@@ -2,6 +2,13 @@ import { Prisma } from "../../generated/prisma";
 import { prisma } from "../../prisma/prismaClient";
 import { nHoursLater } from "../utils/dateUtils";
 
+export class CompletedClassAbsenceConflictError extends Error {
+  constructor() {
+    super("Cannot add absence on a completed class slot.");
+    this.name = "CompletedClassAbsenceConflictError";
+  }
+}
+
 export const getInstructorAbsences = async (instructorId: number) => {
   try {
     return await prisma.instructorAbsence.findMany({
@@ -23,6 +30,19 @@ export const addInstructorAbsence = async (data: {
       const now = new Date();
       const lockKey = `instructor:${data.instructorId}:${data.absentAt.toISOString()}`;
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
+
+      const completedClass = await tx.class.findFirst({
+        where: {
+          instructorId: data.instructorId,
+          dateTime: data.absentAt,
+          status: "completed",
+        },
+        select: { id: true },
+      });
+
+      if (completedClass) {
+        throw new CompletedClassAbsenceConflictError();
+      }
 
       const classWhere: Prisma.ClassWhereInput = {
         instructorId: data.instructorId,
@@ -84,6 +104,9 @@ export const addInstructorAbsence = async (data: {
       };
     });
   } catch (error) {
+    if (error instanceof CompletedClassAbsenceConflictError) {
+      throw error;
+    }
     console.error("Database Error:", error);
     throw new Error("Failed to add instructor absence.");
   }

--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -510,7 +510,7 @@ const getSlotConstraints = async (
   const start = new Date(startDate);
   const end = new Date(endDate);
 
-  const [schedules, absences] = await Promise.all([
+  const [schedules, absences, completedClasses] = await Promise.all([
     prisma.instructorSchedule.findMany({
       where: {
         instructorId,
@@ -532,6 +532,17 @@ const getSlotConstraints = async (
         instructorId,
         absentAt: { gte: jst(startDate), lt: jst(endDate) },
       },
+    }),
+    prisma.class.findMany({
+      where: {
+        instructorId,
+        dateTime: {
+          gte: jst(startDate),
+          lt: jst(endDate),
+        },
+        status: "completed",
+      },
+      select: { instructorId: true, dateTime: true },
     }),
   ]);
 
@@ -555,13 +566,25 @@ const getSlotConstraints = async (
     ),
   );
 
+  const completedClassSet = new Set(
+    completedClasses
+      .filter((classItem) => classItem.dateTime !== null)
+      .map(
+        (classItem) => `${instructorId}-${classItem.dateTime!.toISOString()}`,
+      ),
+  );
+
   const bookingSet = new Set(
     bookings
       .filter((booking) => booking.dateTime !== null)
       .map((booking) => `${instructorId}-${booking.dateTime!.toISOString()}`),
   );
 
-  const excludeSlots = new Set([...absenceSet, ...bookingSet]);
+  const excludeSlots = new Set([
+    ...absenceSet,
+    ...completedClassSet,
+    ...bookingSet,
+  ]);
   return { schedules, excludeSlots };
 };
 

--- a/backend/src/test/api/instructors/absences.test.ts
+++ b/backend/src/test/api/instructors/absences.test.ts
@@ -99,6 +99,38 @@ describe("POST /instructors/:id/absences", () => {
     ]);
   });
 
+  it("rejects adding an absence on a completed class slot", async () => {
+    const admin = await createAdmin();
+    const authCookie = await generateAuthCookie(admin.id, "admin");
+    const instructor = await createInstructor();
+    const customer = await createCustomer();
+    const absentAt = new Date("2024-07-01T00:00:00.000Z");
+
+    await createClass(customer.id, instructor.id, absentAt, {
+      status: "completed",
+    });
+
+    const response = await request(server)
+      .post(`/instructors/${instructor.id}/absences`)
+      .set("Cookie", authCookie)
+      .send({ absentAt: absentAt.toISOString() })
+      .expect(409);
+
+    expect(response.body).toEqual({
+      message: "Cannot add absence on a completed class slot.",
+    });
+
+    const absence = await prisma.instructorAbsence.findUnique({
+      where: {
+        instructorId_absentAt: {
+          instructorId: instructor.id,
+          absentAt,
+        },
+      },
+    });
+    expect(absence).toBeNull();
+  });
+
   it("fail for unauthenticated request", async () => {
     const instructor = await createInstructor();
 

--- a/backend/src/test/api/instructors/schedules.test.ts
+++ b/backend/src/test/api/instructors/schedules.test.ts
@@ -909,6 +909,35 @@ describe("GET /instructors/:id/available-slots - With Absences", () => {
 
     expect(response.body.data).toEqual([{ dateTime: jst`2025-07-08 19:00` }]);
   });
+
+  it("filters out slots that already have completed classes", async () => {
+    const instructor = await createInstructor();
+    const customer = await createCustomer();
+    const schedule = await createInstructorSchedule(instructor.id, {
+      effectiveFrom: new Date("2025-07-07"),
+      effectiveTo: null,
+      timezone: "Asia/Tokyo",
+    });
+    await createInstructorSlot(schedule.id, 1, new Date(time`09:00`));
+    await createInstructorSlot(schedule.id, 2, new Date(time`19:00`));
+
+    await createClass(
+      customer.id,
+      instructor.id,
+      new Date(jst`2025-07-07 09:00`),
+      {
+        status: "completed",
+      },
+    );
+
+    const response = await request(server)
+      .get(`/instructors/${instructor.id}/available-slots`)
+      .set("Cookie", authCookie)
+      .query({ start: "2025-07-07", end: "2025-07-09", timezone: "Asia/Tokyo" })
+      .expect(200);
+
+    expect(response.body.data).toEqual([{ dateTime: jst`2025-07-08 19:00` }]);
+  });
 });
 
 describe("GET /instructors/available-slots - All Available Slots", () => {

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -1078,7 +1078,18 @@ export const addInstructorAbsence = async (
     });
 
     if (response.status !== 201) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+
+      try {
+        const errorBody = (await response.json()) as { message?: string };
+        if (errorBody.message) {
+          errorMessage = errorBody.message;
+        }
+      } catch {
+        // Keep the default message when the response body is not JSON.
+      }
+
+      throw new Error(errorMessage);
     }
 
     const result: CreateAbsenceResponse = await response.json();


### PR DESCRIPTION
## Summary
- reject instructor absence creation when the target slot already has a completed class
- hide completed-class slots from the admin availability absence editor
- surface the backend validation message in the frontend and cover the behavior with regression tests

## Why
Adding an absence to a completed class slot created an inconsistent state where attendance/payroll history remained completed while the instructor was also marked absent.

## Validation
- backend API test run covered the new regression in `src/test/api/instructors/absences.test.ts`
- backend API test run covered the available-slot regression in `src/test/api/instructors/schedules.test.ts`
- verified in Playwright against the worktree app that Helen's completed slot in the week of March 15–21, 2026 is not selectable in `Edit Absences`

## Notes
- Playwright artifacts were left untracked and are not included in this PR.