### PR TITLE
Fix duplicate instructor profile scrollbars

### DIFF
--- a/frontend/src/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
+++ b/frontend/src/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
@@ -6,7 +6,5 @@
   align-items: flex-start;
   background-color: #fff;
   padding: 40px;
-  max-height: 90vh;
   max-width: 100vh;
-  overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary

- remove the profile-specific viewport height and overflow rules
- rely on the shared modal as the single vertical scroll container
- preserve the existing profile layout and width constraint

## Root cause

The shared modal already applies `max-height` and `overflow-y: auto`. The instructor-profile wrapper added its own `max-height: 90vh` and `overflow-x: hidden`; per CSS overflow behavior, that also made its vertical overflow scrollable. On common desktop viewport heights, both nested elements overflowed and rendered two right-side scrollbars.

## Impact

Instructor profiles now scroll through one modal container instead of two nested containers.

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`
- Playwright verification at 1440×1080 and 1280×720 confirmed the shared modal is scrollable and the inner profile wrapper is not