### PR TITLE
Harden release security checks

### DIFF
--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -139,7 +139,7 @@ export const sendUserResetEmailController = async (
     const user = await getUserByEmail(userType, normalizedEmail);
 
     if (!user) {
-      return res.sendStatus(404);
+      return res.sendStatus(202);
     }
 
     const passwordResetToken = await generatePasswordResetToken(user.email);
@@ -153,10 +153,17 @@ export const sendUserResetEmailController = async (
 
     if (!sendResult.success) {
       await deletePasswordResetToken(passwordResetToken.email);
-      return res.sendStatus(503); // Failed to send password reset email. 503 Service Unavailable
+      console.error("Failed to send password reset email", {
+        context: {
+          email: normalizedEmail,
+          userType,
+          time: new Date().toISOString(),
+        },
+      });
+      return res.sendStatus(202);
     }
 
-    return res.sendStatus(201);
+    return res.sendStatus(202);
   } catch (error) {
     console.error("Error sending password reset email", {
       error,
@@ -166,7 +173,7 @@ export const sendUserResetEmailController = async (
         time: new Date().toISOString(),
       },
     });
-    res.sendStatus(500);
+    res.sendStatus(202);
   }
 };
 

--- a/backend/src/routes/usersRouter.ts
+++ b/backend/src/routes/usersRouter.ts
@@ -50,13 +50,14 @@ const sendPasswordResetConfig = {
     summary: "Send password reset email",
     description: "Send password reset email",
     responses: {
-      201: { description: "Password reset email sent successfully" },
+      202: {
+        description:
+          "Password reset request accepted if the account can receive email",
+      },
       400: {
         description: "Bad request - validation failed",
         schema: ErrorResponse,
       },
-      404: { description: "User not found" },
-      503: { description: "Service unavailable - failed to send email" },
     },
   },
 } as const;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -32,9 +32,11 @@ import { globalRegistry, createOpenApiSpec } from "./openapi/spec";
 import { registerRoutesFromConfig } from "./openapi/routerRegistry";
 
 export const server = express();
+server.disable("x-powered-by");
 
 // Set up allowed origin
 const allowedOrigin = process.env.FRONTEND_ORIGIN || "";
+const corsErrorMessage = "Not allowed by CORS";
 
 // CORS Configuration
 server.use(
@@ -49,7 +51,7 @@ server.use(
         return callback(null, true);
       }
 
-      return callback(new Error("Not allowed by CORS"));
+      return callback(new Error(corsErrorMessage));
     },
     credentials: true,
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
@@ -116,3 +118,24 @@ if (process.env.NODE_ENV === "development") {
     res.send(openApiSpec);
   });
 }
+
+const errorHandler: express.ErrorRequestHandler = (err, req, res, next) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  if (err instanceof Error && err.message === corsErrorMessage) {
+    return res.status(403).json({ message: "Forbidden origin" });
+  }
+
+  console.error("Unhandled request error", {
+    error: err instanceof Error ? err.message : "unknown_error",
+    path: req.path,
+    method: req.method,
+    time: new Date().toISOString(),
+  });
+
+  return res.status(500).json({ message: "Internal server error" });
+};
+
+server.use(errorHandler);

--- a/backend/src/test/api/users.test.ts
+++ b/backend/src/test/api/users.test.ts
@@ -131,6 +131,24 @@ describe("POST /users/authenticate", () => {
   });
 });
 
+describe("CORS error handling", () => {
+  it("returns a generic forbidden response for disallowed origins", async () => {
+    const response = await request(server)
+      .post("/users/authenticate")
+      .set("Origin", "https://evil.example")
+      .send({
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+        userType: "admin",
+      })
+      .expect(403);
+
+    expect(response.body).toEqual({ message: "Forbidden origin" });
+    expect(response.text).not.toContain("src/server.ts");
+    expect(response.text).not.toContain("node_modules");
+  });
+});
+
 describe("POST /users/send-password-reset", () => {
   it("succeed for existing admin", async () => {
     const adminData = generateTestAdmin();
@@ -142,7 +160,7 @@ describe("POST /users/send-password-reset", () => {
         email: adminData.email,
         userType: "admin",
       })
-      .expect(201);
+      .expect(202);
 
     // Verify token was created in database
     const token = await prisma.passwordResetToken.findFirst({
@@ -162,7 +180,7 @@ describe("POST /users/send-password-reset", () => {
         email: customerData.email,
         userType: "customer",
       })
-      .expect(201);
+      .expect(202);
 
     const token = await prisma.passwordResetToken.findFirst({
       where: { email: customerData.email },
@@ -180,7 +198,7 @@ describe("POST /users/send-password-reset", () => {
         email: instructorData.email,
         userType: "instructor",
       })
-      .expect(201);
+      .expect(202);
 
     const token = await prisma.passwordResetToken.findFirst({
       where: { email: instructorData.email },
@@ -188,14 +206,14 @@ describe("POST /users/send-password-reset", () => {
     expect(token).toBeTruthy();
   });
 
-  it("fail with non-existent user", async () => {
+  it("returns the same accepted response for non-existent user", async () => {
     await request(server)
       .post("/users/send-password-reset")
       .send({
         email: faker.internet.email(),
         userType: "admin",
       })
-      .expect(404);
+      .expect(202);
   });
 });
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,8 +1,29 @@
+const isProduction = process.env.NODE_ENV === "production";
+
+const scriptSrc = isProduction
+  ? "script-src 'self'"
+  : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+
+const connectSrc = isProduction
+  ? "connect-src 'self' https:"
+  : "connect-src 'self' http://localhost:4000 http://127.0.0.1:4000 https:";
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
-    value:
-      "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://localhost:4000 https:; object-src 'none'; upgrade-insecure-requests",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "img-src 'self' data: blob: https://*.public.blob.vercel-storage.com",
+      "font-src 'self' data:",
+      "style-src 'self' 'unsafe-inline'",
+      scriptSrc,
+      connectSrc,
+      "object-src 'none'",
+      "upgrade-insecure-requests",
+    ].join("; "),
   },
   {
     key: "Referrer-Policy",

--- a/frontend/src/lib/utils/alertUtils.ts
+++ b/frontend/src/lib/utils/alertUtils.ts
@@ -1,18 +1,10 @@
 import Swal from "sweetalert2";
 
-const buildAlertHtml = (text: string): string => `
-  <div style="text-align:center;">
-    <div style="display:inline-block; text-align:left; margin:0 auto; max-width: 100%; width: fit-content; white-space: normal; overflow-wrap: break-word;">
-      ${text}
-    </div>
-  </div>
-`;
-
 export const confirmAlert: (text: string) => Promise<boolean> = (
   text: string,
 ) => {
   const result = Swal.fire({
-    html: buildAlertHtml(text),
+    text,
     icon: "warning",
     confirmButtonText: "OK",
     cancelButtonText: "Cancel",
@@ -36,7 +28,7 @@ export const successAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: buildAlertHtml(text),
+    text,
     icon: "success",
     confirmButtonText: "OK",
     showConfirmButton: true,
@@ -51,7 +43,7 @@ export const errorAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: buildAlertHtml(text),
+    text,
     icon: "error",
     confirmButtonText: "OK",
     showConfirmButton: true,
@@ -66,7 +58,7 @@ export const warningAlert: (text: string) => Promise<void> = async (
   text: string,
 ) => {
   Swal.fire({
-    html: buildAlertHtml(text),
+    text,
     icon: "warning",
     confirmButtonText: "OK",
     showConfirmButton: true,


### PR DESCRIPTION
## Problem
Pre-release security testing found several hardening gaps: alert text could execute injected HTML, password reset responses revealed account existence, production CSP allowed inline/eval scripts, and rejected CORS requests exposed stack traces.

## Fix
- Render SweetAlert messages as text instead of HTML.
- Return a generic 202 response for password reset requests.
- Tighten production CSP script/connect directives while keeping dev compatibility.
- Add generic backend error handling for CORS failures and disable Express X-Powered-By.
- Add regression coverage for password reset and CORS behavior.

## Validation
- npm run lint (frontend)
- npm run build (frontend)
- npx vitest run src/test/api/users.test.ts (backend)
- npm run format (backend, frontend)
- Playwright smoke retest for the XSS payload and CORS response