### PR TITLE
Add beta import package generation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "prisma migrate deploy",
     "db:bootstrap": "ts-node ./src/seed/bootstrap.ts",
     "seed:dummy": "ts-node ./src/seed/dummy.ts",
+    "beta:generate-import": "ts-node ./src/seed/generateBetaImportFromRawSchedule.ts",
     "prisma:init": "prisma generate && npx prisma migrate reset && npm run db:bootstrap",
     "fixture:generate:normalized-import": "ts-node ./src/seed/generateNormalizedImportFixture.ts",
     "test": "prisma generate && vitest run src/test/api",

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -69,6 +69,16 @@ import {
 import { getInstructorAbsencesByMonth } from "../services/instructorAbsenceService";
 import { getSchedulesByEventNameAndDate } from "../services/scheduleService";
 
+function getJstRecurringParts(date: Date): { weekday: number; time: string } {
+  const jstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  const hour = String(jstDate.getUTCHours()).padStart(2, "0");
+  const minute = String(jstDate.getUTCMinutes()).padStart(2, "0");
+  return {
+    weekday: jstDate.getUTCDay(),
+    time: `${hour}:${minute}`,
+  };
+}
+
 // GET all classes along with related instructors and customers data
 export const getAllClassesController = async (_: Request, res: Response) => {
   try {
@@ -636,19 +646,12 @@ export const createClassesForMonthController = async (
               return;
             }
 
-            // Extract time from startAt
-            const time = `${startAt
-              .getHours()
-              .toString()
-              .padStart(2, "0")}:${startAt
-              .getMinutes()
-              .toString()
-              .padStart(2, "0")}`;
+            const { weekday, time } = getJstRecurringParts(startAt);
 
             // Get the first date of the class of the month
             const firstDate = calculateFirstDate(
               firstDateOfMonth < startAt ? startAt : firstDateOfMonth,
-              days[startAt.getDay()],
+              days[weekday],
               time,
             );
 

--- a/backend/src/seed/generateBetaImportFromRawSchedule.ts
+++ b/backend/src/seed/generateBetaImportFromRawSchedule.ts
@@ -1,0 +1,460 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  buildNormalizedPackageZip,
+  normalizeRawScheduleCsvToPackage,
+  parseCsv,
+  validateNormalizedImportFiles,
+  type NormalizedFileName,
+} from "../services/adminImport";
+
+const SOURCE_FILE = "20250818_(Main) AaasoBo!schedule.xlsx - Data base.csv";
+const FEE_SOURCE_WORKBOOK = "20240817_(Main) AaasoBo!schedule.xlsx";
+const OUTPUT_DIR = "beta-release-import";
+const NORMALIZED_DIR = path.join(OUTPUT_DIR, "normalized");
+const RAW_OUTPUT_FILE = "raw-beta-customers-20250818.csv";
+const ZIP_OUTPUT_FILE = "normalized-beta-import-20250818.zip";
+
+const SELECTED_CUSTOMERS = ["河野麻未", "高坂博章"];
+const SELECTED_INSTRUCTORS = ["Keziah", "Elian", "Zee", "Kang", "Rhoselle"];
+const DEFAULT_RECURRING_TIMEZONE_OFFSET = "+09:00";
+
+type CsvObjectRow = Record<string, string>;
+type InstructorFeeTemplate = {
+  trial_fee: string;
+  regular_fee: string;
+  cancel_fee: string;
+  cancel_without_notice_fee: string;
+  monthly_cancel_fee: string;
+};
+
+function csvEscape(value: string | undefined): string {
+  const normalized = value ?? "";
+  if (
+    normalized.includes(",") ||
+    normalized.includes('"') ||
+    normalized.includes("\n") ||
+    normalized.includes("\r")
+  ) {
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+  return normalized;
+}
+
+function toCsv(rows: string[][]): string {
+  return `${rows.map((row) => row.map(csvEscape).join(",")).join("\n")}\n`;
+}
+
+function parseCliOption(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inlineValue = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inlineValue) {
+    return inlineValue.slice(prefix.length).trim();
+  }
+
+  const optionIndex = process.argv.indexOf(`--${name}`);
+  if (optionIndex >= 0) {
+    return process.argv[optionIndex + 1]?.trim();
+  }
+
+  return undefined;
+}
+
+function requireIsoDate(value: string, optionName: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${optionName} must use YYYY-MM-DD format.`);
+  }
+}
+
+function normalizeRecurringStartAt(): string {
+  const startAt =
+    parseCliOption("start-at") ?? process.env.BETA_IMPORT_START_AT?.trim();
+  if (startAt) {
+    if (
+      !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+        startAt,
+      )
+    ) {
+      throw new Error(
+        "--start-at must use ISO datetime format with timezone, for example 2026-06-01T00:00:00+09:00.",
+      );
+    }
+    return startAt;
+  }
+
+  const startDate =
+    parseCliOption("start-date") ?? process.env.BETA_IMPORT_START_DATE?.trim();
+  if (!startDate) {
+    throw new Error(
+      "Missing beta import start date. Provide --start-date=YYYY-MM-DD, --start-at=YYYY-MM-DDTHH:mm:ss+09:00, BETA_IMPORT_START_DATE, or BETA_IMPORT_START_AT.",
+    );
+  }
+
+  requireIsoDate(startDate, "--start-date");
+  return `${startDate}T00:00:00${DEFAULT_RECURRING_TIMEZONE_OFFSET}`;
+}
+
+function rowsFromCsv(csv: string): {
+  header: string[];
+  rows: CsvObjectRow[];
+} {
+  const parsed = parseCsv(csv);
+  const header = parsed[0] ?? [];
+  const rows = parsed
+    .slice(1)
+    .filter((row) => row.some((cell) => cell.trim().length > 0))
+    .map((row) =>
+      Object.fromEntries(
+        header.map((column, index) => [column, row[index] ?? ""]),
+      ),
+    );
+  return { header, rows };
+}
+
+function csvFromRows(header: string[], rows: CsvObjectRow[]): string {
+  return toCsv([
+    header,
+    ...rows.map((row) => header.map((column) => row[column] ?? "")),
+  ]);
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function readXlsxEntry(workbookPath: string, entryPath: string): string {
+  return execFileSync("unzip", ["-p", workbookPath, entryPath], {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function sharedStringsFromWorkbook(workbookPath: string): string[] {
+  const xml = readXlsxEntry(workbookPath, "xl/sharedStrings.xml");
+  return [...xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/g)].map((match) =>
+    [...match[1].matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)]
+      .map((textMatch) => decodeXml(textMatch[1]))
+      .join(""),
+  );
+}
+
+function columnIndex(column: string): number {
+  return column
+    .split("")
+    .reduce((acc, char) => acc * 26 + char.charCodeAt(0) - 64, 0);
+}
+
+function parseWorksheetRows(
+  workbookPath: string,
+  worksheetPath: string,
+): Record<string, string>[] {
+  const sharedStrings = sharedStringsFromWorkbook(workbookPath);
+  const xml = readXlsxEntry(workbookPath, worksheetPath);
+  const rows: Record<string, string>[] = [];
+
+  for (const rowMatch of xml.matchAll(
+    /<row\b[^>]*r="(\d+)"[^>]*>([\s\S]*?)<\/row>/g,
+  )) {
+    const row: Record<string, string> = {};
+    for (const cellMatch of rowMatch[2].matchAll(
+      /<c\b([^>]*?)(?:\/>|>([\s\S]*?)<\/c>)/g,
+    )) {
+      const ref = cellMatch[1].match(/\br="([A-Z]+)\d+"/)?.[1];
+      if (!ref) {
+        continue;
+      }
+      const rawValue = cellMatch[2]?.match(/<v>([\s\S]*?)<\/v>/)?.[1] ?? "";
+      const type = cellMatch[1].match(/\bt="([^"]+)"/)?.[1];
+      const value =
+        type === "s" && rawValue
+          ? sharedStrings[Number(rawValue)] ?? ""
+          : decodeXml(rawValue);
+      row[ref] = value;
+    }
+    rows[Number(rowMatch[1]) - 1] = row;
+  }
+
+  return rows;
+}
+
+function normalizeMoney(value: string | undefined): string {
+  const amount = Math.abs(Number(value ?? "0"));
+  return Number.isFinite(amount) ? String(Math.trunc(amount)) : "0";
+}
+
+function dateOnlyFromDateTime(value: string): string {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) {
+    throw new Error(`Invalid ISO datetime: ${value}`);
+  }
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
+
+export function extractInstructorFeesFromWorkbook(
+  workbookPath: string,
+): Map<string, InstructorFeeTemplate> {
+  const rows = parseWorksheetRows(workbookPath, "xl/worksheets/sheet3.xml");
+  const headerRow = rows.find((row) => row.U === "Instrucotr");
+  if (!headerRow) {
+    throw new Error("Instructor fee header row was not found in スケ作成");
+  }
+
+  const fees = new Map<string, InstructorFeeTemplate>();
+  for (const row of rows) {
+    const instructorName = row.U?.trim();
+    if (!instructorName || instructorName === "Instrucotr") {
+      continue;
+    }
+    fees.set(instructorName, {
+      trial_fee: normalizeMoney(row.V),
+      regular_fee: normalizeMoney(row.W),
+      cancel_fee: normalizeMoney(row.X),
+      cancel_without_notice_fee: normalizeMoney(row.Y),
+      monthly_cancel_fee: "200",
+    });
+  }
+  return fees;
+}
+
+function filterNormalizedFiles(
+  files: Record<string, string>,
+  instructorFeesByName: Map<string, InstructorFeeTemplate>,
+  recurringStartAt: string,
+): Record<NormalizedFileName, string> {
+  const selectedCustomers = new Set(SELECTED_CUSTOMERS);
+  const selectedInstructors = new Set(SELECTED_INSTRUCTORS);
+  const parsed = Object.fromEntries(
+    Object.entries(files).map(([fileName, csv]) => [
+      fileName,
+      rowsFromCsv(csv),
+    ]),
+  );
+
+  const customers = parsed["customers.csv"].rows.filter((row) =>
+    selectedCustomers.has(row.name),
+  );
+  const customerRefs = new Set(customers.map((row) => row.customer_ref));
+  const children = parsed["children.csv"].rows.filter((row) =>
+    customerRefs.has(row.customer_ref),
+  );
+  const childRefs = new Set(children.map((row) => row.child_ref));
+  const subscriptions = parsed["subscriptions.csv"].rows.filter((row) =>
+    customerRefs.has(row.customer_ref),
+  );
+  const subscriptionRefs = new Set(
+    subscriptions.map((row) => row.subscription_ref),
+  );
+  const planRefs = new Set(subscriptions.map((row) => row.plan_ref));
+  const instructors = parsed["instructors.csv"].rows.filter((row) =>
+    selectedInstructors.has(row.name),
+  );
+  const instructorRefs = new Set(instructors.map((row) => row.instructor_ref));
+  const instructorNameByRef = new Map(
+    instructors.map((row) => [row.instructor_ref, row.name]),
+  );
+  const instructorFees = parsed["instructor_fees.csv"].rows
+    .filter((row) => instructorRefs.has(row.instructor_ref))
+    .map((row) => {
+      const instructorName = instructorNameByRef.get(row.instructor_ref);
+      const fee = instructorName
+        ? instructorFeesByName.get(instructorName)
+        : undefined;
+      return fee
+        ? {
+            ...row,
+            effective_from: dateOnlyFromDateTime(recurringStartAt),
+            effective_to: "",
+            trial_fee: fee.trial_fee,
+            regular_fee: fee.regular_fee,
+            cancel_fee: fee.cancel_fee,
+            cancel_without_notice_fee: fee.cancel_without_notice_fee,
+            monthly_cancel_fee: fee.monthly_cancel_fee,
+          }
+        : row;
+    });
+  const recurringClasses = parsed["recurring_classes.csv"].rows.filter(
+    (row) =>
+      subscriptionRefs.has(row.subscription_ref) &&
+      instructorRefs.has(row.instructor_ref),
+  );
+  const recurringClassRefs = new Set(
+    recurringClasses.map((row) => row.recurring_class_ref),
+  );
+
+  return {
+    "plans.csv": csvFromRows(
+      parsed["plans.csv"].header,
+      parsed["plans.csv"].rows.filter((row) => planRefs.has(row.plan_ref)),
+    ),
+    "customers.csv": csvFromRows(parsed["customers.csv"].header, customers),
+    "children.csv": csvFromRows(parsed["children.csv"].header, children),
+    "subscriptions.csv": csvFromRows(
+      parsed["subscriptions.csv"].header,
+      subscriptions,
+    ),
+    "instructors.csv": csvFromRows(
+      parsed["instructors.csv"].header,
+      instructors,
+    ),
+    "instructor_fees.csv": csvFromRows(
+      parsed["instructor_fees.csv"].header,
+      instructorFees,
+    ),
+    "instructor_schedules.csv": csvFromRows(
+      parsed["instructor_schedules.csv"].header,
+      parsed["instructor_schedules.csv"].rows.filter((row) =>
+        instructorRefs.has(row.instructor_ref),
+      ),
+    ),
+    "instructor_absences.csv": csvFromRows(
+      parsed["instructor_absences.csv"].header,
+      [],
+    ),
+    "events.csv": csvFromRows(
+      parsed["events.csv"].header,
+      parsed["events.csv"].rows,
+    ),
+    "schedules.csv": csvFromRows(parsed["schedules.csv"].header, []),
+    "system_status.csv": csvFromRows(
+      parsed["system_status.csv"].header,
+      parsed["system_status.csv"].rows,
+    ),
+    "recurring_classes.csv": csvFromRows(
+      parsed["recurring_classes.csv"].header,
+      recurringClasses,
+    ),
+    "recurring_class_attendance.csv": csvFromRows(
+      parsed["recurring_class_attendance.csv"].header,
+      parsed["recurring_class_attendance.csv"].rows.filter(
+        (row) =>
+          recurringClassRefs.has(row.recurring_class_ref) &&
+          childRefs.has(row.child_ref),
+      ),
+    ),
+    "classes.csv": csvFromRows(parsed["classes.csv"].header, []),
+    "class_attendance.csv": csvFromRows(
+      parsed["class_attendance.csv"].header,
+      [],
+    ),
+  };
+}
+
+function isRawHeaderRow(row: string[]): boolean {
+  const normalized = row.map((cell) => cell.trim().toLowerCase());
+  return (
+    normalized.includes("name") &&
+    normalized.includes("child name") &&
+    normalized.includes("plan")
+  );
+}
+
+function buildFilteredRawCsv(rawCsv: string): string {
+  const selectedCustomers = new Set(SELECTED_CUSTOMERS);
+  const rows = parseCsv(rawCsv);
+  const headerIndex = rows.findIndex(isRawHeaderRow);
+  if (headerIndex < 0) {
+    throw new Error("Header row for raw schedule CSV not found");
+  }
+
+  const filteredRows = rows.slice(0, headerIndex + 1);
+  let currentCustomerName = "";
+  for (const row of rows.slice(headerIndex + 1)) {
+    const customerName = (row[4] ?? "").trim();
+    if (customerName) {
+      currentCustomerName = customerName;
+    }
+    if (
+      selectedCustomers.has(currentCustomerName) &&
+      row.some((cell) => cell.trim().length > 0)
+    ) {
+      filteredRows.push(row);
+    }
+  }
+
+  return toCsv(filteredRows);
+}
+
+async function main() {
+  const repoRoot = path.resolve(__dirname, "../../..");
+  const sourcePath = path.join(repoRoot, SOURCE_FILE);
+  const outputDir = path.join(repoRoot, OUTPUT_DIR);
+  const normalizedDir = path.join(repoRoot, NORMALIZED_DIR);
+  const recurringStartAt = normalizeRecurringStartAt();
+
+  const rawCsv = fs.readFileSync(sourcePath, "utf8");
+  const instructorFeesByName = extractInstructorFeesFromWorkbook(
+    path.join(repoRoot, FEE_SOURCE_WORKBOOK),
+  );
+  const normalized = normalizeRawScheduleCsvToPackage(rawCsv, {
+    recurringClasses: {
+      startAt: recurringStartAt,
+      customerNames: SELECTED_CUSTOMERS,
+      instructorNames: SELECTED_INSTRUCTORS,
+      classTypes: ["R"],
+    },
+  });
+
+  const files = filterNormalizedFiles(
+    normalized.files,
+    instructorFeesByName,
+    recurringStartAt,
+  );
+  const validation = validateNormalizedImportFiles(files);
+  if (!validation.isValid) {
+    throw new Error(
+      `Generated normalized files are invalid: ${JSON.stringify(
+        validation.issues,
+        null,
+        2,
+      )}`,
+    );
+  }
+
+  fs.mkdirSync(normalizedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outputDir, RAW_OUTPUT_FILE),
+    buildFilteredRawCsv(rawCsv),
+    "utf8",
+  );
+
+  for (const [fileName, csv] of Object.entries(files)) {
+    fs.writeFileSync(path.join(normalizedDir, fileName), csv, "utf8");
+  }
+
+  const zipBuffer = await buildNormalizedPackageZip(files);
+  fs.writeFileSync(path.join(outputDir, ZIP_OUTPUT_FILE), zipBuffer);
+
+  const summary = {
+    source: SOURCE_FILE,
+    feeSource: FEE_SOURCE_WORKBOOK,
+    selectedCustomers: SELECTED_CUSTOMERS,
+    selectedInstructors: SELECTED_INSTRUCTORS,
+    recurringStartAt,
+    outputs: {
+      rawCsv: path.join(OUTPUT_DIR, RAW_OUTPUT_FILE),
+      normalizedDirectory: NORMALIZED_DIR,
+      normalizedZip: path.join(OUTPUT_DIR, ZIP_OUTPUT_FILE),
+    },
+    rowsByFile: validation.report.rowsByFile,
+  };
+
+  fs.writeFileSync(
+    path.join(outputDir, "summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+    "utf8",
+  );
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/backend/src/seed/generateNormalizedImportFixture.ts
+++ b/backend/src/seed/generateNormalizedImportFixture.ts
@@ -100,6 +100,7 @@ type InstructorFeeDef = {
   regular_fee: string;
   cancel_fee: string;
   cancel_without_notice_fee: string;
+  monthly_cancel_fee: string;
 };
 
 type InstructorScheduleDef = {
@@ -484,6 +485,7 @@ function instructorFeeRows(from: string): InstructorFeeDef[] {
       regular_fee: "100",
       cancel_fee: "50",
       cancel_without_notice_fee: "100",
+      monthly_cancel_fee: "200",
     });
   }
   return rows;

--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -72,7 +72,8 @@ type RowByFile = {
     | "trial_fee"
     | "regular_fee"
     | "cancel_fee"
-    | "cancel_without_notice_fee",
+    | "cancel_without_notice_fee"
+    | "monthly_cancel_fee",
     string
   >;
   "instructor_schedules.csv": Record<
@@ -189,7 +190,6 @@ const IMPORT_RESET_TABLES = [
   "SystemStatus",
   "PasswordResetToken",
   "VerificationToken",
-  "Admin",
 ] as const;
 const IMPORT_RESET_TRUNCATE_SQL = `TRUNCATE TABLE ${IMPORT_RESET_TABLES.map((table) => `"${table}"`).join(", ")} RESTART IDENTITY CASCADE`;
 
@@ -934,6 +934,7 @@ export function validateNormalizedImportFiles(
       ["regular_fee", row.data.regular_fee],
       ["cancel_fee", row.data.cancel_fee],
       ["cancel_without_notice_fee", row.data.cancel_without_notice_fee],
+      ["monthly_cancel_fee", row.data.monthly_cancel_fee],
     ] as const) {
       if (value && !/^\d+$/.test(value)) {
         addIssue(
@@ -1690,8 +1691,6 @@ export function validateNormalizedImportFiles(
   };
 }
 
-const DEFAULT_SEED_ADMIN_EMAILS = ["admin@example.com", "admin2@example.com"];
-
 function parseOptionalDate(value: string): Date | null {
   if (!value) {
     return null;
@@ -1710,40 +1709,8 @@ function parseTimeAsDate(value: string): Date {
   return new Date(`1970-01-01T${value}:00.000Z`);
 }
 
-function parseSeedAdminEmails(): string[] {
-  const configured =
-    process.env.IMPORT_SEED_ADMIN_EMAILS ?? process.env.SEED_ADMIN_EMAILS;
-  const source = configured
-    ? configured
-        .split(",")
-        .map((email) => email.trim().toLowerCase())
-        .filter((email) => email.length > 0)
-    : DEFAULT_SEED_ADMIN_EMAILS;
-  return Array.from(new Set(source));
-}
-
 async function resetImportTargetData(tx: TxClient) {
-  const seedAdminEmails = parseSeedAdminEmails();
-  const seedAdmins = await tx.admin.findMany({
-    where: {
-      email: {
-        in: seedAdminEmails,
-      },
-    },
-    select: {
-      name: true,
-      email: true,
-      password: true,
-    },
-  });
-
   await tx.$executeRawUnsafe(IMPORT_RESET_TRUNCATE_SQL);
-
-  if (seedAdmins.length > 0) {
-    await tx.admin.createMany({
-      data: seedAdmins,
-    });
-  }
 }
 
 async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
@@ -1869,6 +1836,7 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
         regularFee: Number(row.data.regular_fee),
         cancelFee: Number(row.data.cancel_fee),
         cancelWithoutNoticeFee: Number(row.data.cancel_without_notice_fee),
+        monthlyCancelFee: Number(row.data.monthly_cancel_fee || "0"),
       })),
     });
   }

--- a/backend/src/services/adminImport/index.ts
+++ b/backend/src/services/adminImport/index.ts
@@ -1,7 +1,9 @@
 export {
   buildNormalizedPackageZip,
   normalizeRawScheduleCsvToPackage,
+  parseCsv,
 } from "./normalize";
+export type { NormalizedFileName } from "./normalize";
 
 export {
   executeNormalizedImportFiles,

--- a/backend/src/services/adminImport/normalize.ts
+++ b/backend/src/services/adminImport/normalize.ts
@@ -41,6 +41,18 @@ interface NormalizeRawScheduleResult {
   report: NormalizationReport;
 }
 
+interface RecurringClassNormalizationOptions {
+  startAt: string;
+  endAt?: string;
+  customerNames?: string[];
+  instructorNames?: string[];
+  classTypes?: string[];
+}
+
+interface NormalizeRawScheduleOptions {
+  recurringClasses?: RecurringClassNormalizationOptions;
+}
+
 interface RawClassRow {
   sourceRow: number;
   prefecture: string;
@@ -50,7 +62,10 @@ interface RawClassRow {
   instructorName: string;
   weekday: number | null;
   startTime: string | null;
+  classType: string;
   childBirthdate: string | null;
+  siblingBirthdate: string | null;
+  detailUrl: string;
   personalInfo: string;
   email: string;
 }
@@ -130,6 +145,20 @@ interface InstructorFeeRow {
   regular_fee: string;
   cancel_fee: string;
   cancel_without_notice_fee: string;
+  monthly_cancel_fee: string;
+}
+
+interface RecurringClassRow {
+  recurring_class_ref: string;
+  subscription_ref: string;
+  instructor_ref: string;
+  start_at: string;
+  end_at: string;
+}
+
+interface RecurringClassAttendanceRow {
+  recurring_class_ref: string;
+  child_ref: string;
 }
 
 const RAW_COLUMN = {
@@ -140,7 +169,10 @@ const RAW_COLUMN = {
   instructorName: 7,
   weekday: 8,
   timeRange: 9,
+  classType: 10,
   childBirthdate: 11,
+  siblingBirthdate: 12,
+  detailUrl: 14,
   personalInfo: 16,
   email: 17,
 } as const;
@@ -207,6 +239,7 @@ export const NORMALIZED_HEADERS = {
     "regular_fee",
     "cancel_fee",
     "cancel_without_notice_fee",
+    "monthly_cancel_fee",
   ],
   "instructor_schedules.csv": [
     "instructor_ref",
@@ -246,6 +279,60 @@ export const NORMALIZED_HEADERS = {
 export const MANDATORY_NORMALIZED_FILES = Object.keys(
   NORMALIZED_HEADERS,
 ) as NormalizedFileName[];
+
+const DEFAULT_BUSINESS_EVENTS = [
+  {
+    event_ref: "EV0001",
+    name: "通常授業日 / Regular Class Day",
+    color: "#FFFFFF",
+  },
+  {
+    event_ref: "EV0002",
+    name: "お休み / No Class",
+    color: "#FAD7CD",
+  },
+  {
+    event_ref: "EV0003",
+    name: "お休み振替対象日 / No Class (Rebookable)",
+    color: "#FF0000",
+  },
+  {
+    event_ref: "EV0004",
+    name: "テーマクラスウィーク / Theme Class Week",
+    color: "#FFFF00",
+  },
+];
+
+const DEFAULT_PLAN_DEFINITIONS = [
+  {
+    price: "3180",
+    name: "月3,180円プラン / 3,180 yen/month Plan",
+    description: "2 classes per week",
+    weekly_class_times: "2",
+    english_background: "0",
+  },
+  {
+    price: "7980",
+    name: "月7,980円プラン / 7,980 yen/month Plan",
+    description: "5 classes per week",
+    weekly_class_times: "5",
+    english_background: "0",
+  },
+  {
+    price: "5980",
+    name: "月5,980円プラン / 5,980 yen/month Plan",
+    description: "1 classes per week",
+    weekly_class_times: "1",
+    english_background: "1",
+  },
+  {
+    price: "10800",
+    name: "月10,800円プラン / 10,800 yen/month Plan",
+    description: "2 classes per week",
+    weekly_class_times: "2",
+    english_background: "2",
+  },
+] as const;
 
 class RefSequence {
   private value = 1;
@@ -422,6 +509,74 @@ function parseWeeklyClassTimes(planName: string): number {
   return 1;
 }
 
+function normalizePlanPrice(planName: string): string {
+  return planName.replace(/[^\d]/g, "");
+}
+
+function buildPlanFromRaw(planRef: string, planName: string): PlanRow {
+  const defaultPlan = DEFAULT_PLAN_DEFINITIONS.find((plan) =>
+    normalizePlanPrice(planName).includes(plan.price),
+  );
+  if (defaultPlan) {
+    return {
+      plan_ref: planRef,
+      name: defaultPlan.name,
+      description: defaultPlan.description,
+      weekly_class_times: defaultPlan.weekly_class_times,
+      english_background: defaultPlan.english_background,
+      termination_at: "",
+    };
+  }
+
+  const weeklyClassTimes = parseWeeklyClassTimes(planName);
+  return {
+    plan_ref: planRef,
+    name: planName,
+    description: `${weeklyClassTimes} classes per week`,
+    weekly_class_times: String(weeklyClassTimes),
+    english_background: "0",
+    termination_at: "",
+  };
+}
+
+function splitChildNames(childName: string): string[] {
+  const parenthetical = childName.match(/^(.+?)\s*[（(]([^）)]+)[）)]$/);
+  if (parenthetical) {
+    return [parenthetical[1], ...parenthetical[2].split(/[,&、，]/)]
+      .map((name) => name.trim())
+      .filter(Boolean);
+  }
+
+  return childName
+    .split(/[&、，]/)
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+function findBirthdateInText(name: string, text: string): string | null {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = text.match(new RegExp(`${escapedName}\\s*(\\d{1,2}/\\d{1,2})`));
+  return parseBirthdate(match?.[1] ?? "");
+}
+
+function childNamesAndBirthdates(row: RawClassRow): {
+  name: string;
+  birthdate: string;
+}[] {
+  const names = splitChildNames(
+    row.childName || `Imported Child ${row.sourceRow}`,
+  );
+  const birthdates = [row.childBirthdate, row.siblingBirthdate].filter(
+    (birthdate): birthdate is string => !!birthdate,
+  );
+
+  return names.map((name, index) => ({
+    name,
+    birthdate:
+      findBirthdateInText(name, row.personalInfo) ?? birthdates[index] ?? "",
+  }));
+}
+
 function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -434,7 +589,73 @@ function generateTempPassword(): string {
   return randomBytes(6).toString("base64url");
 }
 
-function toRecordSet(rows: RawClassRow[]): {
+function buildFallbackSelectType(customerRef: string, planRef: string): string {
+  return `https://example.com/subscriptions/${customerRef.toLowerCase()}-${planRef.toLowerCase()}`;
+}
+
+function buildOptionSet(values: string[] | undefined): Set<string> | null {
+  if (!values || values.length === 0) {
+    return null;
+  }
+  return new Set(values.map((value) => value.trim()).filter(Boolean));
+}
+
+function dateOnlyFromDateTime(value: string): string {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) {
+    throw new Error(
+      "recurringClasses.startAt must start with an ISO date, for example 2026-06-01T00:00:00+09:00",
+    );
+  }
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
+
+function timezoneSuffixFromDateTime(value: string): string {
+  const match = value.match(/(Z|[+-]\d{2}:\d{2})$/);
+  return match?.[1] ?? "+09:00";
+}
+
+function nextDateOnOrAfter(dateOnly: string, weekday: number): string {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  const dayOffset = (weekday - date.getUTCDay() + 7) % 7;
+  date.setUTCDate(date.getUTCDate() + dayOffset);
+  return date.toISOString().slice(0, 10);
+}
+
+function buildRecurringStartAt(
+  startAt: string,
+  weekday: number,
+  startTime: string,
+): string {
+  const firstDate = nextDateOnOrAfter(dateOnlyFromDateTime(startAt), weekday);
+  const timezoneSuffix = timezoneSuffixFromDateTime(startAt);
+  return `${firstDate}T${startTime}:00${timezoneSuffix}`;
+}
+
+function shouldGenerateRecurringClass(
+  row: RawClassRow,
+  options: RecurringClassNormalizationOptions,
+): boolean {
+  const customerNames = buildOptionSet(options.customerNames);
+  const instructorNames = buildOptionSet(options.instructorNames);
+  const classTypes = buildOptionSet(options.classTypes ?? ["R"]);
+
+  if (customerNames && !customerNames.has(row.customerName)) {
+    return false;
+  }
+  if (instructorNames && !instructorNames.has(row.instructorName)) {
+    return false;
+  }
+  if (classTypes && !classTypes.has(row.classType)) {
+    return false;
+  }
+  return true;
+}
+
+function toRecordSet(
+  rows: RawClassRow[],
+  options: NormalizeRawScheduleOptions = {},
+): {
   plans: PlanRow[];
   customers: CustomerRow[];
   children: ChildRow[];
@@ -442,6 +663,8 @@ function toRecordSet(rows: RawClassRow[]): {
   instructors: InstructorRow[];
   instructorFees: InstructorFeeRow[];
   instructorSchedules: InstructorScheduleRow[];
+  recurringClasses: RecurringClassRow[];
+  recurringClassAttendance: RecurringClassAttendanceRow[];
   generatedCustomerEmails: GeneratedEmailReportItem[];
   warnings: string[];
 } {
@@ -450,6 +673,7 @@ function toRecordSet(rows: RawClassRow[]): {
   const childSeq = new RefSequence("CH");
   const subscriptionSeq = new RefSequence("SU");
   const instructorSeq = new RefSequence("IN");
+  const recurringClassSeq = new RefSequence("RC");
 
   const plans: PlanRow[] = [];
   const customers: CustomerRow[] = [];
@@ -458,6 +682,8 @@ function toRecordSet(rows: RawClassRow[]): {
   const instructors: InstructorRow[] = [];
   const instructorFees: InstructorFeeRow[] = [];
   const instructorSchedules: InstructorScheduleRow[] = [];
+  const recurringClasses: RecurringClassRow[] = [];
+  const recurringClassAttendance: RecurringClassAttendanceRow[] = [];
   const generatedCustomerEmails: GeneratedEmailReportItem[] = [];
   const warnings: string[] = [];
 
@@ -467,19 +693,15 @@ function toRecordSet(rows: RawClassRow[]): {
   const subscriptionsByIdentity = new Map<string, SubscriptionRow>();
   const instructorsByName = new Map<string, InstructorRow>();
   const instructorSchedulesByIdentity = new Set<string>();
+  const recurringClassesByIdentity = new Set<string>();
 
   for (const row of rows) {
-    const planName = row.planName || "Imported Plan";
+    const rawPlanName = row.planName || "Imported Plan";
+    const planDraft = buildPlanFromRaw("PL0000", rawPlanName);
+    const planName = planDraft.name;
     let plan = plansByName.get(planName);
     if (!plan) {
-      plan = {
-        plan_ref: planSeq.next(),
-        name: planName,
-        description: `Imported from raw plan label: ${planName}`,
-        weekly_class_times: String(parseWeeklyClassTimes(planName)),
-        english_background: "0",
-        termination_at: "",
-      };
+      plan = { ...planDraft, plan_ref: planSeq.next() };
       plansByName.set(planName, plan);
       plans.push(plan);
     }
@@ -514,32 +736,45 @@ function toRecordSet(rows: RawClassRow[]): {
       customers.push(customer);
     }
 
-    const childName = row.childName || `Imported Child ${row.sourceRow}`;
-    const childIdentity = `${customer.customer_ref}:${childName}`;
-    if (!childrenByIdentity.has(childIdentity)) {
-      const child: ChildRow = {
-        child_ref: childSeq.next(),
-        customer_ref: customer.customer_ref,
-        name: childName,
-        birthdate: row.childBirthdate ?? "",
-        personal_info: row.personalInfo,
-      };
-      childrenByIdentity.set(childIdentity, child);
-      children.push(child);
-    }
+    const rowChildren = childNamesAndBirthdates(row).map((child) => {
+      const childIdentity = `${customer.customer_ref}:${child.name}`;
+      let childRow = childrenByIdentity.get(childIdentity);
+      if (!childRow) {
+        childRow = {
+          child_ref: childSeq.next(),
+          customer_ref: customer.customer_ref,
+          name: child.name,
+          birthdate: child.birthdate,
+          personal_info: row.personalInfo,
+        };
+        childrenByIdentity.set(childIdentity, childRow);
+        children.push(childRow);
+      }
+      return childRow;
+    });
 
     const subscriptionIdentity = `${customer.customer_ref}:${plan.plan_ref}`;
-    if (!subscriptionsByIdentity.has(subscriptionIdentity)) {
-      const subscription: SubscriptionRow = {
+    let subscription = subscriptionsByIdentity.get(subscriptionIdentity);
+    const fallbackSelectType = buildFallbackSelectType(
+      customer.customer_ref,
+      plan.plan_ref,
+    );
+    if (!subscription) {
+      subscription = {
         subscription_ref: subscriptionSeq.next(),
         customer_ref: customer.customer_ref,
         plan_ref: plan.plan_ref,
-        select_type: `https://example.com/subscriptions/${customer.customer_ref.toLowerCase()}-${plan.plan_ref.toLowerCase()}`,
+        select_type: row.detailUrl || fallbackSelectType,
         start_at: "2020-01-01T00:00:00+09:00",
         end_at: "",
       };
       subscriptionsByIdentity.set(subscriptionIdentity, subscription);
       subscriptions.push(subscription);
+    } else if (
+      row.detailUrl &&
+      subscription.select_type === fallbackSelectType
+    ) {
+      subscription.select_type = row.detailUrl;
     }
 
     if (row.instructorName) {
@@ -554,7 +789,7 @@ function toRecordSet(rows: RawClassRow[]): {
           temp_password: generateTempPassword(),
           class_url: `https://import.local/class/${instructorRef.toLowerCase()}`,
           icon: `https://import.local/icon/${instructorRef.toLowerCase()}.png`,
-          nickname: `import_${instructorRef.toLowerCase()}`,
+          nickname: row.instructorName,
           meeting_id: `9000${serial}`,
           passcode: generateTempPassword().slice(0, 8),
           birthdate: "1990-01-01",
@@ -578,6 +813,7 @@ function toRecordSet(rows: RawClassRow[]): {
           regular_fee: "100",
           cancel_fee: "50",
           cancel_without_notice_fee: "100",
+          monthly_cancel_fee: "200",
         });
       }
 
@@ -592,17 +828,67 @@ function toRecordSet(rows: RawClassRow[]): {
         );
       }
       if (row.weekday !== null && row.startTime) {
-        const key = `${instructor.instructor_ref}:2020-01-01:2099-12-31:Asia/Tokyo:${row.weekday}:${row.startTime}`;
+        const effectiveFrom = options.recurringClasses
+          ? dateOnlyFromDateTime(options.recurringClasses.startAt)
+          : "2020-01-01";
+        const key = `${instructor.instructor_ref}:${effectiveFrom}:Asia/Tokyo:${row.weekday}:${row.startTime}`;
         if (!instructorSchedulesByIdentity.has(key)) {
           instructorSchedulesByIdentity.add(key);
           instructorSchedules.push({
             instructor_ref: instructor.instructor_ref,
-            effective_from: "2020-01-01",
-            effective_to: "2099-12-31",
+            effective_from: effectiveFrom,
+            effective_to: "",
             timezone: "Asia/Tokyo",
             weekday: String(row.weekday),
             start_time: row.startTime,
           });
+        }
+      }
+
+      if (
+        options.recurringClasses &&
+        shouldGenerateRecurringClass(row, options.recurringClasses)
+      ) {
+        const subscription = subscriptionsByIdentity.get(subscriptionIdentity);
+        if (rowChildren.length === 0 || !subscription) {
+          warnings.push(
+            `Row ${row.sourceRow}: recurring class could not be linked to child or subscription`,
+          );
+        } else if (row.weekday === null || !row.startTime) {
+          warnings.push(
+            `Row ${row.sourceRow}: recurring class skipped because weekday or time could not be normalized`,
+          );
+        } else {
+          const key = [
+            subscription.subscription_ref,
+            instructor.instructor_ref,
+            rowChildren.map((child) => child.child_ref).join(","),
+            row.weekday,
+            row.startTime,
+            options.recurringClasses.startAt,
+            options.recurringClasses.endAt ?? "",
+          ].join("\u0000");
+          if (!recurringClassesByIdentity.has(key)) {
+            recurringClassesByIdentity.add(key);
+            const recurringClassRef = recurringClassSeq.next();
+            recurringClasses.push({
+              recurring_class_ref: recurringClassRef,
+              subscription_ref: subscription.subscription_ref,
+              instructor_ref: instructor.instructor_ref,
+              start_at: buildRecurringStartAt(
+                options.recurringClasses.startAt,
+                row.weekday,
+                row.startTime,
+              ),
+              end_at: options.recurringClasses.endAt ?? "",
+            });
+            recurringClassAttendance.push(
+              ...rowChildren.map((child) => ({
+                recurring_class_ref: recurringClassRef,
+                child_ref: child.child_ref,
+              })),
+            );
+          }
         }
       }
     }
@@ -616,6 +902,8 @@ function toRecordSet(rows: RawClassRow[]): {
     instructors,
     instructorFees,
     instructorSchedules,
+    recurringClasses,
+    recurringClassAttendance,
     generatedCustomerEmails,
     warnings,
   };
@@ -641,6 +929,7 @@ function buildRawRows(allRows: CsvRow[]): RawClassRow[] {
   let currentEmail = "";
   let currentPersonalInfo = "";
   let currentBirthdate: string | null = null;
+  let currentSiblingBirthdate: string | null = null;
 
   for (let i = headerIndex + 1; i < allRows.length; i += 1) {
     const row = allRows[i];
@@ -655,7 +944,10 @@ function buildRawRows(allRows: CsvRow[]): RawClassRow[] {
     const instructorName = trimOrEmpty(row[RAW_COLUMN.instructorName]);
     const weekdayText = trimOrEmpty(row[RAW_COLUMN.weekday]);
     const timeRange = trimOrEmpty(row[RAW_COLUMN.timeRange]);
+    const classType = trimOrEmpty(row[RAW_COLUMN.classType]);
     const childBirthRaw = trimOrEmpty(row[RAW_COLUMN.childBirthdate]);
+    const siblingBirthRaw = trimOrEmpty(row[RAW_COLUMN.siblingBirthdate]);
+    const detailUrl = trimOrEmpty(row[RAW_COLUMN.detailUrl]);
     const personalInfo = trimOrEmpty(row[RAW_COLUMN.personalInfo]);
     const email = trimOrEmpty(row[RAW_COLUMN.email]);
 
@@ -678,8 +970,12 @@ function buildRawRows(allRows: CsvRow[]): RawClassRow[] {
       currentPersonalInfo = personalInfo;
     }
     const parsedBirthdate = parseBirthdate(childBirthRaw);
+    const parsedSiblingBirthdate = parseBirthdate(siblingBirthRaw);
     if (parsedBirthdate) {
       currentBirthdate = parsedBirthdate;
+    }
+    if (parsedSiblingBirthdate) {
+      currentSiblingBirthdate = parsedSiblingBirthdate;
     }
 
     if (!currentCustomerName || !childName) {
@@ -695,7 +991,10 @@ function buildRawRows(allRows: CsvRow[]): RawClassRow[] {
       instructorName,
       weekday: parseWeekday(weekdayText),
       startTime: normalizeTime(timeRange),
+      classType,
       childBirthdate: parsedBirthdate ?? currentBirthdate,
+      siblingBirthdate: parsedSiblingBirthdate ?? currentSiblingBirthdate,
+      detailUrl,
       personalInfo: personalInfo || currentPersonalInfo,
       email: currentEmail,
     });
@@ -720,10 +1019,11 @@ function rowsToCsvWithHeaders<K extends NormalizedFileName, R extends object>(
 
 export function normalizeRawScheduleCsvToPackage(
   rawCsvContent: string,
+  options: NormalizeRawScheduleOptions = {},
 ): NormalizeRawScheduleResult {
   const parsed = parseCsv(rawCsvContent);
   const rawRows = buildRawRows(parsed);
-  const mapped = toRecordSet(rawRows);
+  const mapped = toRecordSet(rawRows, options);
 
   const files: NormalizedFileMap = {
     "plans.csv": rowsToCsvWithHeaders("plans.csv", mapped.plans),
@@ -749,15 +1049,18 @@ export function normalizeRawScheduleCsvToPackage(
       "instructor_absences.csv",
       [],
     ),
-    "events.csv": rowsToCsvWithHeaders("events.csv", []),
+    "events.csv": rowsToCsvWithHeaders("events.csv", DEFAULT_BUSINESS_EVENTS),
     "schedules.csv": rowsToCsvWithHeaders("schedules.csv", []),
     "system_status.csv": rowsToCsvWithHeaders("system_status.csv", [
       { status: "Running" },
     ]),
-    "recurring_classes.csv": rowsToCsvWithHeaders("recurring_classes.csv", []),
+    "recurring_classes.csv": rowsToCsvWithHeaders(
+      "recurring_classes.csv",
+      mapped.recurringClasses,
+    ),
     "recurring_class_attendance.csv": rowsToCsvWithHeaders(
       "recurring_class_attendance.csv",
-      [],
+      mapped.recurringClassAttendance,
     ),
     "classes.csv": rowsToCsvWithHeaders("classes.csv", []),
     "class_attendance.csv": rowsToCsvWithHeaders("class_attendance.csv", []),
@@ -772,11 +1075,11 @@ export function normalizeRawScheduleCsvToPackage(
     "instructor_fees.csv": mapped.instructorFees.length,
     "instructor_schedules.csv": mapped.instructorSchedules.length,
     "instructor_absences.csv": 0,
-    "events.csv": 0,
+    "events.csv": DEFAULT_BUSINESS_EVENTS.length,
     "schedules.csv": 0,
     "system_status.csv": 1,
-    "recurring_classes.csv": 0,
-    "recurring_class_attendance.csv": 0,
+    "recurring_classes.csv": mapped.recurringClasses.length,
+    "recurring_class_attendance.csv": mapped.recurringClassAttendance.length,
     "classes.csv": 0,
     "class_attendance.csv": 0,
   };

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -32,7 +32,7 @@ function buildMinimalNormalizedFiles() {
     "instructors.csv":
       "instructor_ref,name,email,temp_password,class_url,icon,nickname,meeting_id,passcode,birthdate,favorite_food,hobby,life_history,message_for_children,skill,working_time,english_background,termination_at\nIN0001,Instructor One,instructor.one@example.com,TempPass456!,https://import.local/class/in0001,https://import.local/icon/in0001.png,instructor_in0001,11111111111,PASS0001,1990-01-01,Sushi,Reading,Life history,Message,Skill,Weekdays,0,\n",
     "instructor_fees.csv":
-      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee\nIN0001,PHP,2025-01-01,,75,100,50,100\n",
+      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee,monthly_cancel_fee\nIN0001,PHP,2025-01-01,,75,100,50,100,200\n",
     "instructor_schedules.csv":
       "instructor_ref,effective_from,effective_to,timezone,weekday,start_time\nIN0001,2025-01-01,2025-12-31,Asia/Tokyo,1,09:00\n",
     "instructor_absences.csv": "instructor_ref,absent_at\n",
@@ -205,9 +205,9 @@ describe("POST /admins/import/normalize", () => {
       "instructor_fees.csv"
     ] as string;
     expect(instructorFeesCsv).toContain(
-      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee",
+      "instructor_ref,currency,effective_from,effective_to,trial_fee,regular_fee,cancel_fee,cancel_without_notice_fee,monthly_cancel_fee",
     );
-    expect(instructorFeesCsv).toContain("PHP,2020-01-01,,75,100,50,100");
+    expect(instructorFeesCsv).toContain("PHP,2020-01-01,,75,100,50,100,200");
   });
 
   it("downloads normalized files as a zip bundle by jobId", async () => {
@@ -637,30 +637,29 @@ describe("POST /admins/import/execute", () => {
     expect(slotCount).toBe(2);
   });
 
-  it("preserves only seed admins during full reset import", async () => {
-    const seedAdmin1 = await createAdmin({
+  it("preserves all admins during full reset import", async () => {
+    const admin1 = await createAdmin({
       name: "Seed Admin 1",
       email: "admin@example.com",
       password: "SeedAdminPass1!",
     });
-    const seedAdmin2 = await createAdmin({
+    const admin2 = await createAdmin({
       name: "Seed Admin 2",
       email: "admin2@example.com",
       password: "SeedAdminPass2!",
     });
-    const removableAdmin = await createAdmin({
+    const admin3 = await createAdmin({
       name: "Temporary Admin",
       email: "temporary-admin@example.com",
       password: "TemporaryPass1!",
     });
-    const authCookie = await generateAuthCookie(removableAdmin.id, "admin");
+    const authCookie = await generateAuthCookie(admin3.id, "admin");
 
-    const seedBefore = await prisma.admin.findMany({
-      where: { email: { in: ["admin@example.com", "admin2@example.com"] } },
+    const adminsBefore = await prisma.admin.findMany({
       orderBy: { email: "asc" },
     });
-    const seedBeforeByEmail = new Map(
-      seedBefore.map((item) => [item.email, item.password]),
+    const passwordsBeforeByEmail = new Map(
+      adminsBefore.map((item) => [item.email, item.password]),
     );
 
     const zipBuffer = await buildZipBuffer(buildMinimalNormalizedFiles());
@@ -679,20 +678,21 @@ describe("POST /admins/import/execute", () => {
     });
     const emailsAfter = adminsAfter.map((item) => item.email);
 
-    expect(emailsAfter).toEqual(["admin2@example.com", "admin@example.com"]);
-    expect(emailsAfter).not.toContain("temporary-admin@example.com");
+    expect(emailsAfter).toEqual([
+      "admin2@example.com",
+      "admin@example.com",
+      "temporary-admin@example.com",
+    ]);
 
-    const seedAfterByEmail = new Map(
+    const passwordsAfterByEmail = new Map(
       adminsAfter.map((item) => [item.email, item.password]),
     );
-    expect(seedAfterByEmail.get("admin@example.com")).toBe(
-      seedBeforeByEmail.get("admin@example.com"),
-    );
-    expect(seedAfterByEmail.get("admin2@example.com")).toBe(
-      seedBeforeByEmail.get("admin2@example.com"),
-    );
-    expect(seedAdmin1.email).toBe("admin@example.com");
-    expect(seedAdmin2.email).toBe("admin2@example.com");
+    for (const [email, password] of passwordsBeforeByEmail) {
+      expect(passwordsAfterByEmail.get(email)).toBe(password);
+    }
+    expect(admin1.email).toBe("admin@example.com");
+    expect(admin2.email).toBe("admin2@example.com");
+    expect(admin3.email).toBe("temporary-admin@example.com");
   });
 
   it("rolls back reset and inserts when import fails mid-transaction", async () => {

--- a/backend/src/test/api/classes.test.ts
+++ b/backend/src/test/api/classes.test.ts
@@ -524,6 +524,53 @@ describe("POST /classes/create-classes", () => {
     expect(created.length).toBeGreaterThan(0);
   });
 
+  it("preserves JST weekday and time when generating classes for month", async () => {
+    const admin = await createAdmin();
+    const customer = await createCustomer();
+    const instructor = await createInstructor();
+    const child = await createChild(customer.id);
+    const plan = await createPlan();
+    const subscription = await createSubscription(plan.id, customer.id, {
+      startAt: new Date("2026-06-01T00:00:00.000Z"),
+      endAt: null,
+    });
+    const recurringClass = await prisma.recurringClass.create({
+      data: {
+        instructorId: instructor.id,
+        subscriptionId: subscription.id,
+        startAt: new Date("2026-06-05T07:00:00.000Z"),
+        recurringClassAttendance: {
+          create: {
+            childrenId: child.id,
+          },
+        },
+      },
+    });
+
+    await request(server)
+      .post("/classes/create-classes")
+      .set("Cookie", await generateAuthCookie(admin.id, "admin"))
+      .send({
+        year: 2026,
+        month: "June",
+      })
+      .expect(201);
+
+    const created = await prisma.class.findMany({
+      where: { recurringClassId: recurringClass.id },
+      orderBy: { dateTime: "asc" },
+    });
+
+    expect(
+      created.map((classItem) => classItem.dateTime?.toISOString()),
+    ).toEqual([
+      "2026-06-05T07:00:00.000Z",
+      "2026-06-12T07:00:00.000Z",
+      "2026-06-19T07:00:00.000Z",
+      "2026-06-26T07:00:00.000Z",
+    ]);
+  });
+
   it("uses no-class event names when generating classes for month", async () => {
     const admin = await createAdmin();
     const customer = await createCustomer();

--- a/backend/src/test/services/adminImportNormalize.test.ts
+++ b/backend/src/test/services/adminImportNormalize.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildNormalizedPackageZip,
   normalizeRawScheduleCsvToPackage,
+  parseCsv,
+  validateNormalizedImportFiles,
 } from "../../services/adminImport";
 import JSZip from "jszip";
 
@@ -22,6 +24,12 @@ function csvEscape(value: string): string {
 
 function rawRow(columns: string[]): string {
   return columns.map(csvEscape).join(",");
+}
+
+function csvRows(csv: string): string[][] {
+  return parseCsv(csv).filter((row) =>
+    row.some((cell) => cell.trim().length > 0),
+  );
 }
 
 describe("adminImport normalize service", () => {
@@ -192,6 +200,315 @@ describe("adminImport normalize service", () => {
     const childrenCsv = normalized.files["children.csv"];
     expect(childrenCsv).toContain('"Line1, ""quoted""');
     expect(childrenCsv).toContain('Line2"');
+  });
+
+  it("uses raw detail URLs for subscriptions and instructor names for nicknames", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "Grace",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "https://select-type.com/my/mmag/ad/u/?id=123",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    expect(normalized.files["subscriptions.csv"]).toContain(
+      "https://select-type.com/my/mmag/ad/u/?id=123",
+    );
+    expect(normalized.files["instructors.csv"]).toContain("Grace,90000001");
+  });
+
+  it("keeps recurring class files header-only by default", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "Grace",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    expect(csvRows(normalized.files["recurring_classes.csv"])).toHaveLength(1);
+    expect(
+      csvRows(normalized.files["recurring_class_attendance.csv"]),
+    ).toHaveLength(1);
+  });
+
+  it("includes default business calendar event definitions", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "Grace",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv);
+    expect(csvRows(normalized.files["events.csv"])).toEqual([
+      ["event_ref", "name", "color"],
+      ["EV0001", "通常授業日 / Regular Class Day", "#FFFFFF"],
+      ["EV0002", "お休み / No Class", "#FAD7CD"],
+      ["EV0003", "お休み振替対象日 / No Class (Rebookable)", "#FF0000"],
+      ["EV0004", "テーマクラスウィーク / Theme Class Week", "#FFFF00"],
+    ]);
+    expect(normalized.report.normalizedRowsByFile["events.csv"]).toBe(4);
+  });
+
+  it("splits parenthesized child names and keeps sibling attendance together", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "埼玉",
+        "10/16",
+        "河野麻未",
+        "Miyu (Yuna,Haruto)",
+        "2180円（週1回25分）",
+        "Keziah",
+        "Fri",
+        "16:00-16:25",
+        "R",
+        "5/19",
+        "12/26",
+        "4",
+        "https://select-type.com/my/mmag/ad/u/?id=9308472",
+        "",
+        "Birthday Miyu 5/19 Yuna12/26 Haruto5/9",
+        "kono@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv, {
+      recurringClasses: {
+        startAt: "2026-06-01T00:00:00+09:00",
+        customerNames: ["河野麻未"],
+        instructorNames: ["Keziah"],
+      },
+    });
+
+    expect(csvRows(normalized.files["children.csv"])).toEqual([
+      ["child_ref", "customer_ref", "name", "birthdate", "personal_info"],
+      [
+        "CH0001",
+        "CU0001",
+        "Miyu",
+        "2000-05-19",
+        "Birthday Miyu 5/19 Yuna12/26 Haruto5/9",
+      ],
+      [
+        "CH0002",
+        "CU0001",
+        "Yuna",
+        "2000-12-26",
+        "Birthday Miyu 5/19 Yuna12/26 Haruto5/9",
+      ],
+      [
+        "CH0003",
+        "CU0001",
+        "Haruto",
+        "2000-05-09",
+        "Birthday Miyu 5/19 Yuna12/26 Haruto5/9",
+      ],
+    ]);
+    expect(csvRows(normalized.files["recurring_class_attendance.csv"])).toEqual(
+      [
+        ["recurring_class_ref", "child_ref"],
+        ["RC0001", "CH0001"],
+        ["RC0001", "CH0002"],
+        ["RC0001", "CH0003"],
+      ],
+    );
+  });
+
+  it("uses the recurring start date as the open-ended instructor schedule effective date", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "3180円（週2回25分）",
+        "Grace",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv, {
+      recurringClasses: {
+        startAt: "2026-06-01T00:00:00+09:00",
+      },
+    });
+
+    expect(csvRows(normalized.files["instructor_schedules.csv"])).toEqual([
+      [
+        "instructor_ref",
+        "effective_from",
+        "effective_to",
+        "timezone",
+        "weekday",
+        "start_time",
+      ],
+      ["IN0001", "2026-06-01", "", "Asia/Tokyo", "1", "19:00"],
+    ]);
+    expect(csvRows(normalized.files["plans.csv"])[1]).toEqual([
+      "PL0001",
+      "月3,180円プラン / 3,180 yen/month Plan",
+      "2 classes per week",
+      "2",
+      "0",
+      "",
+    ]);
+  });
+
+  it("generates filtered recurring classes with the first matching weekly datetime", () => {
+    const csv = [
+      RAW_HEADER,
+      rawRow([
+        "",
+        "",
+        "東京",
+        "10/2",
+        "田中花子",
+        "Mitsuki",
+        "1980円（週1回25分）",
+        "Grace",
+        "Mon",
+        "19:00-19:25",
+        "R",
+        "6/2",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "tanaka@example.com",
+        "",
+        "",
+      ]),
+      rawRow([
+        "",
+        "",
+        "大阪",
+        "10/3",
+        "鈴木一郎",
+        "Aoi",
+        "1980円（週1回25分）",
+        "Grace",
+        "Tue",
+        "17:00-17:25",
+        "C",
+        "7/7",
+        "",
+        "4",
+        "",
+        "",
+        "",
+        "suzuki@example.com",
+        "",
+        "",
+      ]),
+    ].join("\n");
+
+    const normalized = normalizeRawScheduleCsvToPackage(csv, {
+      recurringClasses: {
+        startAt: "2026-06-01T00:00:00+09:00",
+        customerNames: ["田中花子"],
+        instructorNames: ["Grace"],
+        classTypes: ["R"],
+      },
+    });
+
+    const recurringRows = csvRows(normalized.files["recurring_classes.csv"]);
+    expect(recurringRows).toEqual([
+      [
+        "recurring_class_ref",
+        "subscription_ref",
+        "instructor_ref",
+        "start_at",
+        "end_at",
+      ],
+      ["RC0001", "SU0001", "IN0001", "2026-06-01T19:00:00+09:00", ""],
+    ]);
+
+    const attendanceRows = csvRows(
+      normalized.files["recurring_class_attendance.csv"],
+    );
+    expect(attendanceRows).toEqual([
+      ["recurring_class_ref", "child_ref"],
+      ["RC0001", "CH0001"],
+    ]);
+    expect(validateNormalizedImportFiles(normalized.files).isValid).toBe(true);
   });
 
   it("builds a zip that contains all normalized files", async () => {

--- a/backend/src/utils/dateUtils.ts
+++ b/backend/src/utils/dateUtils.ts
@@ -55,22 +55,26 @@ const getDayNumber = (day: Day): number => {
   return days.indexOf(day);
 };
 
-// Calculate the first date of `day` and `time` after `from`.
-// e.g., from: "2024-08-01", day: "Mon", time: "09:00" => "2024-08-05T00:00:00Z"
+// Calculate the first JST date/time of `day` and `time` after `from`.
 export function calculateFirstDate(from: Date, day: Day, time: string): Date {
-  const date = new Date(from);
-
-  // The following calculation for setDate works only for after 09:00 in Japanese time.
-  // Japanese time is UTC+9. Thus, after 09:00, date.getUTCDay() returns the same day as in Japan.
-  date.setDate(
-    date.getDate() + ((getDayNumber(day) - date.getUTCDay() + 7) % 7),
+  const fromInJst = new Date(from.getTime() + JAPAN_TIME_DIFF * 60 * 60 * 1000);
+  const offsetDays = (getDayNumber(day) - fromInJst.getUTCDay() + 7) % 7;
+  const [hour, minute] = time.split(":").map(Number);
+  const candidate = new Date(
+    Date.UTC(
+      fromInJst.getUTCFullYear(),
+      fromInJst.getUTCMonth(),
+      fromInJst.getUTCDate() + offsetDays,
+      hour - JAPAN_TIME_DIFF,
+      minute,
+    ),
   );
 
-  const [hour, minute] = time.split(":");
-  // TODO: Consider the affected part.
-  date.setUTCHours(parseInt(hour));
-  date.setUTCMinutes(parseInt(minute));
-  return date;
+  if (candidate < from) {
+    candidate.setUTCDate(candidate.getUTCDate() + 7);
+  }
+
+  return candidate;
 }
 
 export const getMonthNumber = (month: Month): number => {

--- a/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
+++ b/frontend/src/components/admins-dashboard/BusinessCalendarClient.tsx
@@ -187,7 +187,7 @@ const BusinessCalendarClient = ({
   };
 
   // Display the failure message if the schedule is not loaded
-  if (!businessSchedule || businessSchedule.length === 0 || !events) {
+  if (!businessSchedule || !events) {
     return <div>Failed to load AaasoBo! schedule.</div>;
   }
 


### PR DESCRIPTION
## Summary
- add a reproducible beta import generator for the selected customers/instructors; generated output is intentionally left untracked
- require an explicit beta import start date via --start-date/--start-at or BETA_IMPORT_START_DATE/BETA_IMPORT_START_AT
- generate recurring classes from normalized raw schedule data, with open-ended instructor schedules/fees and monthly cancel fees
- keep existing Admin rows untouched during import resets, while preserving class generation timezone behavior and calendar empty-schedule handling

## Usage
- cd backend && npm run beta:generate-import -- --start-date=2026-06-01
- or: BETA_IMPORT_START_DATE=2026-06-01 npm run beta:generate-import

## Verification
- npx tsc --noEmit
- npm run beta:generate-import fails when no start date is provided
- npm run beta:generate-import -- --start-date=2026-06-01
- npm run beta:generate-import -- --start-at=2026-06-01T00:00:00+09:00
- previous local pipeline run passed frontend format/lint/unused/build, backend format/unused/build, and backend API tests with --maxWorkers=4