### PR TITLE
Add production-safe bootstrap seed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,14 @@ AaasoBo! is an online English conversation service run by a Japanese NPO that ta
 - **Development**: `npm run dev` (starts with nodemon and ts-node)
 - **Database**:
   - Start PostgreSQL: `npm run db:start` (Docker container)
-  - Initialize/Reset DB: `npm run prisma:init` (runs migrations + seed)
+  - Initialize/Reset DB: `npm run prisma:init` (runs migrations + bootstrap)
+  - Apply migrations: `npm run db:migrate` (production-safe migration deploy)
+  - Bootstrap required data: `npm run db:bootstrap` (idempotent, production-safe seed)
+  - Insert dummy data: `npm run seed:dummy` (manual local/demo seed)
 - **Testing**: `npm run test` (Vitest)
 - **Unused Code Check**: `npm run lint:unused`
 - **Formatting**: `npm run format` (Prettier + Prisma format)
-- **Build**: `npm run build` (generates Prisma client, resets DB, runs dummy seed)
+- **Build**: `npm run build` (installs shared dependencies, generates Prisma client, applies migrations, and bootstraps required data)
 
 ### Frontend
 - **Setup**: `cd frontend && npm install`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ KEY2="<generate_with_openssl_rand_hex_32>"
 RESEND_API_KEY="Dummy Resend API Key"
 AUTH_SECRET="<generate_with_openssl_rand_hex_32>"
 AUTH_SALT="next-auth.session-token"
+BOOTSTRAP_ADMIN_EMAIL="admin@example.com"
+BOOTSTRAP_ADMIN_NAME="Local Admin"
+BOOTSTRAP_ADMIN_PASSWORD="<local_admin_password>"
 ```
 
 Note that the following variables should be changed to match your local setup:
@@ -51,6 +54,7 @@ Note that the following variables should be changed to match your local setup:
 - `RESEND_API_KEY` is shared in the development team.
 - `AUTH_SECRET` must match the frontend `AUTH_SECRET` (same value).
 - `AUTH_SALT` must be `next-auth.session-token` (the session cookie name used by the frontend in this repo).
+- `BOOTSTRAP_ADMIN_EMAIL`, `BOOTSTRAP_ADMIN_NAME`, and `BOOTSTRAP_ADMIN_PASSWORD` are used by `npm run db:bootstrap` to create the first admin only when it does not already exist. Do not commit real production credentials.
 
 `KEY1` and `KEY2` are used for security purposes. They should be changed to a random string, for example, by running either of the following command:
 
@@ -74,9 +78,25 @@ npm run db:start
 
 #### Prisma
 
+Reset the local database, run migrations, and bootstrap required data:
+
 ```sh
 npm run prisma:init
 ```
+
+Run only the idempotent bootstrap seed for required production-safe data:
+
+```sh
+npm run db:bootstrap
+```
+
+Insert local dummy data explicitly when needed:
+
+```sh
+npm run seed:dummy
+```
+
+Vercel deploys run `npm run build`, which generates Prisma, applies migrations with `prisma migrate deploy`, and then runs the idempotent bootstrap seed.
 
 #### Tests
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,12 +8,15 @@
     "db:start": "docker run --name summer-postgres -p 5432:5432 -e POSTGRES_PASSWORD=summer -d postgres",
     "generate": "prisma generate",
     "dev": "prisma generate && nodemon --exec ts-node ./api/app.ts",
-    "prisma:init": "prisma generate && npx prisma migrate reset && npx ts-node ./src/seed/dummy.ts",
+    "db:migrate": "prisma migrate deploy",
+    "db:bootstrap": "ts-node ./src/seed/bootstrap.ts",
+    "seed:dummy": "ts-node ./src/seed/dummy.ts",
+    "prisma:init": "prisma generate && npx prisma migrate reset && npm run db:bootstrap",
     "fixture:generate:normalized-import": "ts-node ./src/seed/generateNormalizedImportFixture.ts",
     "test": "prisma generate && vitest run src/test/api",
     "test:api": "prisma generate && vitest run src/test/api",
     "test:performance": "prisma generate && vitest run src/test/performance",
-    "build": "cd ../shared && npm install && cd ../backend && prisma generate && prisma migrate reset --force && echo 'Start executing dummy.ts' && ts-node ./src/seed/dummy.ts && echo 'Finish executing dummy.ts'",
+    "build": "cd ../shared && npm install && cd ../backend && prisma generate && npm run db:migrate && npm run db:bootstrap",
     "lint:unused": "knip"
   },
   "engines": {

--- a/backend/src/seed/bootstrap.ts
+++ b/backend/src/seed/bootstrap.ts
@@ -1,0 +1,123 @@
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../../generated/prisma/client";
+import { hashPassword } from "../utils/commonUtils";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.POSTGRES_PRISMA_URL,
+});
+const prisma = new PrismaClient({ adapter });
+
+const defaultPlans = [
+  {
+    name: "月3,180円プラン / 3,180 yen/month Plan",
+    description: "2 classes per week",
+    weeklyClassTimes: 2,
+    englishBackground: 0,
+  },
+  {
+    name: "月7,980円プラン / 7,980 yen/month Plan",
+    description: "5 classes per week",
+    weeklyClassTimes: 5,
+    englishBackground: 0,
+  },
+  {
+    name: "月5,980円プラン / 5,980 yen/month Plan",
+    description: "1 classes per week",
+    weeklyClassTimes: 1,
+    englishBackground: 1,
+  },
+  {
+    name: "月10,800円プラン / 10,800 yen/month Plan",
+    description: "2 classes per week",
+    weeklyClassTimes: 2,
+    englishBackground: 2,
+  },
+];
+
+async function ensureSystemStatus() {
+  const existing = await prisma.systemStatus.findFirst({
+    select: { id: true },
+  });
+
+  if (existing) {
+    console.log("SystemStatus already exists. Skipping.");
+    return;
+  }
+
+  await prisma.systemStatus.create({
+    data: { status: "Running" },
+  });
+  console.log("Created SystemStatus.");
+}
+
+async function ensureBootstrapAdmin() {
+  const email = process.env.BOOTSTRAP_ADMIN_EMAIL?.trim().toLowerCase();
+  const name = process.env.BOOTSTRAP_ADMIN_NAME?.trim() || "Admin";
+  const password = process.env.BOOTSTRAP_ADMIN_PASSWORD;
+
+  if (!email) {
+    console.log("BOOTSTRAP_ADMIN_EMAIL is not set. Skipping admin creation.");
+    return;
+  }
+
+  const existing = await prisma.admin.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+
+  if (existing) {
+    console.log(`Admin ${email} already exists. Skipping.`);
+    return;
+  }
+
+  if (!password) {
+    throw new Error(
+      "BOOTSTRAP_ADMIN_PASSWORD must be set when creating a bootstrap admin.",
+    );
+  }
+
+  await prisma.admin.create({
+    data: {
+      name,
+      email,
+      password: await hashPassword(password),
+    },
+  });
+  console.log(`Created bootstrap admin ${email}.`);
+}
+
+async function ensureDefaultPlans() {
+  for (const plan of defaultPlans) {
+    const existing = await prisma.plan.findFirst({
+      where: {
+        name: plan.name,
+        terminationAt: null,
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      console.log(`Plan already exists: ${plan.name}. Skipping.`);
+      continue;
+    }
+
+    await prisma.plan.create({ data: plan });
+    console.log(`Created plan: ${plan.name}.`);
+  }
+}
+
+async function main() {
+  await ensureSystemStatus();
+  await ensureBootstrapAdmin();
+  await ensureDefaultPlans();
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add an idempotent backend bootstrap seed for system status, default plans, and optional bootstrap admin creation
- split migration/bootstrap/dummy seed commands so dummy data is manual only
- make backend build run Prisma generation, migration deploy, and bootstrap for Vercel deploys
- update setup docs for bootstrap admin env vars and seed commands