### PR TITLE
Shorten Japanese customer profile edit label

### DIFF
--- a/frontend/src/components/customers-dashboard/profile/CustomerProfile.tsx
+++ b/frontend/src/components/customers-dashboard/profile/CustomerProfile.tsx
@@ -223,7 +223,7 @@ function CustomerProfile({
               ) : null}
               <ActionButton
                 className="editCustomer"
-                btnText={language === "ja" ? "プロフィールを編集" : "Edit"}
+                btnText={language === "ja" ? "編集" : "Edit"}
                 type="button"
                 onClick={(e) => {
                   e.preventDefault();


### PR DESCRIPTION
## Summary

- change the Japanese customer-profile edit button label from `プロフィールを編集` to `編集`
- leave the English label and all other profile behavior unchanged

## Why

The longer Japanese label is truncated in the customer profile layout. The shorter wording matches the other edit buttons and fits cleanly.

## Validation

- `npm run format`
- frontend CI-equivalent gate: Prettier format check, ESLint with zero warnings, unused-code check, and production build

The production build completed successfully. It logged expected `ECONNREFUSED` messages while trying to fetch local system status during static generation because the backend was not running.

Closes #606