### PR TITLE
Rename instructor English-background labels

### DIFF
--- a/backend/src/constants/englishBackground.ts
+++ b/backend/src/constants/englishBackground.ts
@@ -1,0 +1,7 @@
+import { EnglishBackground } from "../types";
+
+export const ENGLISH_BACKGROUND_LABELS: Record<EnglishBackground, string> = {
+  [EnglishBackground.NonNative]: "Program Original",
+  [EnglishBackground.NativeA]: "Native A",
+  [EnglishBackground.NativeB]: "Native B",
+};

--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -361,7 +361,7 @@ export const getAllInstructorsController = async (
     const data = instructors.map((instructor, number) => {
       const { id, name, nickname, email } = instructor;
       const englishBackgroundLabel: Record<EnglishBackground, string> = {
-        [EnglishBackground.NonNative]: "Non Native",
+        [EnglishBackground.NonNative]: "Program Original",
         [EnglishBackground.NativeA]: "Native A",
         [EnglishBackground.NativeB]: "Native B",
       };
@@ -839,7 +839,7 @@ export const getAllPlansController = async (_: Request, res: Response) => {
         plan;
       const [planNameJpn, planNameEng] = name.split(" / ");
       const englishBackgroundLabel: Record<EnglishBackground, string> = {
-        [EnglishBackground.NonNative]: "Non Native",
+        [EnglishBackground.NonNative]: "Program Original",
         [EnglishBackground.NativeA]: "Native A",
         [EnglishBackground.NativeB]: "Native B",
       };

--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -88,6 +88,7 @@ import type {
   RegisterEventRequest,
   UpdateEventRequest,
 } from "../../../shared/schemas/admins";
+import { ENGLISH_BACKGROUND_LABELS } from "../constants/englishBackground";
 import { EnglishBackground } from "../types";
 
 // Register Admin
@@ -360,18 +361,12 @@ export const getAllInstructorsController = async (
     // Transform the data structure.
     const data = instructors.map((instructor, number) => {
       const { id, name, nickname, email } = instructor;
-      const englishBackgroundLabel: Record<EnglishBackground, string> = {
-        [EnglishBackground.NonNative]: "Program Original",
-        [EnglishBackground.NativeA]: "Native A",
-        [EnglishBackground.NativeB]: "Native B",
-      };
-
       return {
         No: number + 1,
         ID: id,
         Instructor: nickname,
         English:
-          englishBackgroundLabel[
+          ENGLISH_BACKGROUND_LABELS[
             instructor.englishBackground as EnglishBackground
           ],
         "Full Name": name,
@@ -838,18 +833,13 @@ export const getAllPlansController = async (_: Request, res: Response) => {
       const { id, name, weeklyClassTimes, description, englishBackground } =
         plan;
       const [planNameJpn, planNameEng] = name.split(" / ");
-      const englishBackgroundLabel: Record<EnglishBackground, string> = {
-        [EnglishBackground.NonNative]: "Program Original",
-        [EnglishBackground.NativeA]: "Native A",
-        [EnglishBackground.NativeB]: "Native B",
-      };
-
       return {
         No: number + 1,
         ID: id,
         "Plan (Japanese)": planNameJpn,
         "Plan (English)": planNameEng,
-        English: englishBackgroundLabel[englishBackground as EnglishBackground],
+        English:
+          ENGLISH_BACKGROUND_LABELS[englishBackground as EnglishBackground],
         "Weekly Class Times": weeklyClassTimes,
         Description: description,
       };

--- a/backend/src/test/api/admins/instructor-list.test.ts
+++ b/backend/src/test/api/admins/instructor-list.test.ts
@@ -29,7 +29,7 @@ describe("GET /admins/instructor-list", () => {
         Instructor: instructor1.nickname,
         English:
           instructor1.englishBackground === EnglishBackground.NonNative
-            ? "Non Native"
+            ? "Program Original"
             : instructor1.englishBackground === EnglishBackground.NativeA
               ? "Native A"
               : "Native B",
@@ -42,7 +42,7 @@ describe("GET /admins/instructor-list", () => {
         Instructor: instructor2.nickname,
         English:
           instructor2.englishBackground === EnglishBackground.NonNative
-            ? "Non Native"
+            ? "Program Original"
             : instructor2.englishBackground === EnglishBackground.NativeA
               ? "Native A"
               : "Native B",

--- a/backend/src/test/api/admins/instructor-list.test.ts
+++ b/backend/src/test/api/admins/instructor-list.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../testUtils";
 import { prisma } from "../../setup";
 import { EnglishBackground } from "../../../types";
+import { ENGLISH_BACKGROUND_LABELS } from "../../../constants/englishBackground";
 
 describe("GET /admins/instructor-list", () => {
   it("succeed with multiple instructors", async () => {
@@ -28,11 +29,9 @@ describe("GET /admins/instructor-list", () => {
         ID: instructor1.id,
         Instructor: instructor1.nickname,
         English:
-          instructor1.englishBackground === EnglishBackground.NonNative
-            ? "Program Original"
-            : instructor1.englishBackground === EnglishBackground.NativeA
-              ? "Native A"
-              : "Native B",
+          ENGLISH_BACKGROUND_LABELS[
+            instructor1.englishBackground as EnglishBackground
+          ],
         "Full Name": instructor1.name,
         Email: instructor1.email,
       },
@@ -41,11 +40,9 @@ describe("GET /admins/instructor-list", () => {
         ID: instructor2.id,
         Instructor: instructor2.nickname,
         English:
-          instructor2.englishBackground === EnglishBackground.NonNative
-            ? "Program Original"
-            : instructor2.englishBackground === EnglishBackground.NativeA
-              ? "Native A"
-              : "Native B",
+          ENGLISH_BACKGROUND_LABELS[
+            instructor2.englishBackground as EnglishBackground
+          ],
         "Full Name": instructor2.name,
         Email: instructor2.email,
       },

--- a/backend/src/test/api/admins/plan-list.test.ts
+++ b/backend/src/test/api/admins/plan-list.test.ts
@@ -27,7 +27,7 @@ describe("GET /admins/plan-list", () => {
         "Plan (English)": plan1NameEng,
         English:
           plan1.englishBackground === EnglishBackground.NonNative
-            ? "Non Native"
+            ? "Program Original"
             : plan1.englishBackground === EnglishBackground.NativeA
               ? "Native A"
               : "Native B",
@@ -41,7 +41,7 @@ describe("GET /admins/plan-list", () => {
         "Plan (English)": plan2NameEng,
         English:
           plan2.englishBackground === EnglishBackground.NonNative
-            ? "Non Native"
+            ? "Program Original"
             : plan2.englishBackground === EnglishBackground.NativeA
               ? "Native A"
               : "Native B",

--- a/backend/src/test/api/admins/plan-list.test.ts
+++ b/backend/src/test/api/admins/plan-list.test.ts
@@ -4,6 +4,7 @@ import { server } from "../../../server";
 import { createAdmin, createPlan, generateAuthCookie } from "../../testUtils";
 import { prisma } from "../../setup";
 import { EnglishBackground } from "../../../types";
+import { ENGLISH_BACKGROUND_LABELS } from "../../../constants/englishBackground";
 
 describe("GET /admins/plan-list", () => {
   it("succeed with multiple plans", async () => {
@@ -26,11 +27,9 @@ describe("GET /admins/plan-list", () => {
         "Plan (Japanese)": plan1NameJpn,
         "Plan (English)": plan1NameEng,
         English:
-          plan1.englishBackground === EnglishBackground.NonNative
-            ? "Program Original"
-            : plan1.englishBackground === EnglishBackground.NativeA
-              ? "Native A"
-              : "Native B",
+          ENGLISH_BACKGROUND_LABELS[
+            plan1.englishBackground as EnglishBackground
+          ],
         "Weekly Class Times": plan1.weeklyClassTimes,
         Description: plan1.description,
       },
@@ -40,11 +39,9 @@ describe("GET /admins/plan-list", () => {
         "Plan (Japanese)": plan2NameJpn,
         "Plan (English)": plan2NameEng,
         English:
-          plan2.englishBackground === EnglishBackground.NonNative
-            ? "Program Original"
-            : plan2.englishBackground === EnglishBackground.NativeA
-              ? "Native A"
-              : "Native B",
+          ENGLISH_BACKGROUND_LABELS[
+            plan2.englishBackground as EnglishBackground
+          ],
         "Weekly Class Times": plan2.weeklyClassTimes,
         Description: plan2.description,
       },

--- a/frontend/src/app/admins/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/admins/(protected)/dashboard/page.tsx
@@ -77,7 +77,7 @@ function calcInstructorEnglishBackgroundCounts(
     (counts, instructor) => {
       const normalized = instructor.English.trim().toLowerCase();
 
-      if (normalized === "non native") {
+      if (normalized === "program original") {
         counts.nonNative += 1;
       } else if (normalized === "native a") {
         counts.nativeA += 1;

--- a/frontend/src/app/admins/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/admins/(protected)/dashboard/page.tsx
@@ -11,6 +11,10 @@ import { getInstructorProfiles } from "@/lib/api/instructorsApi";
 import { authenticateUserSession } from "@/lib/auth/sessionUtils";
 import { getCookie } from "@/proxy";
 import { defaultUserImageUrl } from "@/lib/data/data";
+import {
+  ENGLISH_BACKGROUND_LABELS,
+  EnglishBackground,
+} from "@/lib/data/englishBackground";
 
 const MONTH_WINDOW = 12;
 
@@ -77,7 +81,10 @@ function calcInstructorEnglishBackgroundCounts(
     (counts, instructor) => {
       const normalized = instructor.English.trim().toLowerCase();
 
-      if (normalized === "program original") {
+      if (
+        normalized ===
+        ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative].toLowerCase()
+      ) {
         counts.nonNative += 1;
       } else if (normalized === "native a") {
         counts.nativeA += 1;

--- a/frontend/src/components/admins-dashboard/dashboard/DashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/dashboard/DashboardClient.tsx
@@ -4,6 +4,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { UserIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import styles from "./DashboardClient.module.scss";
+import {
+  ENGLISH_BACKGROUND_LABELS,
+  EnglishBackground,
+} from "@/lib/data/englishBackground";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { defaultUserImageUrl } from "@/lib/data/data";
@@ -350,21 +354,21 @@ export default function DashboardClient({
         <article className={styles.kpiCard}>
           <UserIcon className={styles.kpiIcon} />
           <div>
-            <p>Program Original</p>
+            <p>{ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative]}</p>
             <strong>{metrics.instructorsByEnglishBackground.nonNative}</strong>
           </div>
         </article>
         <article className={styles.kpiCard}>
           <UserIcon className={styles.kpiIcon} />
           <div>
-            <p>Native A</p>
+            <p>{ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA]}</p>
             <strong>{metrics.instructorsByEnglishBackground.nativeA}</strong>
           </div>
         </article>
         <article className={styles.kpiCard}>
           <UserIcon className={styles.kpiIcon} />
           <div>
-            <p>Native B</p>
+            <p>{ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB]}</p>
             <article>
               <strong>{metrics.instructorsByEnglishBackground.nativeB}</strong>
             </article>
@@ -399,9 +403,18 @@ export default function DashboardClient({
           <div className={styles.englishBackgroundFilterGroup}>
             {[
               { value: "all", label: "All" },
-              { value: "non-native", label: "Program Original" },
-              { value: "native-a", label: "Native A" },
-              { value: "native-b", label: "Native B" },
+              {
+                value: "non-native",
+                label: ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative],
+              },
+              {
+                value: "native-a",
+                label: ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA],
+              },
+              {
+                value: "native-b",
+                label: ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB],
+              },
             ].map((option) => (
               <RadioButton
                 key={option.value}

--- a/frontend/src/components/admins-dashboard/dashboard/DashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/dashboard/DashboardClient.tsx
@@ -350,7 +350,7 @@ export default function DashboardClient({
         <article className={styles.kpiCard}>
           <UserIcon className={styles.kpiIcon} />
           <div>
-            <p>Non Native</p>
+            <p>Program Original</p>
             <strong>{metrics.instructorsByEnglishBackground.nonNative}</strong>
           </div>
         </article>
@@ -399,7 +399,7 @@ export default function DashboardClient({
           <div className={styles.englishBackgroundFilterGroup}>
             {[
               { value: "all", label: "All" },
-              { value: "non-native", label: "Non Native" },
+              { value: "non-native", label: "Program Original" },
               { value: "native-a", label: "Native A" },
               { value: "native-b", label: "Native B" },
             ].map((option) => (

--- a/frontend/src/components/admins-dashboard/plans-dashboard/PlanProfile.tsx
+++ b/frontend/src/components/admins-dashboard/plans-dashboard/PlanProfile.tsx
@@ -64,7 +64,7 @@ function PlanProfile({
   );
 
   const englishBackgroundLabels = [
-    "Non Native",
+    "Program Original",
     "Native A",
     "Native B",
   ] as const;

--- a/frontend/src/components/admins-dashboard/plans-dashboard/PlanProfile.tsx
+++ b/frontend/src/components/admins-dashboard/plans-dashboard/PlanProfile.tsx
@@ -23,6 +23,7 @@ import {
 import { confirmAlert } from "@/lib/utils/alertUtils";
 import { getLocalizedText } from "@/lib/utils/stringUtils";
 import { EnglishBackground } from "@/types";
+import { ENGLISH_BACKGROUND_LABELS } from "@/lib/data/englishBackground";
 
 function PlanProfile({
   plan,
@@ -62,12 +63,6 @@ function PlanProfile({
   const [localMessages, setLocalMessages] = useState<Record<string, string>>(
     {},
   );
-
-  const englishBackgroundLabels = [
-    "Program Original",
-    "Native A",
-    "Native B",
-  ] as const;
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -285,7 +280,7 @@ function PlanProfile({
                         }
                         onChange={handleRadioChange}
                         label={
-                          englishBackgroundLabels[EnglishBackground.NonNative]
+                          ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative]
                         }
                         className={styles.planTypeRadio}
                       />
@@ -298,7 +293,7 @@ function PlanProfile({
                         }
                         onChange={handleRadioChange}
                         label={
-                          englishBackgroundLabels[EnglishBackground.NativeA]
+                          ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA]
                         }
                         className={styles.planTypeRadio}
                       />
@@ -311,14 +306,18 @@ function PlanProfile({
                         }
                         onChange={handleRadioChange}
                         label={
-                          englishBackgroundLabels[EnglishBackground.NativeB]
+                          ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB]
                         }
                         className={styles.planTypeRadio}
                       />
                     </>
                   ) : (
                     <h4 className={styles.planDescription__text}>
-                      {englishBackgroundLabels[latestPlan.englishBackground]}
+                      {
+                        ENGLISH_BACKGROUND_LABELS[
+                          latestPlan.englishBackground as EnglishBackground
+                        ]
+                      }
                     </h4>
                   )}
                 </div>

--- a/frontend/src/components/customers-dashboard/regular-classes/AddSubscription.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/AddSubscription.tsx
@@ -8,6 +8,8 @@ import { getAllPlans } from "@/lib/api/plansApi";
 import { registerSubscription } from "@/lib/api/subscriptionsApi";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
 import InputField from "@/components/elements/inputField/InputField";
+import { ENGLISH_BACKGROUND_LABELS } from "@/lib/data/englishBackground";
+import { EnglishBackground } from "@/types";
 
 function AddSubscription({
   customerId,
@@ -128,20 +130,11 @@ function AddSubscription({
                     <option disabled value="">
                       Select a category
                     </option>
-                    {englishBGs.map((bg) => {
-                      const label =
-                        bg === 1
-                          ? "Native A"
-                          : bg === 2
-                            ? "Native B"
-                            : "Non Native";
-
-                      return (
-                        <option key={bg} value={bg}>
-                          {label}
-                        </option>
-                      );
-                    })}
+                    {englishBGs.map((bg) => (
+                      <option key={bg} value={bg}>
+                        {ENGLISH_BACKGROUND_LABELS[bg as EnglishBackground]}
+                      </option>
+                    ))}
                   </select>
                 </div>
                 <div className={styles.fieldGroup}>

--- a/frontend/src/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/components/features/registerForm/RegisterForm.tsx
@@ -65,7 +65,7 @@ const RegisterForm = ({
     EnglishBackground.NonNative,
   );
   const englishBackgroundLabels = [
-    "Non Native",
+    "Program Original",
     "Native A",
     "Native B",
   ] as const;

--- a/frontend/src/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/components/features/registerForm/RegisterForm.tsx
@@ -33,6 +33,7 @@ import Uploader from "./uploadImages/Uploader";
 import { EnglishBackground } from "@/types";
 import RadioButton from "../../elements/radioButton/RadioButton";
 import TextAreaInput from "../../elements/textAreaInput/TextAreaInput";
+import { ENGLISH_BACKGROUND_LABELS } from "@/lib/data/englishBackground";
 
 const RegisterForm = ({
   categoryType,
@@ -64,12 +65,6 @@ const RegisterForm = ({
   const [englishBackground, setEnglishBackground] = useState<EnglishBackground>(
     EnglishBackground.NonNative,
   );
-  const englishBackgroundLabels = [
-    "Program Original",
-    "Native A",
-    "Native B",
-  ] as const;
-
   const handleRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newEnglishBackground = Number(e.target.value);
     setEnglishBackground(newEnglishBackground);
@@ -368,7 +363,7 @@ const RegisterForm = ({
                   value={EnglishBackground.NonNative}
                   checked={englishBackground === EnglishBackground.NonNative}
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NonNative]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative]}
                   className={styles.englishBackgroundRadio}
                 />
                 <RadioButton
@@ -376,7 +371,7 @@ const RegisterForm = ({
                   value={EnglishBackground.NativeA}
                   checked={englishBackground === EnglishBackground.NativeA}
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NativeA]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA]}
                   className={styles.englishBackgroundRadio}
                 />
                 <RadioButton
@@ -384,7 +379,7 @@ const RegisterForm = ({
                   value={EnglishBackground.NativeB}
                   checked={englishBackground === EnglishBackground.NativeB}
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NativeB]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB]}
                   className={styles.englishBackgroundRadio}
                 />
               </div>
@@ -476,7 +471,7 @@ const RegisterForm = ({
               value={EnglishBackground.NonNative}
               checked={englishBackground === EnglishBackground.NonNative}
               onChange={handleRadioChange}
-              label={englishBackgroundLabels[EnglishBackground.NonNative]}
+              label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative]}
               className={styles.englishBackgroundRadio}
             />
             <RadioButton
@@ -484,7 +479,7 @@ const RegisterForm = ({
               value={EnglishBackground.NativeA}
               checked={englishBackground === EnglishBackground.NativeA}
               onChange={handleRadioChange}
-              label={englishBackgroundLabels[EnglishBackground.NativeA]}
+              label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA]}
               className={styles.englishBackgroundRadio}
             />
             <RadioButton
@@ -492,7 +487,7 @@ const RegisterForm = ({
               value={EnglishBackground.NativeB}
               checked={englishBackground === EnglishBackground.NativeB}
               onChange={handleRadioChange}
-              label={englishBackgroundLabels[EnglishBackground.NativeB]}
+              label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB]}
               className={styles.englishBackgroundRadio}
             />
           </div>

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -115,7 +115,7 @@ function InstructorProfile({
   const { language } = useLanguage();
   const formRef = useRef<HTMLFormElement>(null);
   const englishBackgroundLabels = [
-    "Non Native",
+    "Program Original",
     "Native A",
     "Native B",
   ] as const;

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -36,6 +36,7 @@ import InstructorFeeRates from "./InstructorFeeRates";
 import { EnglishBackground } from "@/types";
 import RadioButton from "../../elements/radioButton/RadioButton";
 import TextAreaInput from "../../elements/textAreaInput/TextAreaInput";
+import { ENGLISH_BACKGROUND_LABELS } from "@/lib/data/englishBackground";
 
 // Define the specific string fields that are editable in this component
 type EditableInstructorFields =
@@ -114,11 +115,6 @@ function InstructorProfile({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { language } = useLanguage();
   const formRef = useRef<HTMLFormElement>(null);
-  const englishBackgroundLabels = [
-    "Program Original",
-    "Native A",
-    "Native B",
-  ] as const;
   const englishBackgroundClassNames = ["", "nativeA", "nativeB"] as const;
 
   const handleEditClick = () => {
@@ -293,8 +289,8 @@ function InstructorProfile({
                       }`}
                   >
                     {
-                      englishBackgroundLabels[
-                        latestInstructor.englishBackground
+                      ENGLISH_BACKGROUND_LABELS[
+                        latestInstructor.englishBackground as EnglishBackground
                       ]
                     }
                   </div>
@@ -328,7 +324,7 @@ function InstructorProfile({
                     EnglishBackground.NonNative
                   }
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NonNative]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NonNative]}
                   className={styles.englishBackgroundRadio}
                 />
                 <RadioButton
@@ -339,7 +335,7 @@ function InstructorProfile({
                     EnglishBackground.NativeA
                   }
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NativeA]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeA]}
                   className={styles.englishBackgroundRadio}
                 />
                 <RadioButton
@@ -350,7 +346,7 @@ function InstructorProfile({
                     EnglishBackground.NativeB
                   }
                   onChange={handleRadioChange}
-                  label={englishBackgroundLabels[EnglishBackground.NativeB]}
+                  label={ENGLISH_BACKGROUND_LABELS[EnglishBackground.NativeB]}
                   className={styles.englishBackgroundRadio}
                 />
               </>

--- a/frontend/src/lib/data/englishBackground.ts
+++ b/frontend/src/lib/data/englishBackground.ts
@@ -1,0 +1,9 @@
+import { EnglishBackground } from "@/types";
+
+export { EnglishBackground };
+
+export const ENGLISH_BACKGROUND_LABELS: Record<EnglishBackground, string> = {
+  [EnglishBackground.NonNative]: "Program Original",
+  [EnglishBackground.NativeA]: "Native A",
+  [EnglishBackground.NativeB]: "Native B",
+};


### PR DESCRIPTION
## Summary

- display `Program Original` instead of `Non Native` across instructor and plan lists, forms, profiles, dashboard metrics, filters, reports, and plan selection
- centralize English-background display labels in one typed frontend mapping and one typed backend mapping
- preserve the existing enum values and `non-native` filter key so stored data and filtering behavior remain unchanged
- update dashboard aggregation and API expectations for the new display label

## Impact

Users see the three requested choices as `Program Original`, `Native A`, and `Native B`. Display text is no longer duplicated across components or controllers, and no data migration is required.

## Validation

- frontend format check passed
- frontend lint passed with zero warnings
- frontend unused-code check passed
- frontend production build passed
- backend format and unused-code checks passed
- full backend API suite passed (27 files, 252 tests)
- backend production build, migrations, and bootstrap passed

Closes #581