### PR TITLE
Reorder admin sidebar and keep Data Import last

### DIFF
--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -81,16 +81,6 @@ export function getLinks(
       icon: UsersIcon,
     },
     {
-      name: "Plan List",
-      href: "/admins/plan-list",
-      icon: AcademicCapIcon,
-    },
-    {
-      name: "Event List",
-      href: "/admins/event-list",
-      icon: BellIcon,
-    },
-    {
       name: "Admin List",
       href: "/admins/admin-list",
       icon: UserIcon,
@@ -104,6 +94,16 @@ export function getLinks(
       name: "AaasoBo! Calendar",
       href: "/admins/business-calendar",
       icon: CalendarDaysIcon,
+    },
+    {
+      name: "Plan List",
+      href: "/admins/plan-list",
+      icon: AcademicCapIcon,
+    },
+    {
+      name: "Event List",
+      href: "/admins/event-list",
+      icon: BellIcon,
     },
     {
       name: "Data Import",


### PR DESCRIPTION
## Summary

- move Plan List and Event List toward the bottom of the admin sidebar
- keep Plan List, Event List, and Data Import as the final three entries in that order
- preserve all existing navigation destinations and the relative order of other links

## Why

These less frequently used admin pages should appear after the primary operational navigation, while Data Import remains the bottom-most item.

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`

Closes #582
