### PR TITLE
[codex] Replace customer booking calendar with weekly slot grid

### DIFF
--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AllInstructorAvailabilityCalendar.tsx
@@ -1,30 +1,20 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import {
   getInstructorAvailableSlotsByType,
   getInstructorProfiles,
 } from "@/lib/api/instructorsApi";
 import type { AvailableSlot } from "@shared/schemas/instructors";
-import Calendar from "@/components/features/calendar/Calendar";
-import { EventSourceFuncArg, EventClickArg } from "@fullcalendar/core";
 import styles from "./AllInstructorAvailabilityCalendar.module.scss";
-import { greenSuccess } from "@/styles/colors";
 import { EnglishBackground } from "@/types";
+import AvailabilityWeekGrid, {
+  AvailabilityWeekGridSlot,
+} from "./AvailabilityWeekGrid";
 
-interface CalendarEvent {
-  id: string;
-  start: string;
-  end: string;
-  title: string;
-  color: string;
-  textColor: string;
-  extendedProps: {
-    type: "available";
-    availableInstructorIds: number[];
-    instructorCount: number;
-  };
-}
+type AvailabilityOverviewSlot = AvailabilityWeekGridSlot & {
+  availableInstructorIds: number[];
+};
 
 interface AllInstructorAvailabilityCalendarProps {
   onSlotSelect: (
@@ -35,107 +25,45 @@ interface AllInstructorAvailabilityCalendarProps {
   englishBackground: EnglishBackground;
 }
 
-// Helper function to format date for API calls
-const formatJSTDate = (date: Date): string => {
-  return date.toISOString().split("T")[0];
-};
-
-// Helper function to create calendar event from slot data
-const createCalendarEvent = (
-  slot: AvailableSlot,
-  language: "ja" | "en",
-): CalendarEvent => {
-  const start = slot.dateTime;
-  const end = new Date(new Date(start).getTime() + 25 * 60000).toISOString();
-
-  const instructorCount = slot.availableInstructors.length;
-  const title =
-    language === "ja"
-      ? `講師${instructorCount}名`
-      : `${instructorCount} instructors`;
-
-  return {
-    id: `available-${start}`,
-    start,
-    end,
-    title,
-    color: greenSuccess,
-    textColor: "#FFF",
-    extendedProps: {
-      type: "available" as const,
-      availableInstructorIds: slot.availableInstructors,
-      instructorCount,
-    },
-  };
-};
-
-// Helper function to get error message based on language
-const getErrorMessage = (language: "ja" | "en"): string => {
-  return language === "ja"
-    ? "スケジュールの読み込みに失敗しました"
-    : "Failed to load schedule";
-};
-
 export default function AllInstructorAvailabilityCalendar({
   onSlotSelect,
   language,
   englishBackground,
 }: AllInstructorAvailabilityCalendarProps) {
-  const [refreshKey, setRefreshKey] = useState(0);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const fetchSlots = useCallback(
+    async (startDate: string, endDate: string) => {
+      const response = await getInstructorAvailableSlotsByType(
+        startDate,
+        endDate,
+        englishBackground,
+      );
 
-  const fetchCalendarEvents = useCallback(
-    async (info: EventSourceFuncArg) => {
-      const startStr = formatJSTDate(info.start);
-      const exclusiveEnd = new Date(info.end);
-      exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);
-      const endStr = formatJSTDate(exclusiveEnd);
-
-      try {
-        setErrorMessage(null);
-        const response = await getInstructorAvailableSlotsByType(
-          startStr,
-          endStr,
-          englishBackground,
-        );
-
-        if ("data" in response) {
-          return response.data.map((slot: AvailableSlot) =>
-            createCalendarEvent(slot, language),
-          );
-        }
-
-        return [];
-      } catch (error) {
-        console.error("Failed to fetch calendar data:", error);
-        setErrorMessage(getErrorMessage(language));
+      if (!("data" in response)) {
         return [];
       }
+
+      return response.data.map((slot: AvailableSlot) => ({
+        dateTime: slot.dateTime,
+        instructorCount: slot.availableInstructors.length,
+        availableInstructorIds: slot.availableInstructors,
+      }));
     },
-    [language, englishBackground],
+    [englishBackground],
   );
 
-  const handleSlotClick = useCallback(
-    async (clickInfo: EventClickArg) => {
-      const eventType = clickInfo.event.extendedProps.type;
-
-      if (eventType !== "available") {
-        return;
-      }
-
-      const dateTime = clickInfo.event.start!.toISOString();
-      const instructorIds =
-        clickInfo.event.extendedProps.availableInstructorIds;
+  const handleSlotSelect = useCallback(
+    async (slot: AvailabilityWeekGridSlot) => {
+      const overviewSlot = slot as AvailabilityOverviewSlot;
 
       try {
         const allProfiles = await getInstructorProfiles();
         const availableInstructors = allProfiles.filter((profile) =>
-          instructorIds.includes(profile.id),
+          overviewSlot.availableInstructorIds.includes(profile.id),
         );
-        onSlotSelect(dateTime, availableInstructors);
+        onSlotSelect(slot.dateTime, availableInstructors);
       } catch (error) {
         console.error("Failed to fetch instructor profiles:", error);
-        onSlotSelect(dateTime, []);
+        onSlotSelect(slot.dateTime, []);
       }
     },
     [onSlotSelect],
@@ -144,11 +72,6 @@ export default function AllInstructorAvailabilityCalendar({
   return (
     <div className={styles.container}>
       <div className={styles.calendarHeader}>
-        <h3>
-          {language === "ja"
-            ? "空きスケジュール一覧"
-            : "Available Schedule Overview"}
-        </h3>
         <p>
           {language === "ja"
             ? "予約したいスロットをクリックしてください"
@@ -156,21 +79,12 @@ export default function AllInstructorAvailabilityCalendar({
         </p>
       </div>
 
-      {errorMessage && (
-        <div className={styles.errorMessage}>{errorMessage}</div>
-      )}
-
-      <div className={styles.calendarShell}>
-        <Calendar
-          height="500px"
-          contentHeight="400px"
-          key={refreshKey}
-          events={fetchCalendarEvents}
-          eventClick={handleSlotClick}
-          selectable={false}
-          displayEventTime={false}
-        />
-      </div>
+      <AvailabilityWeekGrid
+        fetchSlots={fetchSlots}
+        onSlotSelect={handleSlotSelect}
+        language={language}
+        showInstructorCount
+      />
     </div>
   );
 }

--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AvailabilityWeekGrid.module.scss
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AvailabilityWeekGrid.module.scss
@@ -1,0 +1,218 @@
+@use "@/styles/variables.module.scss" as *;
+
+.gridShell {
+  width: 100%;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.9rem;
+}
+
+.navigationControls {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.iconButton,
+.todayButton {
+  border: none;
+  background: $blue_primary;
+  color: white;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    background: $blue_primary_hover;
+    transform: translateY(-1px);
+  }
+}
+
+.iconButton {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.todayButton {
+  height: 2.25rem;
+  padding: 0 0.85rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.weekRange {
+  color: $text-dark;
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.errorMessage {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  background: $canceled-background-color;
+  color: $canceled-text-color;
+  text-align: center;
+}
+
+.gridScroller {
+  overflow-x: auto;
+}
+
+.calendarGrid {
+  width: 100%;
+  border: 1px solid $border-light;
+  border-radius: 8px;
+  overflow: hidden;
+  background: white;
+}
+
+.headerRow,
+.slotRows {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.headerRow {
+  background: $background-light;
+  border-bottom: 1px solid $border-light;
+}
+
+.dayHeader {
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  white-space: nowrap;
+  border-right: 1px solid $border-light;
+  color: $text-dark;
+  font-size: 0.875rem;
+  font-weight: 600;
+
+  &:last-child {
+    border-right: none;
+  }
+}
+
+.todayDayHeader {
+  background: $yellow-selected;
+}
+
+.slotRows {
+  min-height: 200px;
+}
+
+.dayColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 0.5rem;
+  border-right: 1px solid $border-light;
+
+  &:last-child {
+    border-right: none;
+  }
+}
+
+.timeSlot {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.125rem;
+  border: 1px solid $border-light;
+  border-radius: 4px;
+  background: transparent;
+  color: $text-medium;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+  padding: 0.5rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+
+  &:hover {
+    background: $background-light;
+    border-color: $border-medium;
+    transform: translateY(-1px);
+  }
+}
+
+.slotTime {
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.instructorCount {
+  color: $text-light;
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1.15;
+}
+
+.noSlots,
+.loadingSlot {
+  display: flex;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
+  color: $text-light;
+  font-size: 0.75rem;
+  font-style: italic;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 0.75rem;
+  }
+
+  .weekRange {
+    font-size: 1.1rem;
+  }
+
+  .calendarGrid {
+    min-width: 640px;
+  }
+
+  .dayHeader {
+    padding: 0.5rem 0.25rem;
+    font-size: 0.75rem;
+  }
+
+  .dayColumn {
+    padding: 0.75rem 0.35rem;
+    gap: 0.375rem;
+  }
+
+  .timeSlot {
+    padding: 0.375rem 0.125rem;
+  }
+
+  .slotTime {
+    font-size: 0.6875rem;
+  }
+
+  .instructorCount {
+    font-size: 0.625rem;
+  }
+}

--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AvailabilityWeekGrid.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/AvailabilityWeekGrid.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import styles from "./AvailabilityWeekGrid.module.scss";
+
+const JST_TIME_ZONE = "Asia/Tokyo";
+const DATE_KEY_TIME_ZONE = "UTC";
+const LOAD_TIMEOUT_MS = 30000;
+const WEEKDAY_LABELS = {
+  en: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+  ja: ["日", "月", "火", "水", "木", "金", "土"],
+};
+
+export type AvailabilityWeekGridSlot = {
+  dateTime: string;
+  instructorCount?: number;
+};
+
+type AvailabilityWeekGridProps = {
+  fetchSlots: (
+    startDate: string,
+    endDate: string,
+  ) => Promise<AvailabilityWeekGridSlot[]>;
+  onSlotSelect: (slot: AvailabilityWeekGridSlot) => void;
+  language: LanguageType;
+  showInstructorCount?: boolean;
+};
+
+const getDateParts = (date: Date, timeZone: string) => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+
+  return {
+    year: parts.find((part) => part.type === "year")?.value || "1970",
+    month: parts.find((part) => part.type === "month")?.value || "01",
+    day: parts.find((part) => part.type === "day")?.value || "01",
+  };
+};
+
+const getDateKey = (date: Date, timeZone = JST_TIME_ZONE) => {
+  const { year, month, day } = getDateParts(date, timeZone);
+  return `${year}-${month}-${day}`;
+};
+
+const dateKeyToDate = (dateKey: string) => new Date(`${dateKey}T00:00:00Z`);
+
+const addDays = (dateKey: string, days: number) => {
+  const date = dateKeyToDate(dateKey);
+  date.setUTCDate(date.getUTCDate() + days);
+  return getDateKey(date, DATE_KEY_TIME_ZONE);
+};
+
+const getWeekStart = (dateKey: string) => {
+  const date = dateKeyToDate(dateKey);
+  return addDays(dateKey, -date.getUTCDay());
+};
+
+const getWeekDates = (weekStart: string) =>
+  Array.from({ length: 7 }, (_, index) => addDays(weekStart, index));
+
+const formatWeekRange = (weekDates: string[], language: LanguageType) => {
+  const locale = language === "ja" ? "ja-JP" : "en-US";
+  const formatter = new Intl.DateTimeFormat(locale, {
+    timeZone: DATE_KEY_TIME_ZONE,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return `${formatter.format(dateKeyToDate(weekDates[0]))} - ${formatter.format(dateKeyToDate(weekDates[6]))}`;
+};
+
+const formatHeaderDate = (dateKey: string, language: LanguageType) => {
+  const locale = language === "ja" ? "ja-JP" : "en-US";
+  return new Intl.DateTimeFormat(locale, {
+    timeZone: DATE_KEY_TIME_ZONE,
+    month: "numeric",
+    day: "numeric",
+  }).format(dateKeyToDate(dateKey));
+};
+
+const formatHeaderLabel = (
+  dateKey: string,
+  weekdayIndex: number,
+  language: LanguageType,
+) => {
+  return `${WEEKDAY_LABELS[language][weekdayIndex]} ${formatHeaderDate(
+    dateKey,
+    language,
+  )}`;
+};
+
+const formatSlotTime = (dateTime: string) =>
+  new Intl.DateTimeFormat("en-GB", {
+    timeZone: JST_TIME_ZONE,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(dateTime));
+
+const getInstructorCountLabel = (
+  count: number | undefined,
+  language: LanguageType,
+) => {
+  if (!count) {
+    return language === "ja" ? "講師0名" : "0 instructors";
+  }
+
+  return language === "ja"
+    ? `講師${count}名`
+    : `${count} ${count === 1 ? "instructor" : "instructors"}`;
+};
+
+export default function AvailabilityWeekGrid({
+  fetchSlots,
+  onSlotSelect,
+  language,
+  showInstructorCount = false,
+}: AvailabilityWeekGridProps) {
+  const todayDateKey = getDateKey(new Date());
+  const [weekStart, setWeekStart] = useState(() =>
+    getWeekStart(getDateKey(new Date())),
+  );
+  const [slots, setSlots] = useState<AvailabilityWeekGridSlot[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart]);
+
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const loadSlots = async () => {
+      const requestStart = Date.now();
+      const startDate = weekDates[0];
+      const endDateExclusive = addDays(weekDates[6], 1);
+
+      console.log("[availability-week-grid][load:start]", {
+        startDate,
+        endDateExclusive,
+        language,
+      });
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const nextSlots = await Promise.race([
+          fetchSlots(startDate, endDateExclusive),
+          new Promise<AvailabilityWeekGridSlot[]>((_, reject) => {
+            timeoutId = setTimeout(() => {
+              reject(new Error("Availability request timed out"));
+            }, LOAD_TIMEOUT_MS);
+          }),
+        ]);
+
+        if (isActive) {
+          setSlots(nextSlots);
+        }
+
+        console.log("[availability-week-grid][load:success]", {
+          startDate,
+          endDateExclusive,
+          slotCount: nextSlots.length,
+          durationMs: Date.now() - requestStart,
+        });
+      } catch (error) {
+        console.error("Failed to fetch availability week:", error);
+        console.log("[availability-week-grid][load:error]", {
+          startDate,
+          endDateExclusive,
+          durationMs: Date.now() - requestStart,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (isActive) {
+          setSlots([]);
+          setErrorMessage(
+            language === "ja"
+              ? "スケジュールの読み込みに失敗しました"
+              : "Failed to load schedule",
+          );
+        }
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadSlots();
+
+    return () => {
+      isActive = false;
+    };
+  }, [fetchSlots, language, weekDates]);
+
+  const slotsByDate = useMemo(() => {
+    const grouped = slots.reduce<Record<string, AvailabilityWeekGridSlot[]>>(
+      (groupedSlots, slot) => {
+        const dateKey = getDateKey(new Date(slot.dateTime));
+        if (!groupedSlots[dateKey]) {
+          groupedSlots[dateKey] = [];
+        }
+        groupedSlots[dateKey].push(slot);
+        return groupedSlots;
+      },
+      {},
+    );
+
+    Object.values(grouped).forEach((daySlots) => {
+      daySlots.sort(
+        (first, second) =>
+          new Date(first.dateTime).getTime() -
+          new Date(second.dateTime).getTime(),
+      );
+    });
+
+    return grouped;
+  }, [slots]);
+
+  const goToPreviousWeek = useCallback(() => {
+    setWeekStart((currentWeekStart) => addDays(currentWeekStart, -7));
+  }, []);
+
+  const goToNextWeek = useCallback(() => {
+    setWeekStart((currentWeekStart) => addDays(currentWeekStart, 7));
+  }, []);
+
+  const goToCurrentWeek = useCallback(() => {
+    setWeekStart(getWeekStart(getDateKey(new Date())));
+  }, []);
+
+  return (
+    <div className={styles.gridShell}>
+      <div className={styles.toolbar}>
+        <div className={styles.navigationControls}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label={language === "ja" ? "前の週" : "Previous week"}
+            onClick={goToPreviousWeek}
+          >
+            &lsaquo;
+          </button>
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label={language === "ja" ? "次の週" : "Next week"}
+            onClick={goToNextWeek}
+          >
+            &rsaquo;
+          </button>
+          <button
+            type="button"
+            className={styles.todayButton}
+            onClick={goToCurrentWeek}
+          >
+            {language === "ja" ? "今日" : "today"}
+          </button>
+        </div>
+        <div className={styles.weekRange}>
+          {formatWeekRange(weekDates, language)}
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className={styles.errorMessage}>{errorMessage}</div>
+      )}
+
+      <div className={styles.gridScroller}>
+        <div className={styles.calendarGrid}>
+          <div className={styles.headerRow}>
+            {weekDates.map((dateKey, index) => (
+              <div
+                key={dateKey}
+                className={`${styles.dayHeader} ${
+                  dateKey === todayDateKey ? styles.todayDayHeader : ""
+                }`}
+              >
+                {formatHeaderLabel(dateKey, index, language)}
+              </div>
+            ))}
+          </div>
+
+          <div className={styles.slotRows}>
+            {weekDates.map((dateKey) => {
+              const daySlots = slotsByDate[dateKey] || [];
+
+              return (
+                <div key={dateKey} className={styles.dayColumn}>
+                  {isLoading ? (
+                    <div className={styles.loadingSlot}>
+                      {language === "ja" ? "読み込み中" : "Loading"}
+                    </div>
+                  ) : daySlots.length > 0 ? (
+                    daySlots.map((slot) => (
+                      <button
+                        key={slot.dateTime}
+                        type="button"
+                        className={styles.timeSlot}
+                        onClick={() => onSlotSelect(slot)}
+                      >
+                        <span className={styles.slotTime}>
+                          {formatSlotTime(slot.dateTime)}
+                        </span>
+                        {showInstructorCount && (
+                          <span className={styles.instructorCount}>
+                            {getInstructorCountLabel(
+                              slot.instructorCount,
+                              language,
+                            )}
+                          </span>
+                        )}
+                      </button>
+                    ))
+                  ) : (
+                    <div className={styles.noSlots}>
+                      {language === "ja" ? "空きなし" : "No slots"}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/InstructorAvailabilityCalendar.tsx
@@ -1,26 +1,12 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { getInstructorAvailableSlots } from "@/lib/api/instructorsApi";
-import Calendar from "@/components/features/calendar/Calendar";
-import { EventSourceFuncArg, EventClickArg } from "@fullcalendar/core";
 import styles from "./InstructorAvailabilityCalendar.module.scss";
-import { greenSuccess } from "@/styles/colors";
 import { EnglishBackground } from "@/types";
-
-interface CalendarEvent {
-  id: string;
-  start: string;
-  end: string;
-  title: string;
-  color: string;
-  textColor: string;
-  extendedProps: {
-    type: "available";
-    instructorId: number;
-    instructorName: string;
-  };
-}
+import AvailabilityWeekGrid, {
+  AvailabilityWeekGridSlot,
+} from "./AvailabilityWeekGrid";
 
 interface InstructorAvailabilityCalendarProps {
   instructorId: number;
@@ -32,40 +18,6 @@ interface InstructorAvailabilityCalendarProps {
   language: "ja" | "en";
 }
 
-// Helper function to format date for API calls
-const formatJSTDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
-// Helper function to create calendar event from slot data
-const createAvailableSlotEvent = (
-  slot: any,
-  language: "ja" | "en",
-  instructorId: number,
-  instructorName: string,
-): CalendarEvent => {
-  const start = slot.dateTime;
-  const end = new Date(new Date(start).getTime() + 25 * 60000).toISOString();
-
-  return {
-    id: `available-${start}`,
-    start,
-    end,
-    title: language === "ja" ? "予約可能" : "Available",
-    color: greenSuccess,
-    textColor: "#FFF",
-    extendedProps: {
-      type: "available" as const,
-      instructorId,
-      instructorName,
-    },
-  };
-};
-
-// Helper function to create instructor profile object
 const createInstructorProfile = (
   instructorId: number,
   instructorName: string,
@@ -83,54 +35,30 @@ export default function InstructorAvailabilityCalendar({
   onSlotSelect,
   language,
 }: InstructorAvailabilityCalendarProps) {
-  const [refreshKey, setRefreshKey] = useState(0);
+  const fetchSlots = useCallback(
+    async (startDate: string, endDate: string) => {
+      const slotsResponse = await getInstructorAvailableSlots(
+        instructorId,
+        startDate,
+        endDate,
+        true,
+      );
 
-  const fetchCalendarEvents = useCallback(
-    async (info: EventSourceFuncArg) => {
-      const startStr = formatJSTDate(info.start);
-      const endDate = new Date(info.end);
-      endDate.setDate(endDate.getDate() + 1);
-      const endStr = formatJSTDate(endDate);
-
-      try {
-        const slotsResponse = await getInstructorAvailableSlots(
-          instructorId,
-          startStr,
-          endStr,
-          true, // Exclude booked slots for customer booking
-        );
-
-        if ("data" in slotsResponse) {
-          return slotsResponse.data.map((slot: any) =>
-            createAvailableSlotEvent(
-              slot,
-              language,
-              instructorId,
-              instructorName,
-            ),
-          );
-        }
-
-        return [];
-      } catch (error) {
-        console.error("Failed to fetch calendar data:", error);
+      if (!("data" in slotsResponse)) {
         return [];
       }
+
+      return slotsResponse.data.map((slot) => ({
+        dateTime: slot.dateTime,
+      }));
     },
-    [instructorId, instructorName, language],
+    [instructorId],
   );
 
-  const handleSlotClick = useCallback(
-    (clickInfo: EventClickArg) => {
-      const eventType = clickInfo.event.extendedProps.type;
-
-      if (eventType !== "available") {
-        return;
-      }
-
-      const dateTime = clickInfo.event.start!.toISOString();
+  const handleSlotSelect = useCallback(
+    (slot: AvailabilityWeekGridSlot) => {
       const instructor = createInstructorProfile(instructorId, instructorName);
-      onSlotSelect(dateTime, instructor);
+      onSlotSelect(slot.dateTime, instructor);
     },
     [instructorId, instructorName, onSlotSelect],
   );
@@ -150,16 +78,11 @@ export default function InstructorAvailabilityCalendar({
         </p>
       </div>
 
-      <div className={styles.calendarShell}>
-        <Calendar
-          height="500px"
-          contentHeight="400px"
-          key={refreshKey}
-          events={fetchCalendarEvents}
-          eventClick={handleSlotClick}
-          selectable={false}
-        />
-      </div>
+      <AvailabilityWeekGrid
+        fetchSlots={fetchSlots}
+        onSlotSelect={handleSlotSelect}
+        language={language}
+      />
     </div>
   );
 }

--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.tsx
@@ -41,6 +41,17 @@ interface StepState {
   confirmation: StepStatus;
 }
 
+const formatSelectedDateTime = (dateTime: string, language: LanguageType) =>
+  new Intl.DateTimeFormat(language === "ja" ? "ja-JP" : "en-US", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: language !== "ja",
+  }).format(new Date(dateTime));
+
 export default function ProgressiveBookingFlow({
   classId,
   isFreeTrial,
@@ -424,9 +435,7 @@ export default function ProgressiveBookingFlow({
               {stepStatus.datetime === "completed" && selectedDateTime && (
                 <>
                   <span className={styles.selectedValue}>
-                    {new Date(selectedDateTime).toLocaleString(
-                      language === "ja" ? "ja-JP" : "en-US",
-                    )}
+                    {formatSelectedDateTime(selectedDateTime, language)}
                   </span>
                   <button
                     onClick={handleChangeDateTime}
@@ -460,9 +469,7 @@ export default function ProgressiveBookingFlow({
               {stepStatus.datetime === "completed" && selectedDateTime && (
                 <>
                   <span className={styles.selectedValue}>
-                    {new Date(selectedDateTime).toLocaleString(
-                      language === "ja" ? "ja-JP" : "en-US",
-                    )}
+                    {formatSelectedDateTime(selectedDateTime, language)}
                   </span>
                   <button
                     onClick={handleChangeDateTime}

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -921,17 +921,13 @@ export const getAllInstructorAvailableSlots = async (
         cache: "no-store",
       });
     } else {
-      // From client component (via proxy)
-      apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
-      const backendEndpoint = `/instructors/available-slots?${params}`;
-      headers = {
-        "Content-Type": "application/json",
-        "backend-endpoint": backendEndpoint,
-        "no-cache": "no-cache",
-      };
+      // From client component use the backend directly so date-first
+      // availability is not blocked by the proxy request lifecycle.
+      apiURL = `${BASE_URL}/available-slots?${params}`;
       response = await fetch(apiURL, {
         method,
-        headers,
+        credentials: "include",
+        cache: "no-store",
       });
     }
 
@@ -975,17 +971,13 @@ export const getInstructorAvailableSlotsByType = async (
         cache: "no-store",
       });
     } else {
-      // From client component (via proxy)
-      apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
-      const backendEndpoint = `/instructors/available-slots/by-type?${params}&englishBackground=${englishBackground}`;
-      headers = {
-        "Content-Type": "application/json",
-        "backend-endpoint": backendEndpoint,
-        "no-cache": "no-cache",
-      };
+      // From client component use the backend directly so date-first
+      // booking availability behaves the same as instructor-first.
+      apiURL = `${BASE_URL}/available-slots/by-type?${params}&englishBackground=${englishBackground}`;
       response = await fetch(apiURL, {
         method,
-        headers,
+        credentials: "include",
+        cache: "no-store",
       });
     }
 

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -869,17 +869,13 @@ export const getInstructorAvailableSlots = async (
         cache: "no-store",
       });
     } else {
-      // From client component (via proxy)
-      apiURL = `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`;
-      const backendEndpoint = `/instructors/${instructorId}/available-slots?${params}`;
-      headers = {
-        "Content-Type": "application/json",
-        "backend-endpoint": backendEndpoint,
-        "no-cache": "no-cache",
-      };
+      // From client component use the backend directly so instructor-first
+      // availability is not blocked by the proxy request lifecycle.
+      apiURL = `${BASE_URL}/${instructorId}/available-slots?${params}`;
       response = await fetch(apiURL, {
         method,
-        headers,
+        credentials: "include",
+        cache: "no-store",
       });
     }
 

--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -1,1 +1,0 @@
-export const greenSuccess = "#65b72f";


### PR DESCRIPTION
## Summary
- replace the customer book/rebook FullCalendar view with a weekly slot grid that matches the regular-class schedule style more closely
- reuse the new weekly grid for both date-first and instructor-first booking flows, including week navigation and actual date headers
- fix the instructor-first availability load by calling the instructor slot endpoint directly from the client and keep selected booking timestamps formatted in JST

## Why
The customer booking dialog used a different interaction model and visual treatment than the existing regular-class schedule UI. The new weekly grid makes the booking flow more consistent and easier to scan. During rollout, the instructor-first flow also exposed a loading issue where slot data was not rendering reliably through the client proxy path.

## Impact
- customers now see a regular-class-style availability grid in both booking and rebooking dialogs
- date-first selection shows time plus instructor count
- instructor-first selection now loads actual slots instead of getting stuck on loading
- today's header uses the same shared pale-yellow highlight as the main calendar

## Validation
- Playwright: logged in as Alice, opened rebook flow, selected instructor-first, chose Helen, confirmed the grid rendered real slots instead of staying on loading
- Playwright: verified the date-first weekly grid flow and styling updates
- `frontend npm run format-check`
- `frontend npm run lint -- --max-warnings 0`
- `frontend npm run lint:unused`
- `frontend npm run build` (passes; build still emits the existing non-fatal system-status `ECONNREFUSED` logs)
