### PR TITLE
Simplify instructor profile dialog frame

### DIFF
--- a/frontend/src/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
+++ b/frontend/src/components/customers-dashboard/instructor-profiles/InstructorProfileModal.module.scss
@@ -5,6 +5,5 @@
   flex-direction: column;
   align-items: flex-start;
   background-color: #fff;
-  padding: 40px;
-  max-width: 100vh;
+  max-width: min(100vh, calc(100vw - 32px));
 }

--- a/frontend/src/components/customers-dashboard/instructor-profiles/InstructorsList.tsx
+++ b/frontend/src/components/customers-dashboard/instructor-profiles/InstructorsList.tsx
@@ -156,6 +156,7 @@ export default function InstructorsList({
       {selectedInstructor && (
         <Modal
           isOpen={!!selectedInstructor}
+          className="instructorProfile"
           onClose={() => {
             if (clickedInstructor) {
               setClickedInstructor(null);

--- a/frontend/src/components/elements/modal/Modal.module.scss
+++ b/frontend/src/components/elements/modal/Modal.module.scss
@@ -77,3 +77,22 @@
     }
   }
 }
+
+.instructorProfile {
+  padding: 16px;
+
+  .modalContent {
+    background: transparent;
+    border-radius: 0.5rem;
+    max-height: min(700px, calc(100vh - 32px));
+  }
+
+  .closeButton {
+    z-index: 10001;
+    background-color: rgba(255, 255, 255, 0.9);
+
+    &:hover {
+      background-color: #fff;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- remove the padded outer-window appearance from instructor profile dialogs
- retain the dimmed overlay, close control, and bounded vertical scrolling
- add a 16px viewport gutter and responsive width cap for narrow screens
- scope the transparent modal surface to instructor profile dialogs so other modal styles are unchanged

## Why

The profile dialog wrapped the existing instructor profile card in a second white, padded surface. Showing the card as the dialog provides a cleaner single-panel presentation.

## Validation

- `frontend`: Prettier format check
- `frontend`: ESLint with zero warnings
- `frontend`: unused-code check
- `frontend`: production build
- `git diff --check`

The production build completed successfully. It logged non-fatal `ECONNREFUSED` messages for the system-status API because the backend was not running locally.

Closes #604