### PR TITLE
[codex] fix repeated welcome modal

### DIFF
--- a/frontend/src/components/customers-dashboard/classes/welcomeModalController/WelcomeModal.tsx
+++ b/frontend/src/components/customers-dashboard/classes/welcomeModalController/WelcomeModal.tsx
@@ -10,10 +10,12 @@ import {
   LOGIN_REQUIRED_MESSAGE,
   WELCOME_MODAL_TITLE1,
 } from "@/lib/messages/customerDashboard";
+import { UNEXPECTED_ERROR_MESSAGE } from "@/lib/messages/formValidation";
 import { validateSession } from "@/app/actions/validateSession";
 import { confirmAndDeclineFreeTrialClass } from "@/lib/utils/confirmAndDeclineFreeTrialClass";
 import { errorAlert } from "@/lib/utils/alertUtils";
 import { CONTACT_EMAIL, LINE_QR_CODE_URL } from "@/lib/data/contacts";
+import { useRouter } from "next/navigation";
 
 export default function WelcomeModal({
   customerId,
@@ -21,6 +23,8 @@ export default function WelcomeModal({
   setIsWelcomeModalOpen,
   userSessionType,
 }: WelcomeModalProps) {
+  const router = useRouter();
+
   const handleClick = async () => {
     const { isValid, error } = await validateSession(customerId);
 
@@ -32,9 +36,13 @@ export default function WelcomeModal({
       );
     }
 
-    await markWelcomeSeen(customerId);
+    const isMarkedAsSeen = await markWelcomeSeen(customerId);
+    if (!isMarkedAsSeen) {
+      return errorAlert(UNEXPECTED_ERROR_MESSAGE[language]);
+    }
 
     setIsWelcomeModalOpen(false);
+    router.refresh();
   };
 
   return (

--- a/frontend/src/lib/api/customersApi.ts
+++ b/frontend/src/lib/api/customersApi.ts
@@ -496,7 +496,7 @@ export const getChildProfiles = async (
 export const markWelcomeSeen = async (
   customerId: number,
   cookie?: string,
-): Promise<void> => {
+): Promise<boolean> => {
   try {
     let apiURL;
     let headers;
@@ -529,9 +529,13 @@ export const markWelcomeSeen = async (
       console.error(
         `Failed to update welcome status: ${response.status} ${response.statusText}`,
       );
+      return false;
     }
+
+    return true;
   } catch (error) {
     console.error("API error while marking welcome message as seen:", error);
+    return false;
   }
 };
 


### PR DESCRIPTION
## What changed
- Mark welcome message as seen now reports success or failure.
- On success, the modal closes and the dashboard is refreshed so the updated `hasSeenWelcome` value is reloaded.

## Why
- The customer dashboard decides whether to show the welcome modal from `customer.hasSeenWelcome` on the server render.
- Without a refresh after the PATCH, stale RSC state could bring the modal back on revisit or navigation.

## Validation
- `/home/momori/.codex/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh frontend`
