### PR TITLE
Add all-columns customer list filter

### DIFF
--- a/frontend/src/components/admins-dashboard/ListTable.tsx
+++ b/frontend/src/components/admins-dashboard/ListTable.tsx
@@ -24,6 +24,8 @@ import GenerateClassesForm from "./GenerateClassesForm";
 import FilterButton from "./FilterButton";
 import { OMIT_CLASS_STATUSES, PAGE_SIZE_OPTIONS } from "@/lib/data/data";
 
+const ALL_COLUMNS_FILTER = "__all_columns__";
+
 function useTable<TData extends RowData>(options: TableOptions<TData>) {
   const resolvedOptions: TableOptionsResolved<TData> = {
     state: {},
@@ -71,7 +73,9 @@ function ListTable({
 }: ListTableProps) {
   const [currentData, setCurrentData] = useState<any[]>(fetchedData);
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [filterColumn, setFilterColumn] = useState<string>("0");
+  const [filterColumn, setFilterColumn] = useState<string>(
+    listType === "Customer List" ? ALL_COLUMNS_FILTER : "0",
+  );
   const [filterValue, setFilterValue] = useState<string>("");
   const [pagination, setPagination] = useState({
     pageIndex: 0, // Initial page index
@@ -252,22 +256,39 @@ function ListTable({
     const prioritizedColumns = ["Children", "Customer"];
 
     return [
+      ALL_COLUMNS_FILTER,
       ...prioritizedColumns.filter((key) => availableColumns.includes(key)),
-      ...availableColumns.filter((key) => !prioritizedColumns.includes(key)),
+      ...availableColumns.filter(
+        (key) => key !== "No" && !prioritizedColumns.includes(key),
+      ),
     ];
   }, [currentData, omitItems, listType]);
 
   // Configure the filter
   const filteredData = useMemo(
     () =>
-      currentData.filter((eachData) =>
-        filterColumn && filterValue
+      currentData.filter((eachData) => {
+        if (!filterValue) return true;
+
+        const normalizedFilterValue = filterValue.toLowerCase();
+
+        if (filterColumn === ALL_COLUMNS_FILTER) {
+          return Object.keys(eachData)
+            .filter((key) => !omitItems.includes(key))
+            .some((key) =>
+              String(eachData[key])
+                .toLowerCase()
+                .includes(normalizedFilterValue),
+            );
+        }
+
+        return filterColumn !== "0"
           ? String(eachData[filterColumn])
               .toLowerCase()
-              .includes(filterValue.toLowerCase())
-          : true,
-      ),
-    [currentData, filterColumn, filterValue],
+              .includes(normalizedFilterValue)
+          : true;
+      }),
+    [currentData, filterColumn, filterValue, omitItems],
   );
 
   // Define the table configuration
@@ -285,17 +306,9 @@ function ListTable({
     onPaginationChange: setPagination, // Update the pagination state when internal APIs mutate the pagination state
   });
 
-  // Change the option color when selected
-  const changeOptionColor = (optionTag: HTMLSelectElement) => {
-    if (parseInt(optionTag.value) !== 0) {
-      optionTag.style.color = "#000000";
-    }
-  };
-
   // Handle the filter change
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setFilterColumn(event.target.value);
-    changeOptionColor(event.target);
   };
 
   // Render the modal component based on the modal type
@@ -329,13 +342,17 @@ function ListTable({
       <div className={styles.container}>
         <div className={styles.topContainer}>
           <div className={styles.filterContainer}>
-            <select value={filterColumn} onChange={handleChange}>
+            <select
+              value={filterColumn}
+              onChange={handleChange}
+              style={{ color: filterColumn === "0" ? "#888888" : "#000000" }}
+            >
               <option disabled value="0">
                 Select a column
               </option>
               {filterColumns.map((key) => (
                 <option key={key} value={key}>
-                  {key}
+                  {key === ALL_COLUMNS_FILTER ? "All Columns" : key}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## Summary

- replace the Customer List’s `No` filter option with `All Columns`
- make `All Columns` the default and place it first in the filter list
- search across all visible Customer List fields when that option is selected
- keep `Children` and `Customer` as the next prioritized column filters

## Why

The `No` option represented the table row number and was unclear in a filtering context. A real all-columns option better matches the common broad-search workflow and is easier to discover as the first/default choice.

This is a follow-up to #591.

## Validation

- `npm run format`
- frontend CI-equivalent gate: Prettier format check, ESLint with zero warnings, unused-code analysis, and production build

The production build completed successfully; expected system-status API connection warnings appeared because the local backend was not running.