### PR TITLE
Fix business calendar JST date rendering

### DIFF
--- a/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
+++ b/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
@@ -14,7 +14,13 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { updateScheduleAction } from "@/app/actions/updateContent";
 import { CONTENT_UPDATE_SUCCESS_MESSAGE } from "@/lib/messages/formValidation";
 import { getAllBusinessSchedules } from "@/lib/api/adminsApi";
-import { getDayCellColorHandler } from "@/lib/utils/calendarUtils";
+import {
+  BUSINESS_CALENDAR_TIME_ZONE,
+  formatDateForScheduleUpdate,
+  formatDateKeyInTimeZone,
+  getDayCellColorHandler,
+  getDayNumberInTimeZone,
+} from "@/lib/utils/calendarUtils";
 import CalendarLegend from "@/components/features/calendarLegend/CalendarLegend";
 import { warningAlert } from "@/lib/utils/alertUtils";
 
@@ -75,16 +81,10 @@ const BusinessCalendarClient = ({
   }, []);
 
   // Set color for each date in the calendar
-  const dayCellColors = getDayCellColorHandler(businessSchedule);
-
-  // Convert date to string in the format "MM/DD/YYYY"
-  const dateToString = (date: Date) => {
-    return date.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-  };
+  const dayCellColors = getDayCellColorHandler(
+    businessSchedule,
+    BUSINESS_CALENDAR_TIME_ZONE,
+  );
 
   // Register or delete event on selected date
   const handleDateSelect = (arg: DateSelectArg) => {
@@ -95,8 +95,8 @@ const BusinessCalendarClient = ({
 
     const startDate = new Date(arg.start);
     const endDate = new Date(arg.end.getTime() - 24 * 60 * 60 * 1000);
-    const startDateStr = dateToString(startDate);
-    const endDateStr = dateToString(endDate);
+    const startDateStr = formatDateForScheduleUpdate(startDate);
+    const endDateStr = formatDateForScheduleUpdate(endDate);
 
     // If the start date is the current date or before, do not allow selection
     if (startDate < new Date()) {
@@ -112,15 +112,17 @@ const BusinessCalendarClient = ({
     setIsModalOpen(true);
 
     // Set selected dates for updating the schedule
-    if (startDate.getDate() === endDate.getDate()) {
+    if (
+      formatDateKeyInTimeZone(startDate) === formatDateKeyInTimeZone(endDate)
+    ) {
       setSelectedDates([startDateStr]);
     } else {
       setSelectedDates([startDateStr, endDateStr]);
     }
 
     // Save the selected calendar position to localStorage
-    const currentYear = new Date().getFullYear();
-    const selectedYear = startDate.getFullYear();
+    const currentYear = Number(formatDateKeyInTimeZone(new Date()).slice(0, 4));
+    const selectedYear = Number(formatDateKeyInTimeZone(startDate).slice(0, 4));
 
     if (selectedYear < currentYear) {
       localStorage.setItem("calendarPosition", "prev");
@@ -214,7 +216,7 @@ const BusinessCalendarClient = ({
           timeZone="Asia/Tokyo"
           locale={language === "ja" ? "ja" : "en"}
           dayCellContent={(arg) => {
-            return { html: String(arg.date.getDate()) };
+            return { html: getDayNumberInTimeZone(arg.date) };
           }}
           contentHeight="auto"
           selectable={userSessionType === "admin"}

--- a/frontend/src/lib/utils/calendarUtils.tsx
+++ b/frontend/src/lib/utils/calendarUtils.tsx
@@ -1,8 +1,4 @@
-import {
-  DayCellContentArg,
-  DayCellMountArg,
-  EventContentArg,
-} from "@fullcalendar/core";
+import { DayCellMountArg, EventContentArg } from "@fullcalendar/core";
 import styles from "../../components/features/calendarView/CalendarView.module.scss";
 import Image from "next/image";
 import {
@@ -11,6 +7,42 @@ import {
   XCircleIcon,
 } from "@heroicons/react/24/outline";
 import { formatTime24Hour } from "./dateUtils";
+
+export const BUSINESS_CALENDAR_TIME_ZONE = "Asia/Tokyo";
+
+export const formatDateKeyInTimeZone = (
+  date: Date,
+  timeZone: string = BUSINESS_CALENDAR_TIME_ZONE,
+) => {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone,
+  }).format(date);
+};
+
+export const formatDateForScheduleUpdate = (
+  date: Date,
+  timeZone: string = BUSINESS_CALENDAR_TIME_ZONE,
+) => {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone,
+  }).format(date);
+};
+
+export const getDayNumberInTimeZone = (
+  date: Date,
+  timeZone: string = BUSINESS_CALENDAR_TIME_ZONE,
+) => {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    timeZone,
+  }).format(date);
+};
 
 export const createRenderEventContent = (userType: UserType) => {
   const RenderEventContent = (eventInfo: EventContentArg) => {
@@ -136,6 +168,7 @@ export const getClassSlotTimesForCalendar = () => {
 
 export function getDayCellColorHandler(
   businessSchedule: { date: string; color: string }[],
+  timeZone?: string,
 ): (arg: DayCellMountArg) => void {
   const dateToColorMap = new Map<string, string>(
     businessSchedule.map((item) => [item.date, item.color]),
@@ -144,12 +177,13 @@ export function getDayCellColorHandler(
   return (arg: DayCellMountArg) => {
     if (arg.isOther) return;
 
-    // Get offset in minutes from UTC
-    const offset = new Date().getTimezoneOffset();
-
-    // Adjust the date to the local timezone by subtracting the offset
-    const localDate = new Date(arg.date.getTime() - offset * 60 * 1000);
-    const dateStr = localDate.toISOString().split("T")[0];
+    const dateStr = timeZone
+      ? formatDateKeyInTimeZone(arg.date, timeZone)
+      : new Intl.DateTimeFormat("en-CA", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        }).format(arg.date);
     const color = dateToColorMap.get(dateStr);
 
     if (color) {


### PR DESCRIPTION
## Summary
- format AaasoBo! business calendar day numbers in Asia/Tokyo instead of browser-local time
- use JST date keys for business calendar schedule colors and selected date ranges
- add shared timezone-aware date helpers for calendar rendering

## Root Cause
FullCalendar was configured with timeZone="Asia/Tokyo", but business calendar rendering used local Date getters like getDate(). In timezones outside Japan, a JST midnight cell can still be the previous local date, shifting the displayed day number and schedule color lookup.

## Validation
- npm run lint
- npm run build
- manual Intl check that 2026-05-24T15:00:00Z formats as 2026-05-25 / day 25 in Asia/Tokyo

Fixes #566