### PR TITLE
Refresh class data after booking without reloading

### DIFF
--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/BookingModal.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/BookingModal.tsx
@@ -14,6 +14,7 @@ interface BookingModalProps {
   customerId: number;
   adminId?: number;
   plan?: Plan;
+  onBookingSuccess: () => void;
 }
 
 export default function BookingModal({
@@ -27,6 +28,7 @@ export default function BookingModal({
   customerId,
   adminId,
   plan,
+  onBookingSuccess,
 }: BookingModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} className="booking">
@@ -40,6 +42,7 @@ export default function BookingModal({
         customerId={customerId}
         adminId={adminId}
         plan={plan}
+        onBookingSuccess={onBookingSuccess}
       />
     </Modal>
   );

--- a/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/bookingActions/ProgressiveBookingFlow.tsx
@@ -30,6 +30,7 @@ interface ProgressiveBookingFlowProps {
   childProfiles: Child[];
   customerId: number;
   plan?: Plan;
+  onBookingSuccess: () => void;
 }
 
 type StepStatus = "completed" | "current" | "pending";
@@ -62,6 +63,7 @@ export default function ProgressiveBookingFlow({
   customerId,
   adminId,
   plan,
+  onBookingSuccess,
 }: ProgressiveBookingFlowProps) {
   // All hooks must be called at the top level
   const [selectedMode, setSelectedMode] = useState<
@@ -335,7 +337,7 @@ export default function ProgressiveBookingFlow({
           : "Booking completed successfully.",
       );
       onClose();
-      window.location.reload();
+      onBookingSuccess();
     } catch (error) {
       console.error("Booking failed:", error);
       errorAlert(language === "ja" ? "予約に失敗しました" : "Booking failed");

--- a/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookableClassList/RebookableClassList.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookableClassList/RebookableClassList.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/data/data";
 import BookingModal from "../../bookingActions/BookingModal";
 import { errorAlert } from "@/lib/utils/alertUtils";
+import { useBookingSuccess } from "../rebookingModalController/RebookingModalController";
 
 export default function RebookableClassList({
   customerId,
@@ -28,6 +29,8 @@ export default function RebookableClassList({
   userSessionType,
   childProfiles,
 }: RebookableClassListProps) {
+  const onBookingSuccess = useBookingSuccess();
+
   const handleRebook = (
     id: number,
     rebookableUntil: Date,
@@ -168,6 +171,7 @@ export default function RebookableClassList({
           customerId={customerId}
           adminId={adminId}
           plan={plan}
+          onBookingSuccess={onBookingSuccess}
         />
       )}
     </ul>

--- a/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookingModalController/RebookingModalController.tsx
+++ b/frontend/src/components/customers-dashboard/classes/classActions/rebookingActions/rebookingModalController/RebookingModalController.tsx
@@ -1,11 +1,26 @@
 "use client";
 
 import Modal from "@/components/elements/modal/Modal";
-import { useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { CHILD_PROFILE_REQUIRED_MESSAGE } from "@/lib/messages/customerDashboard";
 import { errorAlert } from "@/lib/utils/alertUtils";
+import { useRouter } from "next/navigation";
+
+const BookingSuccessContext = createContext<(() => void) | null>(null);
+
+export const useBookingSuccess = () => {
+  const onBookingSuccess = useContext(BookingSuccessContext);
+
+  if (!onBookingSuccess) {
+    throw new Error(
+      "useBookingSuccess must be used within RebookingModalController",
+    );
+  }
+
+  return onBookingSuccess;
+};
 
 export default function RebookingModalController({
   rebookableClasses,
@@ -15,8 +30,14 @@ export default function RebookingModalController({
   modalContent,
 }: RebookingModalControllerProps) {
   const { language } = useLanguage();
+  const router = useRouter();
   const [isRebookingModalOpen, setIsRebookingModalOpen] = useState(false);
   const rebookableClassesNumber = rebookableClasses.length;
+
+  const handleBookingSuccess = useCallback(() => {
+    setIsRebookingModalOpen(false);
+    router.refresh();
+  }, [router]);
 
   const handleRebookingClick = () => {
     if (!hasChildProfile)
@@ -39,13 +60,15 @@ export default function RebookingModalController({
           disabled={rebookableClassesNumber === 0}
         />
       ) : null}
-      <Modal
-        isOpen={isRebookingModalOpen}
-        onClose={() => setIsRebookingModalOpen(false)}
-        className="rebooking"
-      >
-        {modalContent}
-      </Modal>
+      <BookingSuccessContext.Provider value={handleBookingSuccess}>
+        <Modal
+          isOpen={isRebookingModalOpen}
+          onClose={() => setIsRebookingModalOpen(false)}
+          className="rebooking"
+        >
+          {modalContent}
+        </Modal>
+      </BookingSuccessContext.Provider>
     </>
   );
 }


### PR DESCRIPTION
## Summary

- replace the full browser reload after a successful class booking with a scoped Next.js `router.refresh()`
- keep success-toast behavior and close both the nested booking dialog and parent rebooking modal
- refresh server-rendered calendar data and rebookable-class counts after the mutation
- share the same success path for customer bookings and admin-assisted customer bookings

## Root cause

The booking flow owned only the nested dialog close callback, while the parent modal owned the rebookable count and the route's server components owned calendar data. A full browser reload was being used to reset all three layers at once.

The parent rebooking modal now owns the post-booking refresh callback. It provides that callback to the nested booking flow, closes itself on success, and refreshes the current Next.js route. The booking flow continues to own the success toast and its nested-dialog close.

## Validation

- `npm run format`
- frontend CI-equivalent gate: Prettier format check, ESLint with zero warnings, unused-code check, and production build
- reviewed both customer and admin-assisted render paths; both use the shared `ClassCalendar` and `RebookingActions` flow

The frontend package has no unit-test or component-test command, so no focused automated test was added. The production build completed successfully. It logged expected `ECONNREFUSED` messages while fetching local system status during static generation because the backend was not running.

Closes #607