### PR TITLE
Fix/556 enable generating classes for the current month

### DIFF
--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -45,6 +45,7 @@ import {
   getMonthNumber,
   isSameLocalDate,
   nHoursBefore,
+  toDateKey,
 } from "../utils/dateUtils";
 import { getInstructorContactById } from "../services/instructorsService";
 import { getCustomerContactById } from "../services/customersService";
@@ -61,6 +62,8 @@ import {
   createAttendances,
   deleteAttendancesByClassId,
 } from "../services/classAttendancesService";
+import { getInstructorAbsencesByMonth } from "../services/instructorAbsenceService";
+import { getSchedulesByEventIdAndDate } from "../services/scheduleService";
 
 // GET all classes along with related instructors and customers data
 export const getAllClassesController = async (_: Request, res: Response) => {
@@ -519,10 +522,14 @@ export const createClassesForMonthController = async (
   try {
     const result = await prisma.$transaction(
       async (tx: Prisma.TransactionClient) => {
-        // First date of a giving month.
+        // First date of the given month
         const monthNum = getMonthNumber(month);
         if (monthNum === -1) throw new Error("Invalid month");
         const firstDateOfMonth = new Date(Date.UTC(year, monthNum, 1));
+
+        // Define until when schedule should be created
+        const until = getFirstDateInMonths(firstDateOfMonth, 1);
+        until.setUTCDate(until.getUTCDate() - 1);
 
         // Get valid recurring classes.
         const recurringClasses = await getValidRecurringClasses(
@@ -530,11 +537,7 @@ export const createClassesForMonthController = async (
           firstDateOfMonth,
         );
 
-        // Define until when schedule should be created.
-        const until = getFirstDateInMonths(firstDateOfMonth, 1);
-        until.setUTCDate(until.getUTCDate() - 1);
-
-        // Get excluded classes.
+        // Get already existing classes
         const recurringClassIds = recurringClasses.map(
           (recurringClass) => recurringClass.id,
         );
@@ -545,10 +548,62 @@ export const createClassesForMonthController = async (
           until,
         );
 
-        // TODO: Get the instructors' unavailability and exclude it.
-        // TODO: Get the holiday and exclude it.
+        // Extract instructor ids
+        const instructorIds = recurringClasses
+          .map((r) => r.instructorId)
+          .filter(Boolean) as number[];
 
-        // Repeat the number of recurring classes.
+        // Get instructors' unavailability
+        const instructorAbsences = await getInstructorAbsencesByMonth(
+          instructorIds,
+          firstDateOfMonth,
+          until,
+          tx,
+        );
+
+        // Get no classes
+        const noClasses = await getSchedulesByEventIdAndDate(
+          2,
+          firstDateOfMonth,
+          until,
+        );
+
+        // Get rebookable no classes
+        const rebookableNoClasses = await getSchedulesByEventIdAndDate(
+          3,
+          firstDateOfMonth,
+          until,
+        );
+
+        // Prepare sets
+        const existingSet = new Set(
+          excludedClasses.map(
+            (cls) =>
+              `${cls.instructorId}-${new Date(cls.dateTime!).toISOString()}`,
+          ),
+        );
+
+        // TEMP: Adjust timezone. Remove once timezone handling is fixed.
+        const absenceSet = new Set(
+          instructorAbsences.map(
+            (absence) =>
+              `${absence.instructorId}-${new Date(
+                absence.absentAt.getTime() + 9 * 60 * 60 * 1000,
+              ).toISOString()}`,
+          ),
+        );
+
+        const noClassSet = new Set(
+          noClasses.map((schedule) => toDateKey(new Date(schedule.date!))),
+        );
+
+        const rebookableSet = new Set(
+          rebookableNoClasses.map((schedule) =>
+            toDateKey(new Date(schedule.date!)),
+          ),
+        );
+
+        // Generate classes for each recurring class
         await Promise.all(
           recurringClasses.map(async (recurringClass) => {
             const {
@@ -572,14 +627,18 @@ export const createClassesForMonthController = async (
             }
 
             // If startAt is earlier than the end of the current month, skip it.
-            if (startAt && startAt > until) {
+            if (startAt > until) {
               return;
             }
 
             // Extract time from startAt
-            const hours = startAt.getHours().toString().padStart(2, "0");
-            const minutes = startAt.getMinutes().toString().padStart(2, "0");
-            const time = `${hours}:${minutes}`;
+            const time = `${startAt
+              .getHours()
+              .toString()
+              .padStart(2, "0")}:${startAt
+              .getMinutes()
+              .toString()
+              .padStart(2, "0")}`;
 
             // Get the first date of the class of the month
             const firstDate = calculateFirstDate(
@@ -594,16 +653,32 @@ export const createClassesForMonthController = async (
               endAt && endAt < until ? endAt : until,
             );
 
-            // Filter only the dateTimes that already exist.
-            const filteredDateTimes = dateTimes.filter((date) => {
-              return !excludedClasses.some((excluded) => {
-                return (
-                  new Date(excluded.dateTime!).toISOString() ===
-                    date.toISOString() && excluded.instructorId === instructorId
-                );
-              });
-            });
-            if (filteredDateTimes.length === 0) return;
+            // filter part
+            let filtered = dateTimes;
+
+            // Exclude the dateTimes that already exist.
+            filtered = filtered.filter(
+              (date) =>
+                !existingSet.has(`${instructorId}-${date.toISOString()}`),
+            );
+
+            // Exclude the instructors' unavailability.
+            filtered = filtered.filter(
+              (date) =>
+                !absenceSet.has(`${instructorId}-${date.toISOString()}`),
+            );
+
+            // Exclude the no class.
+            filtered = filtered.filter(
+              (date) => !noClassSet.has(toDateKey(date)),
+            );
+
+            // Exclude the rebokkable no class.
+            filtered = filtered.filter(
+              (date) => !rebookableSet.has(toDateKey(date)),
+            );
+
+            if (filtered.length === 0) return;
 
             const childrenIds = recurringClassAttendance.map(
               (attendee) => attendee.childrenId,
@@ -617,7 +692,7 @@ export const createClassesForMonthController = async (
               subscription.customerId,
               subscriptionId,
               childrenIds,
-              filteredDateTimes,
+              filtered,
             );
           }),
         );

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -529,7 +529,6 @@ export const createClassesForMonthController = async (
 
         // Define until when schedule should be created
         const until = getFirstDateInMonths(firstDateOfMonth, 1);
-        until.setUTCDate(until.getUTCDate() - 1);
 
         // Get valid recurring classes.
         const recurringClasses = await getValidRecurringClasses(

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -15,6 +15,7 @@ import {
   InstructorUnavailableError,
   rebookClass,
   updateClass,
+  cancelClassByInstructor,
 } from "../services/classesService";
 import {
   RequestWithParams,
@@ -552,7 +553,7 @@ export const createClassesForMonthController = async (
           .map((r) => r.instructorId)
           .filter(Boolean) as number[];
 
-        // Get instructors' unavailability
+        // Get instructor absences
         const instructorAbsences = await getInstructorAbsencesByMonth(
           instructorIds,
           firstDateOfMonth,
@@ -661,20 +662,9 @@ export const createClassesForMonthController = async (
                 !existingSet.has(`${instructorId}-${date.toISOString()}`),
             );
 
-            // Exclude the instructors' unavailability.
-            filtered = filtered.filter(
-              (date) =>
-                !absenceSet.has(`${instructorId}-${date.toISOString()}`),
-            );
-
             // Exclude the no class.
             filtered = filtered.filter(
               (date) => !noClassSet.has(toDateKey(date)),
-            );
-
-            // Exclude the rebokkable no class.
-            filtered = filtered.filter(
-              (date) => !rebookableSet.has(toDateKey(date)),
             );
 
             if (filtered.length === 0) return;
@@ -684,7 +674,7 @@ export const createClassesForMonthController = async (
             );
 
             // Create the classes and its attendance based on the recurring id.
-            await createClassesUsingRecurringClassId(
+            const createdClasses = await createClassesUsingRecurringClassId(
               tx,
               id,
               instructorId,
@@ -692,6 +682,25 @@ export const createClassesForMonthController = async (
               subscriptionId,
               childrenIds,
               filtered,
+            );
+
+            // Cancel class due to instructor absence or rebookable no class
+            await Promise.all(
+              createdClasses.map(async (createdClass) => {
+                if (!createdClass.dateTime) return;
+
+                const isInstructorAbsent = absenceSet.has(
+                  `${instructorId}-${createdClass.dateTime.toISOString()}`,
+                );
+
+                const isRebookableNoClass = rebookableSet.has(
+                  toDateKey(createdClass.dateTime),
+                );
+
+                if (isInstructorAbsent || isRebookableNoClass) {
+                  await cancelClassByInstructor(tx, createdClass.id);
+                }
+              }),
             );
           }),
         );

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -530,6 +530,10 @@ export const createClassesForMonthController = async (
           firstDateOfMonth,
         );
 
+        // Define until when schedule should be created.
+        const until = getFirstDateInMonths(firstDateOfMonth, 1);
+        until.setUTCDate(until.getUTCDate() - 1);
+
         // Get excluded classes.
         const recurringClassIds = recurringClasses.map(
           (recurringClass) => recurringClass.id,
@@ -538,14 +542,11 @@ export const createClassesForMonthController = async (
           tx,
           recurringClassIds,
           firstDateOfMonth,
+          until,
         );
 
         // TODO: Get the instructors' unavailability and exclude it.
         // TODO: Get the holiday and exclude it.
-
-        // Define until when schedule should be created.
-        const until = getFirstDateInMonths(firstDateOfMonth, 1);
-        until.setUTCDate(until.getUTCDate() - 1);
 
         // Repeat the number of recurring classes.
         await Promise.all(
@@ -570,8 +571,8 @@ export const createClassesForMonthController = async (
               return;
             }
 
-            // If startAt is earlier than firstDateOfMonth, skip it.
-            if (startAt && firstDateOfMonth < new Date(startAt)) {
+            // If startAt is earlier than the end of the current month, skip it.
+            if (startAt && startAt > until) {
               return;
             }
 
@@ -582,7 +583,7 @@ export const createClassesForMonthController = async (
 
             // Get the first date of the class of the month
             const firstDate = calculateFirstDate(
-              firstDateOfMonth,
+              firstDateOfMonth < startAt ? startAt : firstDateOfMonth,
               days[startAt.getDay()],
               time,
             );
@@ -593,22 +594,16 @@ export const createClassesForMonthController = async (
               endAt && endAt < until ? endAt : until,
             );
 
-            // if you find the same dateTime and instructor id as in the excludedClass, skip it.
-            const isExistingClass = excludedClasses.some((excludedClass) => {
-              const excludedClassDateTimesStr = new Date(
-                excludedClass.dateTime!, // All "excludedClasses" are selected by dateTime, so dateTime is guaranteed to exist.
-              ).toISOString();
-              const dateTimesStr = dateTimes.map((date) =>
-                new Date(date).toISOString(),
-              );
-              return (
-                dateTimesStr.includes(excludedClassDateTimesStr) &&
-                excludedClass.instructorId === instructorId
-              );
+            // Filter only the dateTimes that already exist.
+            const filteredDateTimes = dateTimes.filter((date) => {
+              return !excludedClasses.some((excluded) => {
+                return (
+                  new Date(excluded.dateTime!).toISOString() ===
+                    date.toISOString() && excluded.instructorId === instructorId
+                );
+              });
             });
-            if (isExistingClass) {
-              return;
-            }
+            if (filteredDateTimes.length === 0) return;
 
             const childrenIds = recurringClassAttendance.map(
               (attendee) => attendee.childrenId,
@@ -622,7 +617,7 @@ export const createClassesForMonthController = async (
               subscription.customerId,
               subscriptionId,
               childrenIds,
-              dateTimes,
+              filteredDateTimes,
             );
           }),
         );

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -334,7 +334,7 @@ export const createClassesUsingRecurringClassId = async (
   dateTimes: Date[],
 ) => {
   try {
-    const createdClasses = await tx.class.createManyAndReturn({
+    await tx.class.createManyAndReturn({
       data: dateTimes.map((dateTime, index) => {
         return {
           recurringClassId,
@@ -347,6 +347,14 @@ export const createClassesUsingRecurringClassId = async (
           classCode: `${recurringClassId}-${index}`,
         };
       }),
+      skipDuplicates: true,
+    });
+
+    const createdClasses = await tx.class.findMany({
+      where: {
+        recurringClassId,
+        dateTime: { in: dateTimes },
+      },
     });
 
     await tx.classAttendance.createMany({

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -347,7 +347,6 @@ export const createClassesUsingRecurringClassId = async (
           classCode: `${recurringClassId}-${index}`,
         };
       }),
-      skipDuplicates: true,
     });
 
     const createdClasses = await tx.class.findMany({
@@ -379,12 +378,13 @@ export const getExcludedClasses = async (
   tx: Prisma.TransactionClient,
   recurringClassIds: number[],
   date: Date,
+  until: Date,
 ) => {
   try {
     const excludedClassData = await tx.class.findMany({
       where: {
         recurringClassId: { in: recurringClassIds },
-        dateTime: { gte: date },
+        dateTime: { gte: date, lte: until },
       },
     });
 

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -323,6 +323,27 @@ export const cancelClassById = async (classId: number) => {
   });
 };
 
+// Cancel classes by instructor
+export const cancelClassByInstructor = async (
+  tx: Prisma.TransactionClient,
+  classId: number,
+) => {
+  const now = new Date();
+
+  await tx.classAttendance.deleteMany({
+    where: { classId },
+  });
+
+  await tx.class.update({
+    where: { id: classId },
+    data: {
+      status: "canceledByInstructor",
+      canceledAt: now,
+      updatedAt: now,
+    },
+  });
+};
+
 // Create classes based on the recurring class id
 export const createClassesUsingRecurringClassId = async (
   tx: Prisma.TransactionClient,
@@ -368,7 +389,7 @@ export const createClassesUsingRecurringClassId = async (
         .flat(),
     });
 
-    return { createdClasses };
+    return createdClasses;
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to add classes.");

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -343,6 +343,7 @@ export const createClassesUsingRecurringClassId = async (
           subscriptionId,
           status: "booked",
           dateTime,
+          rebookableUntil: nDaysLater(180, dateTime),
           updatedAt: new Date(),
           classCode: `${recurringClassId}-${index}`,
         };

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -384,7 +384,7 @@ export const getExcludedClasses = async (
     const excludedClassData = await tx.class.findMany({
       where: {
         recurringClassId: { in: recurringClassIds },
-        dateTime: { gte: date, lte: until },
+        dateTime: { gte: date, lt: until },
       },
     });
 

--- a/backend/src/services/instructorAbsenceService.ts
+++ b/backend/src/services/instructorAbsenceService.ts
@@ -130,3 +130,27 @@ export const removeInstructorAbsence = async (
     throw new Error("Failed to remove instructor absence.");
   }
 };
+
+export const getInstructorAbsencesByMonth = async (
+  instructorIds: number[],
+  start: Date,
+  end: Date,
+  tx?: Prisma.TransactionClient,
+) => {
+  const client = tx ?? prisma;
+  try {
+    return await client.instructorAbsence.findMany({
+      where: {
+        instructorId: { in: instructorIds },
+        absentAt: {
+          gte: start,
+          lt: end,
+        },
+      },
+      orderBy: { absentAt: "asc" },
+    });
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch instructor absences.");
+  }
+};

--- a/backend/src/services/scheduleService.ts
+++ b/backend/src/services/scheduleService.ts
@@ -80,3 +80,31 @@ export const deleteOldBusinessCalendar = async () => {
     },
   });
 };
+
+// Fetch schedules by id
+export const getSchedulesByEventIdAndDate = async (
+  eventId: number,
+  start: Date,
+  end: Date,
+) => {
+  try {
+    return await prisma.schedule.findMany({
+      where: {
+        eventId,
+        date: {
+          gte: start,
+          lt: end,
+        },
+      },
+      orderBy: {
+        date: "asc",
+      },
+      include: {
+        event: true,
+      },
+    });
+  } catch (error) {
+    console.error("Database Error:", error);
+    throw new Error("Failed to fetch schedules.");
+  }
+};

--- a/backend/src/utils/dateUtils.ts
+++ b/backend/src/utils/dateUtils.ts
@@ -218,3 +218,6 @@ export function convertToUTCDate(date: Date, timezoneFrom: string): Date {
       return date;
   }
 }
+
+// Extract only the date (e.g., "2026-05-21")
+export const toDateKey = (d: Date) => d.toISOString().split("T")[0];


### PR DESCRIPTION
## Overview
- Fix to enable generating classes for the current month
- Skip generating classes when no class
- Cancel classes when the date is the instructor absence or rebookable no class

## Review Preparation
Step 1: Add a new recurring class (e.g., Mon, Helene, 16:00)
Step 2: Delete classes for the current month
Step 3: Schedule "no class" or "rebookable no class" (e.g., May, 18th)
Step 4: Edit instructor absence (e.g., Helene, May 25th, 16:00)
Step 5: Go to the Class List and click "Generate Classes"

## Review point
1. Skip generating existing classes
2. Skip generating no class event
3. Cancel instructor absence classes after generating them and they should be rebookable
4. Cancel rebookable no classes after generating them and they should be rebookable