### PR TITLE
Always label customer booking action as Book Class

### DIFF
--- a/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookingModalController/RebookingModalController.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookingModalController/RebookingModalController.tsx
@@ -18,10 +18,6 @@ export default function RebookingModalController({
   const [isRebookingModalOpen, setIsRebookingModalOpen] = useState(false);
   const rebookableClassesNumber = rebookableClasses.length;
 
-  const hasFreeTrial =
-    rebookableClassesNumber > 0 &&
-    rebookableClasses.some((classItem) => classItem.isFreeTrial === true);
-
   const handleRebookingClick = () => {
     if (!hasChildProfile)
       return errorAlert(CHILD_PROFILE_REQUIRED_MESSAGE[language]);
@@ -30,12 +26,8 @@ export default function RebookingModalController({
 
   const buttonText =
     language === "ja"
-      ? hasFreeTrial
-        ? `クラスを予約${rebookableClassesNumber > 0 ? ` (${rebookableClassesNumber})` : ""}`
-        : `振替予約${rebookableClassesNumber > 0 ? ` (${rebookableClassesNumber})` : ""}`
-      : hasFreeTrial
-        ? `Book Class${rebookableClassesNumber > 0 ? ` (${rebookableClassesNumber})` : ""}`
-        : `Rebook Class${rebookableClassesNumber > 0 ? ` (${rebookableClassesNumber})` : ""}`;
+      ? `クラスを予約 (${rebookableClassesNumber})`
+      : `Book Class (${rebookableClassesNumber})`;
 
   return (
     <>


### PR DESCRIPTION
## Summary

- always label the customer-dashboard booking action as `Book Class (n)` in English
- always label the action as `クラスを予約 (n)` in Japanese
- keep the available-credit count visible at zero while preserving the existing disabled behavior

## Why

The action previously switched to `Rebook Class` / `振替予約` when no available credit was marked as a free trial. That presentation distinction made the expected booking action appear to be missing even though eligibility and credit behavior were unchanged.

This change removes the credit-type-dependent label branch only. Booking eligibility, credit calculations, modal behavior, customer/admin visibility, and the zero-count disabled state are unchanged.

Closes #585

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`

The production build completed successfully. It logged expected backend `ECONNREFUSED` messages while prerendering because the backend service was not running.