### PR TITLE
Fix proxy handling for bodyless requests

### DIFF
--- a/frontend/src/app/api/proxy/route.ts
+++ b/frontend/src/app/api/proxy/route.ts
@@ -69,7 +69,7 @@ const proxyRequest = async (req: NextRequest, method: string) => {
 
   const contentType = req.headers.get("content-type") || "";
   const isJson = contentType.includes("application/json");
-  const hasBody = method !== "GET" && method !== "DELETE";
+  const hasBody = method !== "GET" && method !== "DELETE" && req.body !== null;
 
   let body: BodyInit | undefined;
   if (hasBody) {


### PR DESCRIPTION
## Summary
- Update the frontend API proxy to only parse and forward a request body when the incoming request actually has one.
- Prevent bodyless JSON `PATCH` requests from failing in the proxy before they reach the backend.

## Root Cause
The customer welcome modal calls `PATCH /customers/:id/seen-welcome` through `/api/proxy` with `Content-Type: application/json` and no body. The proxy treated every non-GET/DELETE request as having a body and called `await req.json()`, which throws on an empty request stream. That produced the 500 seen when opening a customer dashboard from the admin dashboard.

## Impact
Admins and customers can dismiss the welcome modal without the proxy returning a 500 for this bodyless update request. Other bodyless non-GET proxy requests avoid the same failure mode.

## Validation
- `cd frontend && npx prettier --write src/app/api/proxy/route.ts`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`