### PR TITLE
Fix backend Vercel entrypoint

### DIFF
--- a/backend/api/app.ts
+++ b/backend/api/app.ts
@@ -5,4 +5,8 @@ dotenv.config();
 
 const PORT = process.env.PORT;
 
-server.listen(PORT, () => console.log(`[Server]: http://localhost:${PORT}`));
+if (!process.env.VERCEL) {
+  server.listen(PORT, () => console.log(`[Server]: http://localhost:${PORT}`));
+}
+
+export default server;


### PR DESCRIPTION
## Summary

- Export the Express server from the Vercel entrypoint so Vercel creates the `api/app` serverless function.
- Keep `server.listen()` for local development only, outside Vercel.

## Root Cause

The backend-dev deployment was marked Ready but did not expose the Express routes; `POST /users/authenticate` returned Vercel `404 NOT_FOUND`, so the frontend admin login could not reach the auth endpoint.

## Validation

- `npx tsc --noEmit` in `backend`
- `git diff --check -- backend/api/app.ts`
