### PR TITLE
Fix active instructor schedule lookup

### DIFF
--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -94,15 +94,17 @@ export const getActiveInstructorSchedule = async (
   effectiveDate: string,
 ) => {
   try {
+    const targetDate = new Date(effectiveDate);
     const activeSchedule = await prisma.instructorSchedule.findFirst({
       where: {
         instructorId,
-        effectiveFrom: { lte: new Date(effectiveDate) },
-        effectiveTo: null,
+        effectiveFrom: { lte: targetDate },
+        OR: [{ effectiveTo: null }, { effectiveTo: { gt: targetDate } }],
       },
       include: {
         slots: { orderBy: [{ weekday: "asc" }, { startTime: "asc" }] },
       },
+      orderBy: { effectiveFrom: "desc" },
     });
 
     if (!activeSchedule) {

--- a/backend/src/test/api/instructors/schedules.test.ts
+++ b/backend/src/test/api/instructors/schedules.test.ts
@@ -1082,6 +1082,22 @@ describe("GET /instructors/:id/schedules/active", () => {
 
     expect(response.body.data.id).toBe(schedule.id);
   });
+
+  it("succeeds for a finite schedule that is active on the requested date", async () => {
+    const instructor = await createInstructor();
+    const schedule = await createInstructorSchedule(instructor.id, {
+      effectiveFrom: new Date("2024-01-01"),
+      effectiveTo: new Date("2024-07-01"),
+    });
+
+    const response = await request(server)
+      .get(`/instructors/${instructor.id}/schedules/active`)
+      .set("Cookie", authCookie)
+      .query({ effectiveDate: "2024-06-15" })
+      .expect(200);
+
+    expect(response.body.data.id).toBe(schedule.id);
+  });
 });
 
 describe("GET /instructors/:id/schedules/:scheduleId", () => {

--- a/frontend/src/app/instructors/(protected)/availability/AvailabilityPageClient.tsx
+++ b/frontend/src/app/instructors/(protected)/availability/AvailabilityPageClient.tsx
@@ -5,6 +5,7 @@ import {
   getActiveInstructorSchedule,
   InstructorSlot,
 } from "@/lib/api/instructorsApi";
+import { getTodayInJapanISODate } from "@/lib/utils/dateUtils";
 import ScheduleCalendar from "@/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleCalendar";
 import Loading from "@/components/elements/loading/Loading";
 import styles from "./page.module.scss";
@@ -22,7 +23,7 @@ export default function AvailabilityPageClient({
     const fetchSchedule = async () => {
       try {
         setLoading(true);
-        const today = new Date().toISOString().split("T")[0];
+        const today = getTodayInJapanISODate();
         const scheduleData = await getActiveInstructorSchedule(
           instructorId,
           today,

--- a/frontend/src/components/customers-dashboard/regular-classes/InstructorSchedule.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/InstructorSchedule.tsx
@@ -5,6 +5,7 @@ import {
   getActiveInstructorSchedule,
   InstructorSlot,
 } from "@/lib/api/instructorsApi";
+import { getTodayInJapanISODate } from "@/lib/utils/dateUtils";
 import { WEEKDAYS } from "@/lib/utils/scheduleUtils";
 import styles from "./InstructorSchedule.module.scss";
 
@@ -34,9 +35,10 @@ export default function InstructorSchedule({
 
       try {
         // Get instructor's active schedule directly
+        const today = getTodayInJapanISODate();
         const response = await getActiveInstructorSchedule(
           instructorId,
-          effectiveDate,
+          effectiveDate || today,
         );
         // Set the slots from the active schedule
         setSlots(response.schedule?.slots || []);

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -1183,7 +1183,7 @@ export const getActiveInstructorSchedule = async (
   instructorId: number,
   effectiveDate: string,
   cookie?: string,
-) => {
+): Promise<{ schedule: InstructorScheduleWithSlots | null }> => {
   try {
     let apiURL;
     let headers;
@@ -1215,6 +1215,10 @@ export const getActiveInstructorSchedule = async (
         method,
         headers,
       });
+    }
+
+    if (response.status === 404) {
+      return { schedule: null };
     }
 
     if (response.status !== 200) {

--- a/frontend/src/lib/utils/dateUtils.ts
+++ b/frontend/src/lib/utils/dateUtils.ts
@@ -1,6 +1,8 @@
 import { addMinutes, addMonths, startOfDay, isAfter, format } from "date-fns";
 import { TZDate } from "@date-fns/tz";
 
+const JAPAN_TIME_ZONE = "Asia/Tokyo";
+
 // Function to format time for a given time zone(e.g., 19:00)
 export const formatTime = (date: Date, timeZone: string) => {
   return new Intl.DateTimeFormat("en-US", {
@@ -50,16 +52,39 @@ export const formatTimeWithAddedMinutes = (
 
 export const isPastPreviousDayDeadline = (classDateUTC: string): boolean => {
   // Convert class date from UTC to Japan time
-  const classDateInJapan = new TZDate(classDateUTC, "Asia/Tokyo");
+  const classDateInJapan = new TZDate(classDateUTC, JAPAN_TIME_ZONE);
 
   // Get the start of the class day in Japan time (00:00:00)
   const classDayStart = startOfDay(classDateInJapan);
 
   // Get the current date in Japan time (00:00:00 today)
-  const todayInJapan = startOfDay(new TZDate(new Date(), "Asia/Tokyo"));
+  const todayInJapan = startOfDay(new TZDate(new Date(), JAPAN_TIME_ZONE));
 
   // If class date is today or in the past, return true (deadline has passed)
   return !isAfter(classDayStart, todayInJapan);
+};
+
+const formatDateToISOInTimeZone = (date: Date, timeZone: string): string => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+
+  if (!year || !month || !day) {
+    throw new Error("Failed to format date in the requested time zone");
+  }
+
+  return `${year}-${month}-${day}`;
+};
+
+export const getTodayInJapanISODate = (): string => {
+  return formatDateToISOInTimeZone(new Date(), JAPAN_TIME_ZONE);
 };
 
 // Function to calculate the end time of a class.


### PR DESCRIPTION
## Summary

- select instructor schedules that are active for the requested date, including finite historical schedules
- use the Japan calendar date when requesting today's schedule
- render a missing active schedule as an empty state instead of a frontend error

## Root cause

The active-schedule query required `effectiveTo` to be null, so schedules with a finite end date were ignored even when the requested date fell within their effective interval. Frontend callers also derived today from UTC, which can differ from the current date in Japan, and treated the expected 404 response for instructors without a schedule as an exception.

## Impact

Instructor availability and regular-class screens now resolve the correct schedule for the requested Japan date and handle instructors without an active schedule gracefully.

## Validation

- frontend format check, ESLint with zero warnings, unused-code check, and production build
- backend formatting and unused-code check
- backend test suite: 252 tests passed
- backend build, migrations, and bootstrap
