### PR TITLE
[codex] allow next inline scripts

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,7 +1,7 @@
 const isProduction = process.env.NODE_ENV === "production";
 
 const scriptSrc = isProduction
-  ? "script-src 'self'"
+  ? "script-src 'self' 'unsafe-inline'"
   : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
 
 const connectSrc = isProduction


### PR DESCRIPTION
## What changed
- Relaxed the production CSP in `frontend/next.config.mjs` so Next.js inline bootstrap scripts are allowed.

## Why
- A strict `script-src 'self'` blocked Next.js inline runtime scripts in production, which caused the browser CSP error.

## Validation
- Ran the frontend production build successfully.
- Started the app with `NODE_ENV=production` and verified the page loaded in a browser with no console errors.

## Notes
- The local `.env.local` change used for testing was kept out of the PR.
