### PR TITLE
Clarify instructor availability schedule timezone

### DIFF
--- a/frontend/src/app/instructors/(protected)/availability/AvailabilityPageClient.tsx
+++ b/frontend/src/app/instructors/(protected)/availability/AvailabilityPageClient.tsx
@@ -58,7 +58,7 @@ export default function AvailabilityPageClient({
   return (
     <div>
       <h1 className={styles.title}>Instructor Schedule Calendar</h1>
-      <p>This shows the current active schedule for this instructor.</p>
+      <p>This is your current schedule in Japan Standard Time (JST).</p>
       <ScheduleCalendar slots={slots} />
     </div>
   );


### PR DESCRIPTION
## Summary
- address the signed-in instructor directly on the availability page
- explicitly identify the schedule time zone as Japan Standard Time (JST)

## Why
The previous wording referred to “this instructor,” which could be confusing when viewed by the instructor themselves, and it did not explicitly name the displayed time zone.

## User impact
Instructors now see: “This is your current schedule in Japan Standard Time (JST).” Schedule behavior is unchanged.

## Validation
- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`

The production build completed successfully. It logged expected `ECONNREFUSED` messages while the backend was unavailable during static page generation.

Closes #601