### PR TITLE
Extend incremental import fixtures with regular classes

### DIFF
--- a/backend/src/seed/generateIncrementalImportFixture.ts
+++ b/backend/src/seed/generateIncrementalImportFixture.ts
@@ -3,28 +3,69 @@ import path from "node:path";
 import JSZip from "jszip";
 import { NORMALIZED_HEADERS } from "../services/adminImport/normalize";
 
-type CustomerFileName = "customers.csv" | "children.csv" | "subscriptions.csv";
+type CustomerFileName =
+  | "customers.csv"
+  | "children.csv"
+  | "subscriptions.csv"
+  | "recurring_classes.csv"
+  | "recurring_class_attendance.csv";
+type RequiredCustomerFileName =
+  | "customers.csv"
+  | "children.csv"
+  | "subscriptions.csv";
+type OptionalCustomerFileName = Exclude<
+  CustomerFileName,
+  RequiredCustomerFileName
+>;
+type CustomerFiles = Record<RequiredCustomerFileName, string> &
+  Partial<Record<OptionalCustomerFileName, string>>;
 type InstructorFileName =
   | "instructors.csv"
   | "instructor_fees.csv"
   | "instructor_schedules.csv";
 
 type CsvRow = Record<string, string>;
+type FakerLike = {
+  seed: (seed: number) => void;
+  person: {
+    firstName: () => string;
+    lastName: () => string;
+  };
+};
 
 const CUSTOMER_FILES: readonly CustomerFileName[] = [
   "customers.csv",
   "children.csv",
   "subscriptions.csv",
+  "recurring_classes.csv",
+  "recurring_class_attendance.csv",
 ];
 const INSTRUCTOR_FILES: readonly InstructorFileName[] = [
   "instructors.csv",
   "instructor_fees.csv",
   "instructor_schedules.csv",
 ];
-const DEFAULT_PLAN_NAME = "月5,980円プラン / 5,980 yen/month Plan";
+const INCREMENTAL_PLAN_NAME = "月5,980円プラン / 5,980 yen/month Plan";
 const DEFAULT_START_DATE = "2026-01-01";
 const DEFAULT_COUNT = 5;
 const MAX_COUNT = 99_999;
+const DEFAULT_START_ID = 1;
+const MAX_ID = 99_999;
+const FAKER_SEED = 20250301;
+const PATTERN_A_SLOTS = buildPatternSlots(
+  ["1", "2", "3"],
+  ["16:00", "16:30", "17:00", "17:30", "18:00"],
+);
+const PATTERN_B_SLOTS = [
+  ...buildPatternSlots(
+    ["4", "5"],
+    ["18:30", "19:00", "19:30", "20:00", "20:30"],
+  ),
+  ...buildPatternSlots(
+    ["6"],
+    ["09:00", "09:30", "10:00", "10:30", "11:00", "11:30"],
+  ),
+];
 
 const HEADERS: Record<
   CustomerFileName | InstructorFileName,
@@ -35,35 +76,83 @@ const HEADERS: Record<
   "subscriptions.csv": NORMALIZED_HEADERS["subscriptions.csv"].map((header) =>
     header === "plan_ref" ? "plan_name" : header,
   ),
+  "recurring_classes.csv": [
+    "recurring_class_ref",
+    "subscription_ref",
+    "instructor_id",
+    "start_at",
+    "end_at",
+  ],
+  "recurring_class_attendance.csv":
+    NORMALIZED_HEADERS["recurring_class_attendance.csv"],
   "instructors.csv": NORMALIZED_HEADERS["instructors.csv"],
   "instructor_fees.csv": NORMALIZED_HEADERS["instructor_fees.csv"],
   "instructor_schedules.csv": NORMALIZED_HEADERS["instructor_schedules.csv"],
 };
 
-export type GenerateIncrementalImportFixtureOptions = {
-  customerCount?: number;
-  instructorCount?: number;
-  namespace?: string;
-  planName?: string;
+type IncrementalImportFixtureTarget = "customers" | "instructors";
+
+type GenerateIncrementalImportFixtureBaseOptions = {
+  number?: number;
+  startId?: number;
   startDate?: string;
 };
 
-export type GeneratedIncrementalImportFixture = {
-  customerFiles: Record<CustomerFileName, string>;
-  instructorFiles: Record<InstructorFileName, string>;
+export type GenerateIncrementalCustomerFixtureOptions =
+  GenerateIncrementalImportFixtureBaseOptions & {
+    target: "customers";
+    startInstructorId?: number;
+    endInstructorId?: number;
+  };
+
+export type GenerateIncrementalInstructorFixtureOptions =
+  GenerateIncrementalImportFixtureBaseOptions & {
+    target: "instructors";
+  };
+
+export type GenerateIncrementalImportFixtureOptions =
+  | GenerateIncrementalCustomerFixtureOptions
+  | GenerateIncrementalInstructorFixtureOptions;
+
+export type GeneratedIncrementalCustomerFixture = {
+  target: "customers";
+  customerFiles: CustomerFiles;
   customerZip: Buffer;
-  instructorZip: Buffer;
   customerZipFileName: string;
+};
+
+export type GeneratedIncrementalInstructorFixture = {
+  target: "instructors";
+  instructorFiles: Record<InstructorFileName, string>;
+  instructorZip: Buffer;
   instructorZipFileName: string;
 };
 
-type CliArgs = Required<GenerateIncrementalImportFixtureOptions> & {
+export type GeneratedIncrementalImportFixture =
+  | GeneratedIncrementalCustomerFixture
+  | GeneratedIncrementalInstructorFixture;
+
+type CliArgs = Required<GenerateIncrementalImportFixtureBaseOptions> & {
+  target: IncrementalImportFixtureTarget;
   outDir: string;
+  startInstructorId?: number;
+  endInstructorId?: number;
 };
 
 function validateCount(label: string, count: number) {
   if (!Number.isSafeInteger(count) || count < 1 || count > MAX_COUNT) {
     throw new Error(`${label} must be an integer between 1 and ${MAX_COUNT}`);
+  }
+}
+
+function validateIdRange(label: string, startId: number, count: number) {
+  if (!Number.isSafeInteger(startId) || startId < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  if (startId + count - 1 > MAX_ID) {
+    throw new Error(
+      `${label} and count must not generate an ID greater than ${MAX_ID}`,
+    );
   }
 }
 
@@ -77,14 +166,6 @@ function validateStartDate(value: string) {
     !parsed.toISOString().startsWith(value)
   ) {
     throw new Error("startDate must be a valid calendar date");
-  }
-}
-
-function validateNamespace(value: string) {
-  if (!/^[a-z0-9-]+$/.test(value)) {
-    throw new Error(
-      "namespace must contain only lowercase letters, numbers, and hyphens",
-    );
   }
 }
 
@@ -118,85 +199,214 @@ function ref(prefix: "CU" | "CH" | "SU" | "IN", index: number) {
   return `${prefix}${String(index).padStart(4, "0")}`;
 }
 
-function padded(index: number) {
-  return String(index).padStart(5, "0");
+function sanitizeChildFirstName(raw: string, fallbackIndex: number) {
+  const compact = raw
+    .replace(/[.&]/g, "")
+    .trim()
+    .split(/\s+/)[0]
+    ?.replace(/[^A-Za-z]/g, "");
+  return compact || `Child${fallbackIndex}`;
 }
 
-function namespaceCode(namespace: string) {
-  let hash = 0;
-  for (const character of namespace) {
-    hash = (hash * 31 + character.charCodeAt(0)) % 100_000;
+function sanitizeEnglishNamePart(raw: string, fallback: string) {
+  const compact = raw.replace(/[^A-Za-z]/g, "");
+  return compact || fallback;
+}
+
+function prepareCustomerFakers(
+  fakerJa: FakerLike,
+  fakerEn: FakerLike,
+  startId: number,
+) {
+  fakerJa.seed(FAKER_SEED);
+  fakerEn.seed(FAKER_SEED);
+  for (let index = 1; index < startId; index += 1) {
+    fakerJa.person.lastName();
+    fakerJa.person.firstName();
+    fakerEn.person.firstName();
   }
-  return String(hash).padStart(5, "0");
+}
+
+function prepareInstructorFaker(fakerEn: FakerLike, startId: number) {
+  fakerEn.seed(FAKER_SEED);
+  const nicknameCounts = new Map<string, number>();
+  for (let index = 1; index < startId; index += 1) {
+    const first = sanitizeEnglishNamePart(
+      fakerEn.person.firstName(),
+      `Alex${index}`,
+    );
+    fakerEn.person.lastName();
+    nicknameCounts.set(first, (nicknameCounts.get(first) ?? 0) + 1);
+  }
+  return nicknameCounts;
+}
+
+function buildPatternSlots(weekdays: string[], startTimes: string[]) {
+  return weekdays.flatMap((weekday) =>
+    startTimes.map((startTime) => [weekday, startTime] as const),
+  );
+}
+
+function slotsForInstructor(index: number) {
+  return index % 2 === 1 ? PATTERN_A_SLOTS : PATTERN_B_SLOTS;
+}
+
+function formatDateOnly(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function nextDateOnOrAfter(value: string, weekday: number) {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + ((weekday - date.getUTCDay() + 7) % 7));
+  return formatDateOnly(date);
+}
+
+function recurringClassRows(
+  count: number,
+  startId: number,
+  startDate: string,
+  startInstructorId: number,
+  endInstructorId: number,
+) {
+  const recurringClasses: CsvRow[] = [];
+  const attendance: CsvRow[] = [];
+  const instructorCount = endInstructorId - startInstructorId + 1;
+  const recurringClassCount = count * 2;
+
+  for (let index = 0; index < recurringClassCount; index += 1) {
+    const instructorId = startInstructorId + (index % instructorCount);
+    const slotIndex = Math.floor(index / instructorCount);
+    const slot = slotsForInstructor(instructorId)[slotIndex];
+    if (!slot) {
+      throw new Error(
+        `Instructor range ${startInstructorId}-${endInstructorId} has insufficient unique slots for ${recurringClassCount} regular classes`,
+      );
+    }
+    const customerOffset = Math.floor(index / 2);
+    const customerId = startId + customerOffset;
+    const recurringClassId = (customerId - 1) * 2 + (index % 2) + 1;
+    const recurringClassRef = `RC${String(recurringClassId).padStart(4, "0")}`;
+    const [weekday, startTime] = slot;
+    const firstDate = nextDateOnOrAfter(startDate, Number(weekday));
+
+    recurringClasses.push({
+      recurring_class_ref: recurringClassRef,
+      subscription_ref: ref("SU", customerId),
+      instructor_id: String(instructorId),
+      start_at: `${firstDate}T${startTime}:00+09:00`,
+      end_at: "",
+    });
+    attendance.push({
+      recurring_class_ref: recurringClassRef,
+      child_ref: ref("CH", customerId),
+    });
+  }
+
+  return { recurringClasses, attendance };
 }
 
 function customerRows(
+  fakerJa: FakerLike,
+  fakerEn: FakerLike,
   count: number,
-  namespace: string,
-  planName: string,
+  startId: number,
   startDate: string,
+  instructorRange?: { start: number; end: number },
 ) {
   const customers: CsvRow[] = [];
   const children: CsvRow[] = [];
   const subscriptions: CsvRow[] = [];
 
-  for (let index = 1; index <= count; index += 1) {
-    const suffix = padded(index);
+  for (let offset = 0; offset < count; offset += 1) {
+    const index = startId + offset;
     const customerRef = ref("CU", index);
     const lowerRef = customerRef.toLowerCase();
     customers.push({
       customer_ref: customerRef,
-      name: `Incremental Customer ${suffix}`,
+      name: `${fakerJa.person.lastName()} ${fakerJa.person.firstName()}`,
       email: `${lowerRef}@example.com`,
       temp_password: `Temp-${lowerRef}`,
-      prefecture: index % 2 === 0 ? "Osaka" : "Tokyo",
+      prefecture: "東京都 / Tokyo",
       termination_at: "",
       has_seen_welcome: index % 2 === 0 ? "true" : "false",
     });
     children.push({
       child_ref: ref("CH", index),
       customer_ref: customerRef,
-      name: `Child ${suffix}`,
+      name: sanitizeChildFirstName(fakerEn.person.firstName(), index),
       birthdate: `2015-01-${String(((index - 1) % 28) + 1).padStart(2, "0")}`,
-      personal_info: `Dummy child for ${namespace}`,
+      personal_info: "Deterministic dummy child",
     });
     subscriptions.push({
       subscription_ref: ref("SU", index),
       customer_ref: customerRef,
-      plan_name: planName,
-      select_type: `https://example.com/incremental/${namespace}/subscriptions/${suffix}`,
+      plan_name: INCREMENTAL_PLAN_NAME,
+      select_type: `https://example.com/subscriptions/${lowerRef}`,
       start_at: `${startDate}T00:00:00+09:00`,
       end_at: "",
     });
   }
 
-  return {
+  const files: CustomerFiles = {
     "customers.csv": toCsv("customers.csv", customers),
     "children.csv": toCsv("children.csv", children),
     "subscriptions.csv": toCsv("subscriptions.csv", subscriptions),
-  } satisfies Record<CustomerFileName, string>;
+  };
+  if (instructorRange) {
+    const recurring = recurringClassRows(
+      count,
+      startId,
+      startDate,
+      instructorRange.start,
+      instructorRange.end,
+    );
+    files["recurring_classes.csv"] = toCsv(
+      "recurring_classes.csv",
+      recurring.recurringClasses,
+    );
+    files["recurring_class_attendance.csv"] = toCsv(
+      "recurring_class_attendance.csv",
+      recurring.attendance,
+    );
+  }
+  return files;
 }
 
-function instructorRows(count: number, namespace: string, startDate: string) {
+function instructorRows(
+  fakerEn: FakerLike,
+  nicknameCounts: Map<string, number>,
+  count: number,
+  startId: number,
+  startDate: string,
+) {
   const instructors: CsvRow[] = [];
   const fees: CsvRow[] = [];
   const schedules: CsvRow[] = [];
-  const code = namespaceCode(namespace);
-
-  for (let index = 1; index <= count; index += 1) {
-    const suffix = padded(index);
+  for (let offset = 0; offset < count; offset += 1) {
+    const index = startId + offset;
     const instructorRef = ref("IN", index);
     const lowerRef = instructorRef.toLowerCase();
+    const first = sanitizeEnglishNamePart(
+      fakerEn.person.firstName(),
+      `Alex${index}`,
+    );
+    const last = sanitizeEnglishNamePart(
+      fakerEn.person.lastName(),
+      `Taylor${index}`,
+    );
+    const seen = nicknameCounts.get(first) ?? 0;
+    const nickname = seen === 0 ? first : `${first}${seen + 1}`;
+    nicknameCounts.set(first, seen + 1);
     instructors.push({
       instructor_ref: instructorRef,
-      name: `Incremental Instructor ${suffix}`,
+      name: `${first} ${last}`,
       email: `${lowerRef}@example.com`,
       temp_password: `Temp-${lowerRef}`,
-      class_url: `https://example.com/incremental/${namespace}/classes/${suffix}`,
-      icon: `https://example.com/incremental/${namespace}/icons/${suffix}.png`,
-      nickname: `dummy_${namespace}_${suffix}`,
-      meeting_id: `8${code}${suffix}`,
-      passcode: `P${code}${suffix}`,
+      class_url: `https://class.example.com/${lowerRef}`,
+      icon: `https://img.example.com/${lowerRef}.png`,
+      nickname,
+      meeting_id: `MID${String(index).padStart(4, "0")}`,
+      passcode: `PIN${String(index).padStart(4, "0")}`,
       birthdate: `1990-01-${String(((index - 1) % 28) + 1).padStart(2, "0")}`,
       favorite_food: "Sushi",
       hobby: "Reading",
@@ -204,7 +414,7 @@ function instructorRows(count: number, namespace: string, startDate: string) {
       message_for_children: "Let us enjoy learning English!",
       skill: "Conversation",
       working_time: "Weekdays",
-      english_background: String((index - 1) % 3),
+      english_background: index % 2 === 0 ? "1" : "0",
       termination_at: "",
     });
     fees.push({
@@ -218,10 +428,7 @@ function instructorRows(count: number, namespace: string, startDate: string) {
       cancel_without_notice_fee: "100",
       monthly_cancel_fee: "200",
     });
-    for (const [weekday, startTime] of [
-      ["1", "09:00"],
-      ["3", "10:00"],
-    ]) {
+    for (const [weekday, startTime] of slotsForInstructor(index)) {
       schedules.push({
         instructor_ref: instructorRef,
         effective_from: startDate,
@@ -256,47 +463,92 @@ async function createDeterministicZip(
   });
 }
 
+export function generateIncrementalImportFixture(
+  options: GenerateIncrementalCustomerFixtureOptions,
+): Promise<GeneratedIncrementalCustomerFixture>;
+export function generateIncrementalImportFixture(
+  options: GenerateIncrementalInstructorFixtureOptions,
+): Promise<GeneratedIncrementalInstructorFixture>;
 export async function generateIncrementalImportFixture(
-  options: GenerateIncrementalImportFixtureOptions = {},
+  options: GenerateIncrementalImportFixtureOptions,
 ): Promise<GeneratedIncrementalImportFixture> {
-  const customerCount = options.customerCount ?? DEFAULT_COUNT;
-  const instructorCount = options.instructorCount ?? DEFAULT_COUNT;
-  const namespace = options.namespace ?? "sample";
-  const planName = options.planName ?? DEFAULT_PLAN_NAME;
+  const number = options.number ?? DEFAULT_COUNT;
+  const startId = options.startId ?? DEFAULT_START_ID;
   const startDate = options.startDate ?? DEFAULT_START_DATE;
 
-  validateCount("customerCount", customerCount);
-  validateCount("instructorCount", instructorCount);
-  validateNamespace(namespace);
   validateStartDate(startDate);
-  if (!planName.trim()) throw new Error("planName must not be empty");
+  validateCount("number", number);
+  validateIdRange("startId", startId, number);
+  const endId = startId + number - 1;
 
-  const customerFiles = customerRows(
-    customerCount,
-    namespace,
-    planName,
+  if (options.target === "customers") {
+    const hasStartInstructorId = options.startInstructorId !== undefined;
+    const hasEndInstructorId = options.endInstructorId !== undefined;
+    if (hasStartInstructorId !== hasEndInstructorId) {
+      throw new Error(
+        "startInstructorId and endInstructorId must be specified together",
+      );
+    }
+    if (
+      hasStartInstructorId &&
+      (!Number.isSafeInteger(options.startInstructorId) ||
+        !Number.isSafeInteger(options.endInstructorId) ||
+        options.startInstructorId! < 1 ||
+        options.endInstructorId! < options.startInstructorId!)
+    ) {
+      throw new Error(
+        "instructor ID range must contain positive integers with endInstructorId greater than or equal to startInstructorId",
+      );
+    }
+    const { fakerEN_US, fakerJA } = (await import("@faker-js/faker")) as {
+      fakerEN_US: FakerLike;
+      fakerJA: FakerLike;
+    };
+    prepareCustomerFakers(fakerJA, fakerEN_US, startId);
+    const customerFiles = customerRows(
+      fakerJA,
+      fakerEN_US,
+      number,
+      startId,
+      startDate,
+      hasStartInstructorId
+        ? {
+            start: options.startInstructorId!,
+            end: options.endInstructorId!,
+          }
+        : undefined,
+    );
+    return {
+      target: "customers",
+      customerFiles,
+      customerZip: await createDeterministicZip(customerFiles),
+      customerZipFileName: `incremental-customers-${String(startId).padStart(4, "0")}-${String(endId).padStart(4, "0")}.zip`,
+    };
+  }
+
+  const { fakerEN_US } = (await import("@faker-js/faker")) as {
+    fakerEN_US: FakerLike;
+  };
+  const nicknameCounts = prepareInstructorFaker(fakerEN_US, startId);
+  const instructorFiles = instructorRows(
+    fakerEN_US,
+    nicknameCounts,
+    number,
+    startId,
     startDate,
   );
-  const instructorFiles = instructorRows(instructorCount, namespace, startDate);
-  const [customerZip, instructorZip] = await Promise.all([
-    createDeterministicZip(customerFiles),
-    createDeterministicZip(instructorFiles),
-  ]);
-
   return {
-    customerFiles,
+    target: "instructors",
     instructorFiles,
-    customerZip,
-    instructorZip,
-    customerZipFileName: `incremental-customers-${namespace}.zip`,
-    instructorZipFileName: `incremental-instructors-${namespace}.zip`,
+    instructorZip: await createDeterministicZip(instructorFiles),
+    instructorZipFileName: `incremental-instructors-${String(startId).padStart(4, "0")}-${String(endId).padStart(4, "0")}.zip`,
   };
 }
 
 function usageAndExit(message?: string): never {
   if (message) console.error(`Error: ${message}`);
   console.error(
-    "Usage: ts-node ./src/seed/generateIncrementalImportFixture.ts [--customers COUNT] [--instructors COUNT] [--namespace VALUE] [--plan-name VALUE] [--start-date YYYY-MM-DD] [--out-dir PATH]",
+    "Usage: ts-node ./src/seed/generateIncrementalImportFixture.ts --target customers|instructors [--number COUNT] [--start-id ID] [--start-instructor-id ID --end-instructor-id ID] [--start-date YYYY-MM-DD] [--out-dir PATH]",
   );
   process.exit(1);
 }
@@ -306,6 +558,17 @@ function parseCount(value: string | undefined, label: string) {
   const parsed = Number(value);
   try {
     validateCount(label, parsed);
+  } catch (error) {
+    usageAndExit(error instanceof Error ? error.message : String(error));
+  }
+  return parsed;
+}
+
+function parseStartId(value: string | undefined, label: string, count: number) {
+  if (value === undefined) return DEFAULT_START_ID;
+  const parsed = Number(value);
+  try {
+    validateIdRange(label, parsed, count);
   } catch (error) {
     usageAndExit(error instanceof Error ? error.message : String(error));
   }
@@ -326,23 +589,49 @@ function parseArgs(argv: string[]): CliArgs {
   }
 
   const allowed = new Set([
-    "customers",
-    "instructors",
-    "namespace",
-    "plan-name",
+    "number",
+    "start-id",
+    "target",
     "start-date",
+    "start-instructor-id",
+    "end-instructor-id",
     "out-dir",
   ]);
   for (const key of values.keys()) {
     if (!allowed.has(key)) usageAndExit(`Unknown flag: --${key}`);
   }
 
+  const number = parseCount(values.get("number"), "number");
+  const target = values.get("target");
+  if (target !== "customers" && target !== "instructors") {
+    usageAndExit("--target must be customers or instructors");
+  }
+  const startInstructorId = values.has("start-instructor-id")
+    ? parseStartId(values.get("start-instructor-id"), "startInstructorId", 1)
+    : undefined;
+  const endInstructorId = values.has("end-instructor-id")
+    ? parseStartId(values.get("end-instructor-id"), "endInstructorId", 1)
+    : undefined;
+  if (target === "instructors" && (startInstructorId || endInstructorId)) {
+    usageAndExit(
+      "--start-instructor-id and --end-instructor-id are only valid for --target customers",
+    );
+  }
+  if ((startInstructorId === undefined) !== (endInstructorId === undefined)) {
+    usageAndExit(
+      "--start-instructor-id and --end-instructor-id must be specified together",
+    );
+  }
+  if (startInstructorId !== undefined && endInstructorId! < startInstructorId) {
+    usageAndExit("--end-instructor-id must be at least --start-instructor-id");
+  }
   return {
-    customerCount: parseCount(values.get("customers"), "customerCount"),
-    instructorCount: parseCount(values.get("instructors"), "instructorCount"),
-    namespace: values.get("namespace") ?? "sample",
-    planName: values.get("plan-name") ?? DEFAULT_PLAN_NAME,
+    target,
+    number,
+    startId: parseStartId(values.get("start-id"), "startId", number),
     startDate: values.get("start-date") ?? DEFAULT_START_DATE,
+    startInstructorId,
+    endInstructorId,
     outDir:
       values.get("out-dir") ??
       path.resolve(
@@ -363,33 +652,53 @@ async function writeFiles(directory: string, files: Record<string, string>) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const generated = await generateIncrementalImportFixture(args);
   await fs.mkdir(args.outDir, { recursive: true });
+
+  console.log("Generated deterministic incremental import fixtures");
+  console.log(`Output directory: ${args.outDir}`);
+  if (args.target === "customers") {
+    const generated = await generateIncrementalImportFixture({
+      ...args,
+      target: "customers",
+    });
+    await Promise.all([
+      writeFiles(path.join(args.outDir, "customers"), generated.customerFiles),
+      fs.writeFile(
+        path.join(args.outDir, generated.customerZipFileName),
+        generated.customerZip,
+      ),
+    ]);
+    for (const fileName of CUSTOMER_FILES) {
+      const content = generated.customerFiles[fileName];
+      if (!content) continue;
+      console.log(`${fileName}: ${content.trim().split("\n").length - 1}`);
+    }
+    console.log(`customer zip: ${generated.customerZipFileName}`);
+    return;
+  }
+
+  const generated = await generateIncrementalImportFixture({
+    ...args,
+    target: "instructors",
+  });
   await Promise.all([
-    writeFiles(path.join(args.outDir, "customers"), generated.customerFiles),
     writeFiles(
       path.join(args.outDir, "instructors"),
       generated.instructorFiles,
-    ),
-    fs.writeFile(
-      path.join(args.outDir, generated.customerZipFileName),
-      generated.customerZip,
     ),
     fs.writeFile(
       path.join(args.outDir, generated.instructorZipFileName),
       generated.instructorZip,
     ),
   ]);
-
-  console.log("Generated deterministic incremental import fixtures");
-  console.log(`Output directory: ${args.outDir}`);
-  for (const fileName of CUSTOMER_FILES) {
-    console.log(`${fileName}: ${args.customerCount}`);
-  }
-  console.log(`customer zip: ${generated.customerZipFileName}`);
-  console.log(`instructors.csv: ${args.instructorCount}`);
-  console.log(`instructor_fees.csv: ${args.instructorCount}`);
-  console.log(`instructor_schedules.csv: ${args.instructorCount * 2}`);
+  console.log(`instructors.csv: ${args.number}`);
+  console.log(`instructor_fees.csv: ${args.number}`);
+  console.log(
+    `instructor_schedules.csv: ${
+      generated.instructorFiles["instructor_schedules.csv"].trim().split("\n")
+        .length - 1
+    }`,
+  );
   console.log(`instructor zip: ${generated.instructorZipFileName}`);
 }
 

--- a/backend/src/services/adminImport/incremental.ts
+++ b/backend/src/services/adminImport/incremental.ts
@@ -8,7 +8,12 @@ export type IncrementalImportOperation =
   | "incremental-customers"
   | "incremental-instructors";
 
-type CustomerFileName = "customers.csv" | "children.csv" | "subscriptions.csv";
+type CustomerFileName =
+  | "customers.csv"
+  | "children.csv"
+  | "subscriptions.csv"
+  | "recurring_classes.csv"
+  | "recurring_class_attendance.csv";
 type InstructorFileName =
   | "instructors.csv"
   | "instructor_fees.csv"
@@ -46,6 +51,10 @@ const CUSTOMER_FILES: readonly CustomerFileName[] = [
   "children.csv",
   "subscriptions.csv",
 ];
+const OPTIONAL_CUSTOMER_FILES: readonly CustomerFileName[] = [
+  "recurring_classes.csv",
+  "recurring_class_attendance.csv",
+];
 const INSTRUCTOR_FILES: readonly InstructorFileName[] = [
   "instructors.csv",
   "instructor_fees.csv",
@@ -77,6 +86,14 @@ const HEADERS: Record<IncrementalFileName, readonly string[]> = {
     "start_at",
     "end_at",
   ],
+  "recurring_classes.csv": [
+    "recurring_class_ref",
+    "subscription_ref",
+    "instructor_id",
+    "start_at",
+    "end_at",
+  ],
+  "recurring_class_attendance.csv": ["recurring_class_ref", "child_ref"],
   "instructors.csv": [
     "instructor_ref",
     "name",
@@ -330,9 +347,17 @@ async function parsePackage(
     ]);
   }
 
+  const packageFiles = [...filesFor(operation)];
+  if (
+    operation === "incremental-customers" &&
+    OPTIONAL_CUSTOMER_FILES.some((file) => zip.file(file))
+  ) {
+    packageFiles.push(...OPTIONAL_CUSTOMER_FILES);
+  }
+
   const rows: Partial<Record<IncrementalFileName, ParsedRow[]>> = {};
   const rowsByFile: Record<string, number> = {};
-  for (const file of filesFor(operation)) {
+  for (const file of packageFiles) {
     const entry = zip.file(file);
     if (!entry) {
       issue(issues, file, null, null, `Missing required file: ${file}`);
@@ -402,9 +427,7 @@ async function parsePackage(
 
   const report = {
     rowsByFile,
-    importedByFile: Object.fromEntries(
-      filesFor(operation).map((file) => [file, 0]),
-    ),
+    importedByFile: Object.fromEntries(packageFiles.map((file) => [file, 0])),
   };
   const parsed = { rows, report };
   validateFileData(operation, parsed, issues);
@@ -423,6 +446,9 @@ function validateFileData(
     const customers = parsed.rows["customers.csv"] ?? [];
     const children = parsed.rows["children.csv"] ?? [];
     const subscriptions = parsed.rows["subscriptions.csv"] ?? [];
+    const recurringClasses = parsed.rows["recurring_classes.csv"] ?? [];
+    const recurringAttendance =
+      parsed.rows["recurring_class_attendance.csv"] ?? [];
 
     for (const row of customers) {
       required(issues, "customers.csv", row, [
@@ -481,6 +507,45 @@ function validateFileData(
       assertDateTime(issues, "subscriptions.csv", row, "end_at");
       assertRange(issues, "subscriptions.csv", row, "start_at", "end_at");
     }
+    for (const row of recurringClasses) {
+      required(issues, "recurring_classes.csv", row, [
+        "recurring_class_ref",
+        "subscription_ref",
+        "instructor_id",
+        "start_at",
+      ]);
+      assertRef(issues, "recurring_classes.csv", row, "recurring_class_ref");
+      assertRef(issues, "recurring_classes.csv", row, "subscription_ref");
+      if (
+        row.data.instructor_id &&
+        (!/^\d+$/.test(row.data.instructor_id) ||
+          Number(row.data.instructor_id) < 1)
+      ) {
+        issue(
+          issues,
+          "recurring_classes.csv",
+          row.rowNumber,
+          "instructor_id",
+          "instructor_id must be a positive integer",
+        );
+      }
+      assertDateTime(issues, "recurring_classes.csv", row, "start_at");
+      assertDateTime(issues, "recurring_classes.csv", row, "end_at");
+      assertRange(issues, "recurring_classes.csv", row, "start_at", "end_at");
+    }
+    for (const row of recurringAttendance) {
+      required(issues, "recurring_class_attendance.csv", row, [
+        "recurring_class_ref",
+        "child_ref",
+      ]);
+      assertRef(
+        issues,
+        "recurring_class_attendance.csv",
+        row,
+        "recurring_class_ref",
+      );
+      assertRef(issues, "recurring_class_attendance.csv", row, "child_ref");
+    }
 
     assertUnique(issues, "customers.csv", customers, ["customer_ref"]);
     assertUnique(issues, "customers.csv", customers, ["email"]);
@@ -489,6 +554,19 @@ function validateFileData(
       "subscription_ref",
     ]);
     assertUnique(issues, "subscriptions.csv", subscriptions, ["select_type"]);
+    assertUnique(issues, "recurring_classes.csv", recurringClasses, [
+      "recurring_class_ref",
+    ]);
+    assertUnique(issues, "recurring_classes.csv", recurringClasses, [
+      "instructor_id",
+      "start_at",
+    ]);
+    assertUnique(
+      issues,
+      "recurring_class_attendance.csv",
+      recurringAttendance,
+      ["recurring_class_ref", "child_ref"],
+    );
     const customerRefs = new Set(customers.map((row) => row.data.customer_ref));
     assertReferences(
       issues,
@@ -505,6 +583,37 @@ function validateFileData(
       "customer_ref",
       customerRefs,
       "customers.csv",
+    );
+    const subscriptionRefs = new Set(
+      subscriptions.map((row) => row.data.subscription_ref),
+    );
+    const recurringClassRefs = new Set(
+      recurringClasses.map((row) => row.data.recurring_class_ref),
+    );
+    const childRefs = new Set(children.map((row) => row.data.child_ref));
+    assertReferences(
+      issues,
+      "recurring_classes.csv",
+      recurringClasses,
+      "subscription_ref",
+      subscriptionRefs,
+      "subscriptions.csv",
+    );
+    assertReferences(
+      issues,
+      "recurring_class_attendance.csv",
+      recurringAttendance,
+      "recurring_class_ref",
+      recurringClassRefs,
+      "recurring_classes.csv",
+    );
+    assertReferences(
+      issues,
+      "recurring_class_attendance.csv",
+      recurringAttendance,
+      "child_ref",
+      childRefs,
+      "children.csv",
     );
     return;
   }
@@ -746,20 +855,39 @@ async function validateCustomerDatabase(
   const planNames = [
     ...new Set(subscriptions.map((row) => row.data.plan_name)),
   ];
-  const [existingCustomers, existingSubscriptions, plans] = await Promise.all([
-    tx.customer.findMany({
-      where: { email: { in: emails } },
-      select: { email: true },
-    }),
-    tx.subscription.findMany({
-      where: { selectType: { in: selectTypes } },
-      select: { selectType: true },
-    }),
-    tx.plan.findMany({
-      where: { name: { in: planNames } },
-      select: { id: true, name: true },
-    }),
-  ]);
+  const recurringClasses = parsed.rows["recurring_classes.csv"] ?? [];
+  const instructorIds = [
+    ...new Set(
+      recurringClasses
+        .map((row) => Number(row.data.instructor_id))
+        .filter(Number.isSafeInteger),
+    ),
+  ];
+  const [existingCustomers, existingSubscriptions, plans, instructors] =
+    await Promise.all([
+      tx.customer.findMany({
+        where: { email: { in: emails } },
+        select: { email: true },
+      }),
+      tx.subscription.findMany({
+        where: { selectType: { in: selectTypes } },
+        select: { selectType: true },
+      }),
+      tx.plan.findMany({
+        where: { name: { in: planNames } },
+        select: { id: true, name: true },
+      }),
+      tx.instructor.findMany({
+        where: { id: { in: instructorIds } },
+        select: {
+          id: true,
+          instructorSchedules: {
+            include: { slots: true },
+            orderBy: { effectiveFrom: "desc" },
+          },
+        },
+      }),
+    ]);
 
   for (const existing of existingCustomers) {
     issue(
@@ -810,6 +938,51 @@ async function validateCustomerDatabase(
       }
     }
     if (matches.length === 1) planIds.set(planName, matches[0].id);
+  }
+
+  const instructorById = new Map(
+    instructors.map((instructor) => [instructor.id, instructor]),
+  );
+  for (const row of recurringClasses) {
+    const instructorId = Number(row.data.instructor_id);
+    if (!Number.isSafeInteger(instructorId)) continue;
+    const instructor = instructorById.get(instructorId);
+    if (!instructor) {
+      issue(
+        issues,
+        "recurring_classes.csv",
+        row.rowNumber,
+        "instructor_id",
+        `Instructor ID ${instructorId} does not exist`,
+      );
+      continue;
+    }
+    if (!validDateTime(row.data.start_at)) continue;
+    const localDate = row.data.start_at.slice(0, 10);
+    const localTime = row.data.start_at.slice(11, 16);
+    const weekday = new Date(`${localDate}T00:00:00.000Z`).getUTCDay();
+    const activeSchedule = instructor.instructorSchedules.find((schedule) => {
+      const effectiveFrom = schedule.effectiveFrom.toISOString().slice(0, 10);
+      const effectiveTo = schedule.effectiveTo?.toISOString().slice(0, 10);
+      return (
+        effectiveFrom <= localDate &&
+        (effectiveTo === undefined || localDate < effectiveTo)
+      );
+    });
+    const matchesSlot = activeSchedule?.slots.some(
+      (slot) =>
+        slot.weekday === weekday &&
+        slot.startTime.toISOString().slice(11, 16) === localTime,
+    );
+    if (!matchesSlot) {
+      issue(
+        issues,
+        "recurring_classes.csv",
+        row.rowNumber,
+        "start_at",
+        `Instructor ID ${instructorId} has no matching active schedule slot at ${row.data.start_at}`,
+      );
+    }
   }
   return planIds;
 }
@@ -871,6 +1044,8 @@ async function insertCustomers(
   options: IncrementalImportExecutionOptions,
 ) {
   const customerIds = new Map<string, number>();
+  const childIds = new Map<string, number>();
+  const subscriptionIds = new Map<string, number>();
   let insertedCount = 0;
   for (const row of parsed.rows["customers.csv"] ?? []) {
     const customer = await tx.customer.create({
@@ -890,25 +1065,71 @@ async function insertCustomers(
     await options.onPrimaryRecordInserted?.(insertedCount);
   }
   if ((parsed.rows["children.csv"] ?? []).length > 0) {
-    await tx.child.createMany({
+    const childRows = parsed.rows["children.csv"] ?? [];
+    const createdChildren = await tx.child.createManyAndReturn({
       data: (parsed.rows["children.csv"] ?? []).map((row) => ({
         customerId: customerIds.get(row.data.customer_ref)!,
         name: row.data.name,
         birthdate: optionalDateOnly(row.data.birthdate),
         personalInfo: row.data.personal_info || null,
       })),
+      select: { id: true },
+    });
+    childRows.forEach((row, index) => {
+      childIds.set(row.data.child_ref, createdChildren[index].id);
     });
   }
   if ((parsed.rows["subscriptions.csv"] ?? []).length > 0) {
-    await tx.subscription.createMany({
-      data: (parsed.rows["subscriptions.csv"] ?? []).map((row) => ({
+    const subscriptionRows = parsed.rows["subscriptions.csv"] ?? [];
+    const createdSubscriptions = await tx.subscription.createManyAndReturn({
+      data: subscriptionRows.map((row) => ({
         customerId: customerIds.get(row.data.customer_ref)!,
         planId: planIds.get(row.data.plan_name)!,
         selectType: row.data.select_type,
         startAt: new Date(row.data.start_at),
         endAt: optionalDateTime(row.data.end_at),
       })),
+      select: { id: true },
     });
+    subscriptionRows.forEach((row, index) => {
+      subscriptionIds.set(
+        row.data.subscription_ref,
+        createdSubscriptions[index].id,
+      );
+    });
+  }
+
+  const recurringRows = parsed.rows["recurring_classes.csv"] ?? [];
+  if (recurringRows.length > 0) {
+    const createdRecurringClasses = await tx.recurringClass.createManyAndReturn(
+      {
+        data: recurringRows.map((row) => ({
+          subscriptionId: subscriptionIds.get(row.data.subscription_ref)!,
+          instructorId: Number(row.data.instructor_id),
+          startAt: new Date(row.data.start_at),
+          endAt: optionalDateTime(row.data.end_at),
+        })),
+        select: { id: true },
+      },
+    );
+    const recurringClassIds = new Map<string, number>();
+    recurringRows.forEach((row, index) => {
+      recurringClassIds.set(
+        row.data.recurring_class_ref,
+        createdRecurringClasses[index].id,
+      );
+    });
+    const attendanceRows = parsed.rows["recurring_class_attendance.csv"] ?? [];
+    if (attendanceRows.length > 0) {
+      await tx.recurringClassAttendance.createMany({
+        data: attendanceRows.map((row) => ({
+          recurringClassId: recurringClassIds.get(
+            row.data.recurring_class_ref,
+          )!,
+          childrenId: childIds.get(row.data.child_ref)!,
+        })),
+      });
+    }
   }
 }
 

--- a/backend/src/test/api/admins/import-incremental.test.ts
+++ b/backend/src/test/api/admins/import-incremental.test.ts
@@ -99,38 +99,93 @@ describe("incremental admin imports", () => {
     const admin = await createAdmin();
     const cookie = await generateAuthCookie(admin.id, "admin");
     await createPlan({
-      name: "Dummy Exact Plan",
+      name: "月5,980円プラン / 5,980 yen/month Plan",
       description: "Fixture plan",
-      weeklyClassTimes: 1,
+      weeklyClassTimes: 2,
       englishBackground: 0,
     });
-    const fixture = await generateIncrementalImportFixture({
-      customerCount: 2,
-      instructorCount: 2,
-      namespace: "api-test",
-      planName: "Dummy Exact Plan",
-      startDate: "2026-03-01",
-    });
-    expect(fixture.customerFiles["customers.csv"]).toContain(
-      ",cu0001@example.com,Temp-cu0001,",
+    const [customerFixture, instructorFixture] = await Promise.all([
+      generateIncrementalImportFixture({
+        target: "customers",
+        number: 2,
+        startId: 21,
+        startDate: "2026-03-01",
+        startInstructorId: 1,
+        endInstructorId: 3,
+      }),
+      generateIncrementalImportFixture({
+        target: "instructors",
+        number: 3,
+        startId: 31,
+        startDate: "2026-03-01",
+      }),
+    ]);
+    expect(customerFixture.customerFiles["customers.csv"]).toContain(
+      ",cu0021@example.com,Temp-cu0021,",
     );
-    expect(fixture.instructorFiles["instructors.csv"]).toContain(
-      ",in0001@example.com,Temp-in0001,",
+    expect(customerFixture.customerFiles["customers.csv"]).toContain(
+      ",東京都 / Tokyo,",
     );
+    expect(customerFixture.customerFiles["customers.csv"]).not.toContain(
+      "Incremental Customer",
+    );
+    expect(customerFixture.customerFiles["children.csv"]).not.toContain(
+      "Child 00021",
+    );
+    expect(instructorFixture.instructorFiles["instructors.csv"]).toContain(
+      ",in0031@example.com,Temp-in0031,",
+    );
+    expect(instructorFixture.instructorFiles["instructors.csv"]).not.toContain(
+      "Incremental Instructor",
+    );
+    expect(
+      instructorFixture.instructorFiles["instructors.csv"]
+        .trim()
+        .split("\n")
+        .slice(1)
+        .map((row) => {
+          const columns = row.split(",");
+          const firstName = columns[1]?.split(" ")[0];
+          const nickname = columns[6];
+          return nickname?.replace(/\d+$/, "") === firstName;
+        }),
+    ).toEqual([true, true, true]);
+    expect(
+      instructorFixture.instructorFiles["instructors.csv"]
+        .trim()
+        .split("\n")
+        .slice(1)
+        .map((row) => row.split(",").at(-2)),
+    ).toEqual(["0", "1", "0"]);
+    expect(
+      customerFixture.customerFiles["recurring_classes.csv"]
+        ?.trim()
+        .split("\n")
+        .slice(1)
+        .map((row) => {
+          const columns = row.split(",");
+          return [columns[2], columns[3]];
+        }),
+    ).toEqual([
+      ["1", "2026-03-02T16:00:00+09:00"],
+      ["2", "2026-03-05T18:30:00+09:00"],
+      ["3", "2026-03-02T16:00:00+09:00"],
+      ["1", "2026-03-02T16:30:00+09:00"],
+    ]);
 
-    const customerResponse = await request(server)
-      .post("/admins/import/incremental/customers")
-      .set("Cookie", cookie)
-      .attach("file", fixture.customerZip, {
-        filename: fixture.customerZipFileName,
-        contentType: "application/zip",
-      })
-      .expect(200);
     const instructorResponse = await request(server)
       .post("/admins/import/incremental/instructors")
       .set("Cookie", cookie)
-      .attach("file", fixture.instructorZip, {
-        filename: fixture.instructorZipFileName,
+      .attach("file", instructorFixture.instructorZip, {
+        filename: instructorFixture.instructorZipFileName,
+        contentType: "application/zip",
+      })
+      .expect(200);
+    const customerResponse = await request(server)
+      .post("/admins/import/incremental/customers")
+      .set("Cookie", cookie)
+      .attach("file", customerFixture.customerZip, {
+        filename: customerFixture.customerZipFileName,
         contentType: "application/zip",
       })
       .expect(200);
@@ -139,12 +194,46 @@ describe("incremental admin imports", () => {
       "customers.csv": 2,
       "children.csv": 2,
       "subscriptions.csv": 2,
+      "recurring_classes.csv": 4,
+      "recurring_class_attendance.csv": 4,
     });
     expect(instructorResponse.body.report.importedByFile).toEqual({
-      "instructors.csv": 2,
-      "instructor_fees.csv": 2,
-      "instructor_schedules.csv": 4,
+      "instructors.csv": 3,
+      "instructor_fees.csv": 3,
+      "instructor_schedules.csv": 46,
     });
+    const recurringClasses = await prisma.recurringClass.findMany({
+      orderBy: { id: "asc" },
+      include: { recurringClassAttendance: true },
+    });
+    expect(
+      recurringClasses.map((recurringClass) => ({
+        instructorId: recurringClass.instructorId,
+        startAt: recurringClass.startAt?.toISOString(),
+        attendance: recurringClass.recurringClassAttendance.length,
+      })),
+    ).toEqual([
+      {
+        instructorId: 1,
+        startAt: "2026-03-02T07:00:00.000Z",
+        attendance: 1,
+      },
+      {
+        instructorId: 2,
+        startAt: "2026-03-05T09:30:00.000Z",
+        attendance: 1,
+      },
+      {
+        instructorId: 3,
+        startAt: "2026-03-02T07:00:00.000Z",
+        attendance: 1,
+      },
+      {
+        instructorId: 1,
+        startAt: "2026-03-02T07:30:00.000Z",
+        attendance: 1,
+      },
+    ]);
   });
 
   it("atomically adds customers, children, and exact-name subscriptions while preserving existing data", async () => {
@@ -189,6 +278,57 @@ describe("incremental admin imports", () => {
       planId: plan.id,
       selectType: "https://example.com/select/1",
     });
+  });
+
+  it("rejects regular classes for missing instructor IDs without writing customers", async () => {
+    const admin = await createAdmin();
+    const cookie = await generateAuthCookie(admin.id, "admin");
+    await createPlan({
+      name: "月5,980円プラン / 5,980 yen/month Plan",
+      description: "Fixture plan",
+      weeklyClassTimes: 2,
+      englishBackground: 0,
+    });
+    const fixture = await generateIncrementalImportFixture({
+      target: "customers",
+      number: 1,
+      startId: 41,
+      startInstructorId: 999,
+      endInstructorId: 999,
+      startDate: "2026-03-01",
+    });
+
+    const response = await request(server)
+      .post("/admins/import/incremental/customers")
+      .set("Cookie", cookie)
+      .attach("file", fixture.customerZip, {
+        filename: fixture.customerZipFileName,
+        contentType: "application/zip",
+      })
+      .expect(400);
+
+    expect(response.body.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "recurring_classes.csv",
+          column: "instructor_id",
+          message: "Instructor ID 999 does not exist",
+        }),
+      ]),
+    );
+    expect(await prisma.customer.count()).toBe(0);
+    expect(await prisma.recurringClass.count()).toBe(0);
+  });
+
+  it("rejects an instructor range without enough unique slots", async () => {
+    await expect(
+      generateIncrementalImportFixture({
+        target: "customers",
+        number: 8,
+        startInstructorId: 1,
+        endInstructorId: 1,
+      }),
+    ).rejects.toThrow("insufficient unique slots");
   });
 
   it("atomically adds instructors with fees and grouped slots without absences", async () => {

--- a/docs/testing/data-import/README.md
+++ b/docs/testing/data-import/README.md
@@ -77,40 +77,80 @@ Run from `backend/`:
 
 ```sh
 npm run fixture:generate:incremental-import -- \
-  --customers 5 \
-  --instructors 5 \
-  --namespace local-01 \
-  --plan-name "月5,980円プラン / 5,980 yen/month Plan" \
+  --target customers \
+  --number 5 \
+  --start-id 1 \
+  --start-instructor-id 1 \
+  --end-instructor-id 5 \
   --start-date 2026-01-01
 ```
 
-This creates two directly uploadable, deterministic packages:
+This creates one directly uploadable, deterministic customer package:
 
-- `incremental-customers-<namespace>.zip`
+- `incremental-customers-0001-0005.zip`
   - `customers.csv`
   - `children.csv`
   - `subscriptions.csv`
-- `incremental-instructors-<namespace>.zip`
+  - `recurring_classes.csv`
+  - `recurring_class_attendance.csv`
+
+To generate an instructor package independently:
+
+```sh
+npm run fixture:generate:incremental-import -- \
+  --target instructors \
+  --number 5 \
+  --start-id 1 \
+  --start-date 2026-01-01
+```
+
+This creates:
+
+- `incremental-instructors-0001-0005.zip`
   - `instructors.csv`
   - `instructor_fees.csv`
   - `instructor_schedules.csv`
 
-All CSV files are also written into `customers/` and `instructors/`
-subdirectories for inspection.
+The selected package's CSV files are also written into its corresponding
+subdirectory for inspection.
 
-Optional arguments:
+Arguments:
 
-- `--customers` and `--instructors` default to `5`.
-- `--namespace` defaults to `sample` and differentiates generated URLs,
-  nicknames, meeting IDs, and passcodes.
-- `--plan-name` defaults to the weekly native-A plan created by
-  `npm run seed:dummy`. The name must exactly match one existing database plan.
+- `--target` is required and accepts `customers` or `instructors`.
+- `--number` configures the selected target's count and defaults to `5`.
+- `--start-id` defaults to `1` and controls generated reference and credential
+  suffixes, not database primary keys. For example, `--target customers
+  --start-id 25` starts at `CU0025`.
+- `--start-instructor-id` and `--end-instructor-id` are optional customer-only
+  arguments that must be supplied together. They are inclusive existing
+  database instructor IDs. When supplied, each ¥5,980 subscription receives two
+  regular classes.
 - `--start-date` defaults to `2026-01-01`.
 - `--out-dir` defaults to
   `../docs/testing/data-import/generated/incremental`.
 
-The exported `generateIncrementalImportFixture()` function returns both file
-maps and ZIP buffers for automated tests or other programmatic use.
+The exported `generateIncrementalImportFixture()` function accepts the
+required `target` and its corresponding count and start-ID options. It returns
+the selected file map and ZIP buffer for automated tests or other programmatic
+use.
+
+Customer subscriptions use the `月5,980円プラン / 5,980 yen/month Plan`
+created by the initial import generator.
+
+Regular classes rotate through the inclusive instructor range before consuming
+the next slot for each instructor. For example, instructor IDs 1 through 3 are
+assigned as `1/slot 1`, `2/slot 1`, `3/slot 1`, `1/slot 2`, and so on. Slots
+follow the initial generator's Pattern A and Pattern B ordering. The customer
+import verifies that every instructor exists and that each selected slot
+matches an active database schedule. It fails atomically if the range has
+insufficient unique slots or the database does not match the generated fixture.
+
+Customer, instructor, and child names use the same seeded Faker patterns as the
+initial import generator. Customer prefecture is `東京都 / Tokyo`.
+Instructor English backgrounds alternate between Program Original and Native A,
+and instructor schedules use the initial generator's Pattern A and Pattern B
+weekly slots. Instructor nicknames use the Faker-generated first name, adding a
+numeric suffix only when a duplicate first name occurs.
 
 Generated login credentials follow the normalized fixture convention:
 

--- a/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.module.scss
+++ b/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.module.scss
@@ -47,11 +47,6 @@
   background: #fff;
 }
 
-.safeText {
-  color: #26734d;
-  font-weight: 600;
-}
-
 .warningText {
   margin-top: 0.3rem !important;
   color: $red-alert;

--- a/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
+++ b/frontend/src/components/admins-dashboard/import-dashboard/DataImportDashboard.tsx
@@ -133,10 +133,6 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
             ? "Requires customers.csv, children.csv, and subscriptions.csv."
             : "Requires instructors.csv, instructor_fees.csv, and instructor_schedules.csv."}
         </p>
-        <p className={styles.safeText}>
-          Add-only: existing data is preserved. If any row fails validation,
-          nothing is imported.
-        </p>
         <label
           className={styles.fileInputLabel}
           htmlFor={`incremental-${target}-zip`}
@@ -307,28 +303,14 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
         <h1>Data Import</h1>
         <p className={styles.subText}>
           Add focused customer or instructor packages, or replace import data
-          with a clean-start package.
+          with a clean package.
         </p>
         <p className={styles.subText}>Admin ID: {adminId}</p>
       </header>
 
-      <section className={styles.operationSection}>
-        <div>
-          <h2>Incremental import (add-only)</h2>
-          <p className={styles.subText}>
-            Adds new records atomically without deleting or changing existing
-            data.
-          </p>
-        </div>
-        <div className={styles.cardGrid}>
-          {renderIncrementalCard("customers")}
-          {renderIncrementalCard("instructors")}
-        </div>
-      </section>
-
       <section className={`${styles.operationSection} ${styles.destructive}`}>
         <div>
-          <h2>Clean-start import (destructive)</h2>
+          <h2>Clean import (destructive)</h2>
           <p className={styles.warningText}>
             Replaces all import-target data. Use only when intentionally
             rebuilding the database.
@@ -495,6 +477,20 @@ export default function DataImportDashboard({ adminId }: { adminId: number }) {
             </table>
           </div>
         )}
+      </section>
+
+      <section className={styles.operationSection}>
+        <div>
+          <h2>Incremental import (add-only)</h2>
+          <p className={styles.subText}>
+            Adds new records atomically without deleting or changing existing
+            data.
+          </p>
+        </div>
+        <div className={styles.cardGrid}>
+          {renderIncrementalCard("customers")}
+          {renderIncrementalCard("instructors")}
+        </div>
       </section>
 
       <Modal


### PR DESCRIPTION
## Summary

- simplify the admin data-import UI wording and place Clean import before Incremental import
- make customer and instructor fixture generation independent through `--target`, `--number`, and `--start-id`
- align generated names, credentials, instructor nicknames, English backgrounds, schedules, and the ¥5,980 plan with the initial dummy-data generator
- add optional `--start-instructor-id` and `--end-instructor-id` customer fixture options
- generate and atomically import recurring classes and child attendance using round-robin instructor/slot assignment
- validate existing instructor IDs, active matching schedule slots, cross-file references, duplicates, and insufficient slot capacity
- document the updated commands and behavior

## Impact

Customer fixtures can now create two regular classes per ¥5,980 subscription. Instructor IDs are traversed inclusively in round-robin order, consuming one unique schedule slot per instructor on each pass. Existing three-file incremental customer ZIPs remain supported when the instructor range is omitted.

## Validation

- targeted incremental import suite: 11 tests passed
- TypeScript check passed
- frontend format, lint, unused-code, and production build passed
- backend format, unused-code, and production build passed
- `git diff --check` passed
- the full serial backend API suite was stopped due to runtime after the completed groups passed