### PR TITLE
[codex] use standard prisma client

### DIFF
--- a/backend/knip.json
+++ b/backend/knip.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": ["generated/**", "prisma.config.ts"],
-  "ignoreDependencies": ["@prisma/client"],
   "prisma": {
     "config": ["package.json"]
   }

--- a/backend/prisma/prismaClient.ts
+++ b/backend/prisma/prismaClient.ts
@@ -1,5 +1,5 @@
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, Prisma } from "../generated/prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { Pool } from "pg";
 
 const globalForPrisma = globalThis as unknown as {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider   = "prisma-client-js"
-  output     = "../generated/prisma"
   engineType = "client"
 }
 

--- a/backend/src/controllers/classesController.ts
+++ b/backend/src/controllers/classesController.ts
@@ -1,4 +1,4 @@
-import { Prisma, Status } from "../../generated/prisma";
+import { Prisma, Status } from "@prisma/client";
 import { Request, Response } from "express";
 import {
   cancelClassById,

--- a/backend/src/controllers/instructorsController.ts
+++ b/backend/src/controllers/instructorsController.ts
@@ -1,4 +1,4 @@
-import { Instructor } from "../../generated/prisma";
+import { Instructor } from "@prisma/client";
 import { Request, Response } from "express";
 import { RequestWithParams } from "../middlewares/validationMiddleware";
 import {

--- a/backend/src/seed/bootstrap.ts
+++ b/backend/src/seed/bootstrap.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "../../generated/prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { hashPassword } from "../utils/commonUtils";
 
 const adapter = new PrismaPg({

--- a/backend/src/seed/dummy.ts
+++ b/backend/src/seed/dummy.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, Prisma } from "../../generated/prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { MessageTarget } from "../types";
 
 const adapter = new PrismaPg({

--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -1,5 +1,5 @@
 import JSZip from "jszip";
-import { Prisma, Status } from "../../../generated/prisma";
+import { Prisma, Status } from "@prisma/client";
 import { prisma } from "../../../prisma/prismaClient";
 import { hashPassword } from "../../utils/commonUtils";
 import {

--- a/backend/src/services/adminsService.ts
+++ b/backend/src/services/adminsService.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../prisma/prismaClient";
-import { Admin } from "../../generated/prisma";
+import { Admin } from "@prisma/client";
 import {
   hashPassword,
   maskedHeadLetters,

--- a/backend/src/services/childrenService.ts
+++ b/backend/src/services/childrenService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 
 export const getChildren = async (customerId: string) => {

--- a/backend/src/services/classAttendancesService.ts
+++ b/backend/src/services/classAttendancesService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 
 export const checkIfChildHasCompletedClass = async (

--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -1,4 +1,4 @@
-import { Prisma, Status } from "../../generated/prisma";
+import { Prisma, Status } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import { getJstDayRange, nDaysLater, nHoursLater } from "../utils/dateUtils";
 import { NewClassToRebookType } from "../controllers/classesController";

--- a/backend/src/services/customersService.ts
+++ b/backend/src/services/customersService.ts
@@ -1,4 +1,4 @@
-import { Customer, Prisma } from "../../generated/prisma";
+import { Customer, Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import {
   hashPassword,

--- a/backend/src/services/instructorAbsenceService.ts
+++ b/backend/src/services/instructorAbsenceService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import { nHoursLater } from "../utils/dateUtils";
 

--- a/backend/src/services/instructorPayrollService.ts
+++ b/backend/src/services/instructorPayrollService.ts
@@ -3,7 +3,7 @@ import type {
   InstructorPayrollPeriod,
   InstructorPayrollResponse,
 } from "../../../shared/schemas/admins";
-import type { Status } from "../../generated/prisma";
+import type { Status } from "@prisma/client";
 
 const PAYROLL_TIMEZONE = "Asia/Tokyo";
 const MONTH_FORMATTER = new Intl.DateTimeFormat("en-CA", {

--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../prisma/prismaClient";
-import { Prisma, Status } from "../../generated/prisma";
+import { Prisma, Status } from "@prisma/client";
 import { JAPAN_TIME_DIFF, nDaysLater, nHoursLater } from "../utils/dateUtils";
 import { EnglishBackground } from "../types";
 import {

--- a/backend/src/services/instructorsService.ts
+++ b/backend/src/services/instructorsService.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../prisma/prismaClient";
-import { Instructor } from "../../generated/prisma";
+import { Instructor } from "@prisma/client";
 import {
   hashPassword,
   defaultUserImageUrl,

--- a/backend/src/services/messageBoardService.ts
+++ b/backend/src/services/messageBoardService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import { MessageTarget } from "../types";
 import {

--- a/backend/src/services/recurringClassesService.ts
+++ b/backend/src/services/recurringClassesService.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../prisma/prismaClient";
-import { Prisma, RecurringClass, Class } from "../../generated/prisma";
+import { Prisma, RecurringClass, Class } from "@prisma/client";
 import { JAPAN_TIME_DIFF, nDaysLater, nHoursBefore } from "../utils/dateUtils";
 import {
   NO_CLASS_EVENT_NAME,

--- a/backend/src/services/scheduleService.ts
+++ b/backend/src/services/scheduleService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 import { MONTHS_TO_DELETE_BUSINESS_CALENDAR } from "../utils/commonUtils";
 

--- a/backend/src/services/subscriptionsService.ts
+++ b/backend/src/services/subscriptionsService.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../prisma/prismaClient";
 
 export const getAllSubscriptions = async () => {

--- a/backend/src/services/verificationTokensService.ts
+++ b/backend/src/services/verificationTokensService.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { prisma } from "../../prisma/prismaClient";
-import { Prisma } from "../../generated/prisma";
+import { Prisma } from "@prisma/client";
 import { nHoursLater } from "../utils/dateUtils";
 import { hashToken, safeCompareHash } from "../utils/tokenUtils";
 

--- a/backend/src/test/globalSetup.ts
+++ b/backend/src/test/globalSetup.ts
@@ -3,7 +3,7 @@ import {
   type StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "../../generated/prisma/client";
+import { PrismaClient } from "@prisma/client";
 import dotenv from "dotenv";
 import { mkdir, rm, writeFile } from "fs/promises";
 import path from "path";

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach } from "vitest";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "../../generated/prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { execSync } from "child_process";
 import { readFile } from "fs/promises";
 import path from "path";

--- a/backend/src/test/testUtils.ts
+++ b/backend/src/test/testUtils.ts
@@ -1,7 +1,7 @@
 const { faker } = require("@faker-js/faker");
 import { hashPasswordSync } from "../utils/commonUtils";
 import { prisma } from "./setup";
-import { Prisma, Status } from "../../generated/prisma";
+import { Prisma, Status } from "@prisma/client";
 
 export function setTestDataSeed(seed: number) {
   faker.seed(seed);


### PR DESCRIPTION
## What changed

- Switched backend Prisma imports from the custom `backend/generated/prisma` output to the standard `@prisma/client` entrypoint.
- Removed the custom Prisma output path from `backend/prisma/schema.prisma` so generation targets the default client location.

## Why

- The server was failing to start when the generated custom Prisma client was missing, producing `Cannot find module '../../generated/prisma'` during TypeScript compilation.

## Impact

- Backend startup now relies on the standard generated Prisma client and no longer depends on the gitignored custom output path.
- This restores `npm run dev` and the backend test/build flow in a clean workspace.

## Validation

- `npx tsc --noEmit --pretty false`
- `/home/momori/.codex/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh backend`