### PR TITLE
[codex] Refactor instructor slot calendar

### DIFF
--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AdminInstructorCalendar.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AdminInstructorCalendar.tsx
@@ -1,19 +1,14 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { useRouter } from "next/navigation";
-import type {
-  EventClickArg,
-  EventContentArg,
-  EventSourceFuncArg,
-} from "@fullcalendar/core";
+import type { EventClickArg, EventSourceFuncArg } from "@fullcalendar/core";
 import Calendar from "@/components/features/calendar/Calendar";
+import InstructorSlotCalendar from "@/components/features/instructorSlotCalendar/InstructorSlotCalendar";
 import Modal from "@/components/elements/modal/Modal";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
 import {
   getInstructorAbsences,
   getInstructorAvailableSlots,
-  getInstructorCalendarSlots,
 } from "@/lib/api/instructorsApi";
 import {
   batchUpdateInstructorAbsences,
@@ -24,24 +19,9 @@ import { formatYearDateTime } from "@/lib/utils/dateUtils";
 import type {
   AbsenceCanceledClassSummary,
   InstructorAbsence,
-  InstructorCalendarSlot,
-  InstructorCalendarSlotType,
 } from "@shared/schemas/instructors";
 import { toast } from "react-toastify";
 import styles from "./AdminInstructorCalendar.module.scss";
-
-type MainCalendarEvent = {
-  id: string;
-  start: string;
-  end: string;
-  title: string;
-  color: string;
-  textColor: string;
-  extendedProps: {
-    slotType: InstructorCalendarSlotType;
-    classId?: number;
-  };
-};
 
 type EditCalendarEvent = {
   id: string;
@@ -57,30 +37,11 @@ type EditCalendarEvent = {
   };
 };
 
-const SLOT_LABELS: Record<InstructorCalendarSlotType, string> = {
-  open: "Open",
-  booked: "Booked",
-  rebooked: "Booked",
-  completed: "Done",
-  absence: "Absent",
-  canceledByInstructor: "Canceled",
-};
-
-const SLOT_SYMBOLS: Record<InstructorCalendarSlotType, string> = {
-  open: "○",
-  booked: "●",
-  rebooked: "●",
-  completed: "✓",
-  absence: "−",
-  canceledByInstructor: "×",
-};
-
 export default function AdminInstructorCalendar({
   instructorId,
 }: {
   instructorId: number;
 }) {
-  const router = useRouter();
   const [refreshKey, setRefreshKey] = useState(0);
   const [modalRefreshKey, setModalRefreshKey] = useState(0);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -103,41 +64,6 @@ export default function AdminInstructorCalendar({
     setRefreshKey((prev) => prev + 1);
     setModalRefreshKey((prev) => prev + 1);
   };
-
-  const buildMainEvent = (slot: InstructorCalendarSlot): MainCalendarEvent => ({
-    id: `${slot.slotType}-${slot.classId ?? slot.start}`,
-    start: slot.start,
-    end: slot.end,
-    title: slot.title,
-    color: "#FFFFFF",
-    textColor: "#111827",
-    extendedProps: {
-      slotType: slot.slotType,
-      classId: slot.classId,
-    },
-  });
-
-  const fetchCalendarEvents = useCallback(
-    async (info: EventSourceFuncArg) => {
-      const startStr = formatJSTDate(info.start);
-      const endDate = new Date(info.end);
-      endDate.setDate(endDate.getDate() + 1);
-      const endStr = formatJSTDate(endDate);
-
-      try {
-        const response = await getInstructorCalendarSlots(
-          instructorId,
-          startStr,
-          endStr,
-        );
-        return response.data.map(buildMainEvent);
-      } catch (error) {
-        console.error("Failed to fetch instructor calendar slots:", error);
-        return [];
-      }
-    },
-    [instructorId],
-  );
 
   const fetchEditCalendarEvents = useCallback(
     async (info: EventSourceFuncArg) => {
@@ -216,27 +142,6 @@ export default function AdminInstructorCalendar({
     [instructorId, pendingChanges],
   );
 
-  const handleMainEventClick = useCallback(
-    (clickInfo: EventClickArg) => {
-      const { slotType, classId } = clickInfo.event.extendedProps as {
-        slotType: InstructorCalendarSlotType;
-        classId?: number;
-      };
-
-      if (
-        ["booked", "rebooked", "completed", "canceledByInstructor"].includes(
-          slotType,
-        ) &&
-        classId
-      ) {
-        router.push(
-          `/admins/instructor-list/${instructorId}/class-schedule/${classId}`,
-        );
-      }
-    },
-    [instructorId, router],
-  );
-
   const handleSlotToggle = useCallback((clickInfo: EventClickArg) => {
     const eventType = clickInfo.event.extendedProps.type;
     const dateTime = clickInfo.event.start!.toISOString();
@@ -312,62 +217,14 @@ export default function AdminInstructorCalendar({
     }
   };
 
-  const renderMainEventContent = useCallback((eventInfo: EventContentArg) => {
-    const slotType = eventInfo.event.extendedProps
-      .slotType as InstructorCalendarSlotType;
-    const isClickable = slotType !== "open" && slotType !== "absence";
-    const titleText =
-      eventInfo.event.title &&
-      !["open", "absence"].includes(slotType) &&
-      eventInfo.event.title !== SLOT_LABELS[slotType] &&
-      eventInfo.event.title !== "Class"
-        ? eventInfo.event.title
-        : "";
-    const compactLabel = titleText
-      ? `${SLOT_LABELS[slotType]} - ${titleText}`
-      : SLOT_LABELS[slotType];
-
-    return (
-      <div
-        className={`${styles.eventBlock} ${isClickable ? styles.clickable : ""}`}
-      >
-        <div className={styles.eventHeader}>
-          <span className={styles.statusBadge}>
-            <span className={styles.statusSymbol}>
-              {SLOT_SYMBOLS[slotType]}
-            </span>
-            {compactLabel}
-          </span>
-        </div>
-      </div>
-    );
-  }, []);
-
   return (
     <div className={styles.container}>
-      <Calendar
-        key={refreshKey}
-        height="auto"
-        contentHeight="auto"
-        events={fetchCalendarEvents}
-        eventClick={handleMainEventClick}
-        eventContent={renderMainEventContent}
-        eventClassNames={(arg) => {
-          const slotType = arg.event.extendedProps
-            .slotType as InstructorCalendarSlotType;
-
-          const classMap: Record<InstructorCalendarSlotType, string> = {
-            open: styles.slotOpen,
-            booked: styles.slotBooked,
-            rebooked: styles.slotBooked,
-            completed: styles.slotCompleted,
-            canceledByInstructor: styles.slotOpen,
-            absence: styles.slotAbsent,
-          };
-
-          return [styles.calendarEvent, classMap[slotType]];
-        }}
-        selectable={false}
+      <InstructorSlotCalendar
+        instructorId={instructorId}
+        refreshKey={refreshKey}
+        getClassDetailUrl={(classId) =>
+          `/admins/instructor-list/${instructorId}/class-schedule/${classId}`
+        }
         headerRight={
           <ActionButton
             btnText="Edit Absences"

--- a/frontend/src/components/features/calendar/Calendar.tsx
+++ b/frontend/src/components/features/calendar/Calendar.tsx
@@ -21,7 +21,6 @@ function Calendar({ events, headerRight, ...options }: CalendarProp) {
   return (
     <div style={{ position: "relative" }}>
       <FullCalendar
-        {...options}
         plugins={[timeGridPlugin, momentTimezonePlugin, interactionPlugin]}
         initialView="timeGridWeek"
         headerToolbar={{
@@ -34,6 +33,7 @@ function Calendar({ events, headerRight, ...options }: CalendarProp) {
         slotMaxTime="22:00:00"
         allDaySlot={false}
         timeZone="Asia/Tokyo"
+        {...options}
       />
       {headerRight && (
         <div

--- a/frontend/src/components/features/instructorSlotCalendar/InstructorSlotCalendar.module.scss
+++ b/frontend/src/components/features/instructorSlotCalendar/InstructorSlotCalendar.module.scss
@@ -1,0 +1,90 @@
+@use "@/styles/variables.module.scss" as *;
+
+.eventBlock {
+  min-height: 100%;
+  padding: 1px 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  color: #1f2937;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.eventHeader {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.statusSymbol {
+  width: 10px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.calendarEvent {
+  border-radius: 4px !important;
+  border: 1px solid $border-light !important;
+  background: $white-background !important;
+  color: $text-dark !important;
+  box-shadow: none !important;
+
+  :global(.fc-event-main) {
+    color: inherit !important;
+  }
+}
+
+.slotOpen {
+  background: rgba($green-success, 0.08) !important;
+  border-color: rgba($green-success, 0.28) !important;
+  color: $green-success-hover !important;
+}
+
+.slotBooked {
+  background: rgba($blue_primary, 0.08) !important;
+  border-color: rgba($blue_primary, 0.2) !important;
+  color: $blue_primary !important;
+}
+
+.slotCompleted {
+  background: $completed-background-color !important;
+  border-color: rgba($green-success-hover, 0.16) !important;
+  color: $green-success-hover !important;
+}
+
+.slotAbsent {
+  background: rgba($red-alert, 0.08) !important;
+  border-color: rgba($red-alert, 0.2) !important;
+  color: $red-alert-hover !important;
+}
+
+.slotCanceled {
+  background: $canceled-background-color !important;
+  border-color: rgba($canceled-text-color, 0.18) !important;
+  color: $canceled-text-color !important;
+
+  :global(.fc-event-main) {
+    color: inherit !important;
+  }
+}

--- a/frontend/src/components/features/instructorSlotCalendar/InstructorSlotCalendar.tsx
+++ b/frontend/src/components/features/instructorSlotCalendar/InstructorSlotCalendar.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useCallback } from "react";
+import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  CalendarOptions,
+  EventClickArg,
+  EventContentArg,
+  EventSourceFuncArg,
+} from "@fullcalendar/core";
+import Calendar from "@/components/features/calendar/Calendar";
+import { getInstructorCalendarSlots } from "@/lib/api/instructorsApi";
+import type {
+  InstructorCalendarSlot,
+  InstructorCalendarSlotType,
+} from "@shared/schemas/instructors";
+import styles from "./InstructorSlotCalendar.module.scss";
+
+type SlotCalendarEvent = {
+  id: string;
+  start: string;
+  end: string;
+  title: string;
+  color: string;
+  textColor: string;
+  extendedProps: {
+    slotType: InstructorCalendarSlotType;
+    classId?: number;
+  };
+};
+
+type InstructorSlotCalendarProps = {
+  instructorId: number;
+  getClassDetailUrl: (classId: number) => string;
+  headerRight?: ReactNode;
+  refreshKey?: number;
+  calendarOptions?: Partial<CalendarOptions>;
+};
+
+const SLOT_LABELS: Record<InstructorCalendarSlotType, string> = {
+  open: "Open",
+  booked: "Booked",
+  rebooked: "Booked",
+  completed: "Done",
+  absence: "Absent",
+  canceledByInstructor: "Canceled",
+};
+
+const SLOT_SYMBOLS: Record<InstructorCalendarSlotType, string> = {
+  open: "○",
+  booked: "●",
+  rebooked: "●",
+  completed: "✓",
+  absence: "−",
+  canceledByInstructor: "×",
+};
+
+const CLICKABLE_SLOT_TYPES: InstructorCalendarSlotType[] = [
+  "booked",
+  "rebooked",
+  "completed",
+  "canceledByInstructor",
+];
+
+const formatJSTDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+const buildSlotEvent = (slot: InstructorCalendarSlot): SlotCalendarEvent => ({
+  id: `${slot.slotType}-${slot.classId ?? slot.start}`,
+  start: slot.start,
+  end: slot.end,
+  title: slot.title,
+  color: "#FFFFFF",
+  textColor: "#111827",
+  extendedProps: {
+    slotType: slot.slotType,
+    classId: slot.classId,
+  },
+});
+
+export default function InstructorSlotCalendar({
+  instructorId,
+  getClassDetailUrl,
+  headerRight,
+  refreshKey = 0,
+  calendarOptions,
+}: InstructorSlotCalendarProps) {
+  const router = useRouter();
+
+  const fetchCalendarEvents = useCallback(
+    async (info: EventSourceFuncArg) => {
+      const startStr = formatJSTDate(info.start);
+      const endDate = new Date(info.end);
+      endDate.setDate(endDate.getDate() + 1);
+      const endStr = formatJSTDate(endDate);
+
+      try {
+        const response = await getInstructorCalendarSlots(
+          instructorId,
+          startStr,
+          endStr,
+        );
+
+        return response.data.map(buildSlotEvent);
+      } catch (error) {
+        console.error("Failed to fetch instructor calendar slots:", error);
+        return [];
+      }
+    },
+    [instructorId],
+  );
+
+  const handleEventClick = useCallback(
+    (clickInfo: EventClickArg) => {
+      const { slotType, classId } = clickInfo.event.extendedProps as {
+        slotType: InstructorCalendarSlotType;
+        classId?: number;
+      };
+
+      if (classId && CLICKABLE_SLOT_TYPES.includes(slotType)) {
+        router.push(getClassDetailUrl(classId));
+      }
+    },
+    [getClassDetailUrl, router],
+  );
+
+  const renderEventContent = useCallback((eventInfo: EventContentArg) => {
+    const slotType = eventInfo.event.extendedProps
+      .slotType as InstructorCalendarSlotType;
+    const isClickable = CLICKABLE_SLOT_TYPES.includes(slotType);
+    const titleText =
+      eventInfo.event.title &&
+      !["open", "absence"].includes(slotType) &&
+      eventInfo.event.title !== SLOT_LABELS[slotType] &&
+      eventInfo.event.title !== "Class"
+        ? eventInfo.event.title
+        : "";
+    const compactLabel = titleText
+      ? `${SLOT_LABELS[slotType]} - ${titleText}`
+      : SLOT_LABELS[slotType];
+
+    return (
+      <div
+        className={`${styles.eventBlock} ${isClickable ? styles.clickable : ""}`}
+      >
+        <div className={styles.eventHeader}>
+          <span className={styles.statusBadge}>
+            <span className={styles.statusSymbol}>
+              {SLOT_SYMBOLS[slotType]}
+            </span>
+            {compactLabel}
+          </span>
+        </div>
+      </div>
+    );
+  }, []);
+
+  return (
+    <Calendar
+      key={refreshKey}
+      height="auto"
+      contentHeight="auto"
+      events={fetchCalendarEvents}
+      eventClick={handleEventClick}
+      eventContent={renderEventContent}
+      eventClassNames={(arg) => {
+        const slotType = arg.event.extendedProps
+          .slotType as InstructorCalendarSlotType;
+
+        const classMap: Record<InstructorCalendarSlotType, string> = {
+          open: styles.slotOpen,
+          booked: styles.slotBooked,
+          rebooked: styles.slotBooked,
+          completed: styles.slotCompleted,
+          canceledByInstructor: styles.slotCanceled,
+          absence: styles.slotAbsent,
+        };
+
+        return [styles.calendarEvent, classMap[slotType]];
+      }}
+      selectable={false}
+      headerRight={headerRight}
+      {...calendarOptions}
+    />
+  );
+}

--- a/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendar.tsx
+++ b/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendar.tsx
@@ -1,57 +1,14 @@
-import {
-  getCalendarClasses,
-  getInstructorProfile,
-} from "@/lib/api/instructorsApi";
-import { getValidRange } from "@/lib/utils/calendarUtils";
-import InstructorCalendarClient from "./InstructorCalendarClient";
-import {
-  getAllBusinessSchedules,
-  getAllEvents,
-  getMessageBoardPosts,
-} from "@/lib/api/adminsApi";
+import { getMessageBoardPosts } from "@/lib/api/adminsApi";
 import { getCookie } from "../../../../proxy";
+import InstructorSlotScheduleClient from "./InstructorSlotScheduleClient";
 
-async function InstructorCalendar({
-  adminId,
-  instructorId,
-  userSessionType,
-}: {
-  adminId?: number;
-  instructorId: number;
-  userSessionType?: UserType;
-}) {
-  // Get the cookies from the request headers
+async function InstructorCalendar({ instructorId }: { instructorId: number }) {
   const cookie = await getCookie();
-
-  const [classes, profile, schedule, events, messageBoardPosts] =
-    await Promise.all([
-      getCalendarClasses(instructorId, cookie),
-      getInstructorProfile(instructorId, cookie),
-      getAllBusinessSchedules(cookie),
-      getAllEvents(cookie),
-      getMessageBoardPosts(cookie),
-    ]);
-
-  const instructorCalendarEvents = classes;
-  const createdAt: string = profile.createdAt;
-  const validRange = getValidRange(createdAt, 3);
-
-  const colorsForEvents: { event: string; color: string }[] = events
-    .map((e: EventColor) => ({
-      event: e.Event,
-      color: e["Color Code"],
-    }))
-    .filter((e: { event: string; color: string }) => e.color !== "#FFFFFF"); // Filter out events with white color (#FFFFFF)
+  const messageBoardPosts = await getMessageBoardPosts(cookie);
 
   return (
-    <InstructorCalendarClient
-      adminId={adminId}
+    <InstructorSlotScheduleClient
       instructorId={instructorId}
-      userSessionType={userSessionType}
-      instructorCalendarEvents={instructorCalendarEvents}
-      validRange={validRange}
-      businessSchedule={schedule.organizedData}
-      colorsForEvents={colorsForEvents}
       messageBoardPosts={messageBoardPosts}
     />
   );

--- a/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorSlotScheduleClient.tsx
+++ b/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorSlotScheduleClient.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import InstructorSlotCalendar from "@/components/features/instructorSlotCalendar/InstructorSlotCalendar";
+import MessageBoardPanel from "@/components/features/messageBoardPanel/MessageBoardPanel";
+import { MessageTarget } from "@/types";
+import styles from "./InstructorCalendarClient.module.scss";
+
+type InstructorSlotScheduleClientProps = {
+  instructorId: number;
+  messageBoardPosts?: MessageBoardPostItem[];
+};
+
+export default function InstructorSlotScheduleClient({
+  instructorId,
+  messageBoardPosts = [],
+}: InstructorSlotScheduleClientProps) {
+  const visiblePosts = messageBoardPosts.filter(
+    (post) =>
+      post.target === MessageTarget.instructor ||
+      post.target === MessageTarget.both,
+  );
+
+  return (
+    <div className={styles.calendarContainer}>
+      <MessageBoardPanel
+        posts={visiblePosts}
+        storageKey="instructorClassScheduleMessageBoardOpenState"
+        readMessageStorageKey="readInstructorMessageNumber"
+      />
+      <InstructorSlotCalendar
+        instructorId={instructorId}
+        getClassDetailUrl={(classId) =>
+          `/instructors/class-schedule/${classId}`
+        }
+        calendarOptions={{
+          slotMinTime: "00:00:00",
+          slotMaxTime: "24:00:00",
+          slotDuration: "00:30:00",
+          timeZone: "local",
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -125,7 +125,7 @@ export function getLinks(
 
   const instructorLinks: LinkType[] = [
     {
-      name: "Class Schedule",
+      name: "Calendar",
       href: "/instructors/class-schedule",
       icon: CalendarIcon,
     },
@@ -135,7 +135,7 @@ export function getLinks(
       icon: UserIcon,
     },
     {
-      name: "Availability Schedule",
+      name: "Schedule",
       href: "/instructors/availability",
       icon: ClockIcon,
     },


### PR DESCRIPTION
## Summary
- Share a read-only slot calendar component between admin and instructor views.
- Keep admin-only absence editing in the admin instructor calendar; instructors only see slot statuses and class links.
- Show instructor slots across the full local day and rename instructor nav items to Calendar/Schedule.

## Validation
- /home/momori/.codex/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh
- Frontend gate passed: format-check, lint -- --max-warnings 0, lint:unused, build.
- Earlier smoke coverage: instructor calendar renders Open/Booked/Absent without Edit Absences; booked slot opens instructor class detail; admin calendar retains Edit Absences. Admin modal data fetch on local 3001/4001 was limited by existing CSP allowing localhost:4000 only.