### PR TITLE
Expose payroll information in instructor dashboard

### DIFF
--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -15,7 +15,6 @@ import {
   getAdminController,
   getAllAdminsController,
   getAllInstructorsController,
-  getInstructorPayrollController,
   getInstructorFeesController,
   createInstructorFeeController,
   deleteLatestInstructorFeeController,
@@ -50,10 +49,7 @@ import {
   CreateMessageBoardPostRequest,
   CustomerIdParams,
   InstructorIdParams,
-  InstructorPayrollQuery,
   CreateInstructorFeeRequest,
-  InstructorPayrollResponse,
-  InstructorPayrollErrorResponse,
   InstructorFeeRatesResponse,
   CreateInstructorFeeResponse,
   DeleteLatestInstructorFeeResponse,
@@ -397,44 +393,6 @@ const getAllInstructorsConfig = {
       200: {
         description: "Instructors list retrieved successfully",
         schema: InstructorsListResponse,
-      },
-      500: {
-        description: "Internal server error",
-        schema: ErrorResponse,
-      },
-    },
-  },
-} as const;
-
-const getInstructorPayrollConfig = {
-  method: "get" as const,
-  paramsSchema: InstructorIdParams,
-  querySchema: InstructorPayrollQuery,
-  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
-  handler: getInstructorPayrollController,
-  openapi: {
-    summary: "Get instructor payroll",
-    description: "Get current payroll summary for one instructor and month",
-    responses: {
-      200: {
-        description: "Instructor payroll retrieved successfully",
-        schema: InstructorPayrollResponse,
-      },
-      400: {
-        description: "Invalid query parameters",
-        schema: MessageErrorResponse,
-      },
-      401: {
-        description: "Unauthorized",
-        schema: MessageErrorResponse,
-      },
-      404: {
-        description: "Instructor not found",
-        schema: MessageErrorResponse,
-      },
-      422: {
-        description: "Payroll data cannot be resolved",
-        schema: InstructorPayrollErrorResponse,
       },
       500: {
         description: "Internal server error",
@@ -1138,7 +1096,6 @@ const validatedRouteConfigs = {
   "/instructor-list": [getAllInstructorsConfig],
   "/instructors/:id/fees": [getInstructorFeesConfig, createInstructorFeeConfig],
   "/instructors/:id/fees/latest": [deleteLatestInstructorFeeConfig],
-  "/instructors/:id/payroll": [getInstructorPayrollConfig],
   "/instructor-list/past": [getAllPastInstructorsConfig],
   "/instructor-list/register": [registerInstructorConfig],
   "/instructor-list/register/withIcon": [registerInstructorWithIconConfig],

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -223,15 +223,15 @@ const instructorPayrollConfig = {
   paramsSchema: InstructorIdParams,
   querySchema: InstructorPayrollQuery,
   middleware: [
-    verifyAuthentication(AUTH_ROLES.I, {
+    verifyAuthentication(AUTH_ROLES.AI, {
       requireIdCheck: AUTH_ROLES.I,
     }),
   ] as RequestHandler[],
   handler: getInstructorPayrollController,
   openapi: {
-    summary: "Get own instructor payroll",
+    summary: "Get instructor payroll",
     description:
-      "Get the authenticated instructor's payroll summary for one month",
+      "Get an instructor's payroll summary for one month; instructors may only access their own payroll",
     responses: {
       200: {
         description: "Instructor payroll retrieved successfully",

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -48,6 +48,11 @@ import {
   UpdateInstructorTagsRequest,
 } from "../../../shared/schemas/instructors";
 import {
+  InstructorPayrollErrorResponse,
+  InstructorPayrollQuery,
+  InstructorPayrollResponse,
+} from "../../../shared/schemas/admins";
+import {
   type RequestWithId,
   parseId,
 } from "../../src/middlewares/parseId.middleware";
@@ -75,6 +80,7 @@ import {
   getTagCatalogController,
   updateInstructorTagsController,
 } from "../controllers/instructorTagsController";
+import { getInstructorPayrollController } from "../controllers/adminsController";
 
 const profilesConfig = {
   method: "get" as const,
@@ -207,6 +213,53 @@ const instructorProfileConfig = {
       },
       500: {
         description: "Internal server error",
+      },
+    },
+  },
+} as const;
+
+const instructorPayrollConfig = {
+  method: "get" as const,
+  paramsSchema: InstructorIdParams,
+  querySchema: InstructorPayrollQuery,
+  middleware: [
+    verifyAuthentication(AUTH_ROLES.I, {
+      requireIdCheck: AUTH_ROLES.I,
+    }),
+  ] as RequestHandler[],
+  handler: getInstructorPayrollController,
+  openapi: {
+    summary: "Get own instructor payroll",
+    description:
+      "Get the authenticated instructor's payroll summary for one month",
+    responses: {
+      200: {
+        description: "Instructor payroll retrieved successfully",
+        schema: InstructorPayrollResponse,
+      },
+      400: {
+        description: "Invalid query parameters",
+        schema: MessageErrorResponse,
+      },
+      401: {
+        description: "Unauthorized",
+        schema: MessageErrorResponse,
+      },
+      403: {
+        description: "Instructor ID does not match the authenticated user",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Instructor not found",
+        schema: MessageErrorResponse,
+      },
+      422: {
+        description: "Payroll data cannot be resolved",
+        schema: InstructorPayrollErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: ErrorResponse,
       },
     },
   },
@@ -723,6 +776,7 @@ const validatedRouteConfigs = {
   "/:id/calendar-slots": [calendarSlotsConfig],
   "/:id/calendar-classes": [calendarClassesConfig],
   "/:id/classes/:classId/same-date": [sameDateClassesConfig],
+  "/:id/payroll": [instructorPayrollConfig],
   "/:id/profile": [instructorProfileConfig],
   "/:id/schedules": [instructorSchedulesConfig, createScheduleConfig],
   "/:id/schedules/active": [activeScheduleConfig],

--- a/backend/src/test/api/admins/instructor-payroll.test.ts
+++ b/backend/src/test/api/admins/instructor-payroll.test.ts
@@ -32,7 +32,7 @@ const createInstructorCanceledClasses = async (
   );
 };
 
-describe("GET /admins/instructors/:id/payroll", () => {
+describe("GET /instructors/:id/payroll as admin", () => {
   it("returns both payroll periods for the requested month", async () => {
     const admin = await createAdmin();
     const instructor = await createInstructor();
@@ -116,7 +116,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -265,7 +265,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     const instructor = await createInstructor();
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-13" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(400);
@@ -325,7 +325,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -431,7 +431,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -487,7 +487,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -544,7 +544,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -584,7 +584,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -627,7 +627,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(200);
@@ -665,7 +665,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(422);
@@ -710,7 +710,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(422);
@@ -722,7 +722,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     const admin = await createAdmin();
 
     const response = await request(server)
-      .get("/admins/instructors/999999/payroll")
+      .get("/instructors/999999/payroll")
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(404);
@@ -746,7 +746,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(422);
@@ -784,7 +784,7 @@ describe("GET /admins/instructors/:id/payroll", () => {
     );
 
     const response = await request(server)
-      .get(`/admins/instructors/${instructor.id}/payroll`)
+      .get(`/instructors/${instructor.id}/payroll`)
       .query({ month: "2026-03" })
       .set("Cookie", await generateAuthCookie(admin.id, "admin"))
       .expect(422);

--- a/backend/src/test/api/instructors/payroll.test.ts
+++ b/backend/src/test/api/instructors/payroll.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { server } from "../../../server";
+import { createInstructor, generateAuthCookie } from "../../testUtils";
+
+describe("GET /instructors/:id/payroll", () => {
+  it("returns the authenticated instructor's own payroll", async () => {
+    const instructor = await createInstructor();
+
+    const response = await request(server)
+      .get(`/instructors/${instructor.id}/payroll`)
+      .query({ month: "2026-03" })
+      .set("Cookie", await generateAuthCookie(instructor.id, "instructor"))
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      instructorId: instructor.id,
+      month: "2026-03",
+      timezone: "Asia/Tokyo",
+    });
+    expect(response.body.periods).toHaveLength(2);
+  });
+
+  it("rejects access to another instructor's payroll", async () => {
+    const instructor = await createInstructor();
+    const otherInstructor = await createInstructor();
+
+    const response = await request(server)
+      .get(`/instructors/${otherInstructor.id}/payroll`)
+      .query({ month: "2026-03" })
+      .set("Cookie", await generateAuthCookie(instructor.id, "instructor"))
+      .expect(403);
+
+    expect(response.body).toEqual({ message: "Forbidden: user ID mismatch" });
+  });
+});

--- a/frontend/src/app/instructors/(protected)/payroll/page.tsx
+++ b/frontend/src/app/instructors/(protected)/payroll/page.tsx
@@ -4,7 +4,5 @@ import { getAuthenticatedUserId } from "@/lib/auth/sessionUtils";
 export default async function Page() {
   const instructorId = await getAuthenticatedUserId("instructor");
 
-  return (
-    <InstructorPayroll instructorId={instructorId} audience="instructor" />
-  );
+  return <InstructorPayroll instructorId={instructorId} />;
 }

--- a/frontend/src/app/instructors/(protected)/payroll/page.tsx
+++ b/frontend/src/app/instructors/(protected)/payroll/page.tsx
@@ -1,0 +1,10 @@
+import InstructorPayroll from "@/components/admins-dashboard/instructors-dashboard/InstructorPayroll";
+import { getAuthenticatedUserId } from "@/lib/auth/sessionUtils";
+
+export default async function Page() {
+  const instructorId = await getAuthenticatedUserId("instructor");
+
+  return (
+    <InstructorPayroll instructorId={instructorId} audience="instructor" />
+  );
+}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -308,8 +308,10 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
 
 export default function InstructorPayroll({
   instructorId,
+  audience = "admin",
 }: {
   instructorId: number;
+  audience?: "admin" | "instructor";
 }) {
   const [selectedMonth, setSelectedMonth] = useState(() =>
     getCurrentJstMonth(),
@@ -329,7 +331,12 @@ export default function InstructorPayroll({
 
     const loadPayroll = async () => {
       setIsLoading(true);
-      const response = await getInstructorPayroll(instructorId, requestedMonth);
+      const response = await getInstructorPayroll(
+        instructorId,
+        requestedMonth,
+        undefined,
+        audience,
+      );
 
       if (!isMounted) {
         return;
@@ -351,7 +358,7 @@ export default function InstructorPayroll({
     return () => {
       isMounted = false;
     };
-  }, [instructorId, requestedMonth]);
+  }, [audience, instructorId, requestedMonth]);
 
   const handleMonthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedMonth(event.target.value);

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -308,10 +308,8 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
 
 export default function InstructorPayroll({
   instructorId,
-  audience = "admin",
 }: {
   instructorId: number;
-  audience?: "admin" | "instructor";
 }) {
   const [selectedMonth, setSelectedMonth] = useState(() =>
     getCurrentJstMonth(),
@@ -331,12 +329,7 @@ export default function InstructorPayroll({
 
     const loadPayroll = async () => {
       setIsLoading(true);
-      const response = await getInstructorPayroll(
-        instructorId,
-        requestedMonth,
-        undefined,
-        audience,
-      );
+      const response = await getInstructorPayroll(instructorId, requestedMonth);
 
       if (!isMounted) {
         return;
@@ -358,7 +351,7 @@ export default function InstructorPayroll({
     return () => {
       isMounted = false;
     };
-  }, [audience, instructorId, requestedMonth]);
+  }, [instructorId, requestedMonth]);
 
   const handleMonthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedMonth(event.target.value);

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -681,13 +681,14 @@ export const getInstructorPayroll = async (
   instructorId: number,
   month: string,
   cookie?: string,
+  audience: "admin" | "instructor" = "admin",
 ): Promise<InstructorPayrollResponse | InstructorPayrollApiError> => {
   try {
     let apiURL;
     let headers;
     let response;
     const method = "GET";
-    const backendEndpoint = `/admins/instructors/${instructorId}/payroll?month=${month}`;
+    const backendEndpoint = `/${audience === "admin" ? "admins/instructors" : "instructors"}/${instructorId}/payroll?month=${month}`;
 
     if (cookie) {
       apiURL = `${BACKEND_ORIGIN}${backendEndpoint}`;

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -681,14 +681,13 @@ export const getInstructorPayroll = async (
   instructorId: number,
   month: string,
   cookie?: string,
-  audience: "admin" | "instructor" = "admin",
 ): Promise<InstructorPayrollResponse | InstructorPayrollApiError> => {
   try {
     let apiURL;
     let headers;
     let response;
     const method = "GET";
-    const backendEndpoint = `/${audience === "admin" ? "admins/instructors" : "instructors"}/${instructorId}/payroll?month=${month}`;
+    const backendEndpoint = `/instructors/${instructorId}/payroll?month=${month}`;
 
     if (cookie) {
       apiURL = `${BACKEND_ORIGIN}${backendEndpoint}`;

--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -11,6 +11,7 @@ import {
   BellIcon,
   ArrowUpOnSquareIcon,
   ClipboardDocumentCheckIcon,
+  BanknotesIcon,
 } from "@heroicons/react/24/outline";
 
 export function getLinks(
@@ -138,6 +139,11 @@ export function getLinks(
       name: "Schedule",
       href: "/instructors/availability",
       icon: ClockIcon,
+    },
+    {
+      name: "Payroll",
+      href: "/instructors/payroll",
+      icon: BanknotesIcon,
     },
     {
       name: "AaasoBo! Calendar",


### PR DESCRIPTION
## Summary

- add a Payroll destination to the instructor dashboard
- reuse the same payroll component, API function, calculation, and presentation for admins and instructors
- consolidate payroll access onto `GET /instructors/:id/payroll`
- allow admins to access any instructor's payroll while restricting instructors to their own ID
- cover admin access, instructor self-access, and rejected cross-instructor access

## Why

Payroll data was only available through the admin dashboard. Instructors had no dashboard route for the same calculated periods, class breakdowns, fee rates, totals, currencies, or error states.

Both dashboards now use one canonical instructor-resource endpoint. The endpoint accepts admin and instructor sessions; the existing authentication middleware applies an ID check only to instructors. Payroll remains calculated from current records whenever the page loads or the selected month changes, with no polling.

## Impact

Instructors can now view their own payroll under **Payroll** in the sidebar. They cannot retrieve another instructor's payroll. The existing admin Payroll tab continues to work through the same shared component and endpoint.

## Validation

- frontend format check
- frontend lint with zero warnings
- frontend unused export check
- frontend production build
- backend format
- backend unused export check
- targeted payroll suites: 15 tests passed
- backend API suite: 253 tests passed together; the unrelated large import fixture exceeded its 120-second timeout under parallel load
- isolated import suite: all 17 tests passed, including the large fixture in 106.9 seconds
- backend migration/bootstrap build

The frontend build emitted the existing non-fatal system-status API connection messages while the backend was unavailable and exited successfully.

Closes #586