### PR TITLE
Localize regular class weekdays

### DIFF
--- a/frontend/src/components/customers-dashboard/regular-classes/RegularClassCard.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/RegularClassCard.tsx
@@ -41,7 +41,11 @@ function RegularClassCard({
   const classDateTime = new Date(recurringClass.dateTime);
   const startTime = formatTime(classDateTime, timeZone);
   const endTime = formatTime(getEndTime(classDateTime), timeZone);
-  const day = getWeekday(classDateTime, timeZone);
+  const day = getWeekday(
+    classDateTime,
+    timeZone,
+    language === "ja" ? "ja-JP" : "en-US",
+  );
 
   const handleEdit = (e: MouseEvent) => {
     e.stopPropagation();

--- a/frontend/src/lib/utils/dateUtils.ts
+++ b/frontend/src/lib/utils/dateUtils.ts
@@ -93,8 +93,12 @@ export function getEndTime(date: Date): Date {
 }
 
 // Function to return short form of the day of the week.
-export function getWeekday(date: Date, timeZone: string) {
-  return new Intl.DateTimeFormat("en-US", {
+export function getWeekday(
+  date: Date,
+  timeZone: string,
+  locale: string = "en-US",
+) {
+  return new Intl.DateTimeFormat(locale, {
     weekday: "short",
     timeZone,
   }).format(date);


### PR DESCRIPTION
## Summary

- make the shared weekday formatter accept a locale while preserving its existing English default
- display regular-class weekdays in Japanese or English based on the selected customer language
- retain `Asia/Tokyo` formatting so the schedule remains in JST

## Impact

Customers using Japanese now see weekday labels such as `月` instead of `Mon`; English display remains unchanged.

## Validation

- `npm run format`
- frontend CI-equivalent gate: Prettier format check, ESLint with zero warnings, unused-code check, and production build
- direct `Intl.DateTimeFormat` check confirmed `Mon` for `en-US` and `月` for `ja-JP` for the same JST date

The production build completed successfully. It logged expected `ECONNREFUSED` messages while trying to fetch local system status during static generation because the backend was not running.

Closes #605