### PR TITLE
Show instructors their fee history read-only

### DIFF
--- a/backend/src/controllers/instructorsController.ts
+++ b/backend/src/controllers/instructorsController.ts
@@ -1,6 +1,9 @@
 import { Instructor } from "@prisma/client";
 import { Request, Response } from "express";
-import { RequestWithParams } from "../middlewares/validationMiddleware";
+import {
+  RequestWithParams,
+  RequestWithQuery,
+} from "../middlewares/validationMiddleware";
 import {
   InstructorIdParams,
   ClassIdParams,
@@ -27,12 +30,48 @@ import {
 import { convertToTimezoneDate } from "../utils/dateUtils";
 import { EnglishBackground } from "../types";
 import { getTagsByInstructorIds } from "../services/instructorTagsService";
+import {
+  getInstructorFees,
+  InstructorFeeError,
+} from "../services/instructorFeeService";
 
 function setErrorResponse(res: Response, error: unknown) {
   return res
     .status(500)
     .json({ message: error instanceof Error ? error.message : `${error}` });
 }
+
+export const getMyInstructorFeesController = async (
+  req: RequestWithQuery<Record<string, never>>,
+  res: Response,
+) => {
+  if (!req.user?.id || req.user.userType !== "instructor") {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const instructorId = Number(req.user.id);
+  if (!Number.isSafeInteger(instructorId) || instructorId < 1) {
+    return res.status(401).json({ message: "Invalid authenticated user" });
+  }
+
+  try {
+    const fees = await getInstructorFees(instructorId);
+    return res.status(200).json(fees);
+  } catch (error) {
+    if (error instanceof InstructorFeeError) {
+      return res.status(error.statusCode).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    console.error("Failed to fetch authenticated instructor fees", {
+      error,
+      instructorId,
+    });
+    return res.status(500).json({ message: "Internal server error" });
+  }
+};
 
 // Fetch instructor id by class id
 export const getInstructorIdByClassIdController = async (

--- a/backend/src/routes/instructorsRouter.ts
+++ b/backend/src/routes/instructorsRouter.ts
@@ -9,6 +9,7 @@ import {
   getInstructorProfilesController,
   getSameDateClassesController,
   getInstructorProfilesByEnglishBackgroundController,
+  getMyInstructorFeesController,
 } from "../../src/controllers/instructorsController";
 import { registerRoutes } from "../middlewares/validationMiddleware";
 import {
@@ -48,6 +49,7 @@ import {
   UpdateInstructorTagsRequest,
 } from "../../../shared/schemas/instructors";
 import {
+  InstructorFeeRatesResponse,
   InstructorPayrollErrorResponse,
   InstructorPayrollQuery,
   InstructorPayrollResponse,
@@ -213,6 +215,39 @@ const instructorProfileConfig = {
       },
       500: {
         description: "Internal server error",
+      },
+    },
+  },
+} as const;
+
+const myInstructorFeesConfig = {
+  method: "get" as const,
+  middleware: [verifyAuthentication(AUTH_ROLES.I)] as RequestHandler[],
+  handler: getMyInstructorFeesController,
+  openapi: {
+    summary: "Get authenticated instructor fee history",
+    description:
+      "Get fee history for the authenticated instructor. The instructor identity is derived from the verified session.",
+    responses: {
+      200: {
+        description: "Instructor fee history retrieved successfully",
+        schema: InstructorFeeRatesResponse,
+      },
+      401: {
+        description: "Authentication required",
+        schema: MessageErrorResponse,
+      },
+      403: {
+        description: "Only instructors may access this endpoint",
+        schema: MessageErrorResponse,
+      },
+      404: {
+        description: "Instructor not found",
+        schema: MessageErrorResponse,
+      },
+      500: {
+        description: "Internal server error",
+        schema: MessageErrorResponse,
       },
     },
   },
@@ -762,6 +797,7 @@ const validatedRouteConfigs = {
   "/available-slots": [availableSlotsConfig],
   "/available-slots/by-type": [availableSlotsByTypeConfig],
   "/class/:id": [classInstructorConfig],
+  "/fees": [myInstructorFeesConfig],
   "/profiles": [profilesConfig],
   "/profiles/english-background/:englishBackground": [
     englishBackgroundProfilesConfig,

--- a/backend/src/test/api/instructors.test.ts
+++ b/backend/src/test/api/instructors.test.ts
@@ -10,6 +10,7 @@ import {
   createInstructorAbsence,
   createInstructorSchedule,
   createInstructorSlot,
+  createInstructorFee,
   createSchedule,
   generateAuthCookie,
 } from "../testUtils";
@@ -18,8 +19,9 @@ describe("GET /instructors/all-profiles", () => {
   it("succeed returning detailed instructor profiles", async () => {
     const customer = await createCustomer();
     const authCookie = await generateAuthCookie(customer.id, "customer");
+    const instructor = await createInstructor();
     await createInstructor();
-    await createInstructor();
+    await createInstructorFee(instructor.id);
 
     const response = await request(server)
       .get("/instructors/all-profiles")
@@ -27,6 +29,10 @@ describe("GET /instructors/all-profiles", () => {
       .expect(200);
 
     expect(response.body.instructorProfiles).toHaveLength(2);
+    for (const profile of response.body.instructorProfiles) {
+      expect(profile).not.toHaveProperty("fees");
+      expect(profile).not.toHaveProperty("instructorFees");
+    }
   });
 
   it("fail for unauthenticated request", async () => {
@@ -59,8 +65,9 @@ describe("GET /instructors/profiles", () => {
   it("succeed returning public instructor profiles", async () => {
     const customer = await createCustomer();
     const authCookie = await generateAuthCookie(customer.id, "customer");
+    const instructor = await createInstructor();
     await createInstructor();
-    await createInstructor();
+    await createInstructorFee(instructor.id);
 
     const response = await request(server)
       .get("/instructors/profiles")
@@ -68,6 +75,10 @@ describe("GET /instructors/profiles", () => {
       .expect(200);
 
     expect(response.body).toHaveLength(2);
+    for (const profile of response.body) {
+      expect(profile).not.toHaveProperty("fees");
+      expect(profile).not.toHaveProperty("instructorFees");
+    }
   });
 });
 

--- a/backend/src/test/api/instructors/fees.test.ts
+++ b/backend/src/test/api/instructors/fees.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { server } from "../../../server";
+import {
+  createCustomer,
+  createInstructor,
+  createInstructorFee,
+  generateAuthCookie,
+} from "../../testUtils";
+
+describe("GET /instructors/fees", () => {
+  it("returns only the authenticated instructor's fee history", async () => {
+    const instructor = await createInstructor();
+    const otherInstructor = await createInstructor();
+    const ownFee = await createInstructorFee(instructor.id, {
+      effectiveFrom: new Date("2026-02-01T00:00:00.000Z"),
+      effectiveTo: null,
+      regularFee: 2000,
+    });
+    await createInstructorFee(otherInstructor.id, {
+      effectiveFrom: new Date("2026-02-01T00:00:00.000Z"),
+      effectiveTo: null,
+      regularFee: 9000,
+    });
+
+    const response = await request(server)
+      .get("/instructors/fees")
+      .query({ instructorId: otherInstructor.id })
+      .set("Cookie", await generateAuthCookie(instructor.id, "instructor"))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      instructorId: instructor.id,
+      fees: [
+        expect.objectContaining({
+          id: ownFee.id,
+          regularFee: 2000,
+        }),
+      ],
+    });
+  });
+
+  it("rejects customer access", async () => {
+    const customer = await createCustomer();
+
+    const response = await request(server)
+      .get("/instructors/fees")
+      .set("Cookie", await generateAuthCookie(customer.id, "customer"))
+      .expect(403);
+
+    expect(response.body).toEqual({
+      message: "Forbidden: insufficient permissions",
+    });
+  });
+
+  it("rejects unauthenticated access", async () => {
+    const response = await request(server).get("/instructors/fees").expect(401);
+
+    expect(response.body).toEqual({ message: "No session token found" });
+  });
+});

--- a/frontend/src/app/instructors/(protected)/profile/page.tsx
+++ b/frontend/src/app/instructors/(protected)/profile/page.tsx
@@ -18,7 +18,9 @@ async function Page() {
     instructor = data.instructor;
   }
 
-  return <InstructorProfile instructor={instructor} />;
+  return (
+    <InstructorProfile instructor={instructor} userSessionType="instructor" />
+  );
 }
 
 export default Page;

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorFeeRates.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { toast } from "react-toastify";
 import ActionButton from "../../elements/buttons/actionButton/ActionButton";
@@ -9,6 +9,7 @@ import {
   deleteLatestInstructorFee,
   getInstructorFees,
 } from "@/lib/api/adminsApi";
+import { getMyInstructorFees } from "@/lib/api/instructorsApi";
 import { confirmAlert, errorAlert } from "@/lib/utils/alertUtils";
 import type { InstructorFeeRate } from "@shared/schemas/admins";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -106,11 +107,14 @@ function FeeRateCard({
   );
 }
 
-export default function InstructorFeeRates({
-  instructorId,
-}: {
-  instructorId: number;
-}) {
+type InstructorFeeRatesProps =
+  | { access: "admin"; instructorId: number }
+  | { access: "instructor"; instructorId?: never };
+
+export default function InstructorFeeRates(props: InstructorFeeRatesProps) {
+  const { access } = props;
+  const instructorId =
+    props.access === "admin" ? props.instructorId : undefined;
   const [fees, setFees] = useState<InstructorFeeRate[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -118,14 +122,17 @@ export default function InstructorFeeRates({
   const [formState, setFormState] = useState(createFormState());
   const { language } = useLanguage();
 
-  const applyFees = (nextFees: InstructorFeeRate[]) => {
+  const applyFees = useCallback((nextFees: InstructorFeeRate[]) => {
     setFees(nextFees);
     setFormState(createFormState(nextFees[0] ?? null));
-  };
+  }, []);
 
-  const loadFees = async () => {
+  const loadFees = useCallback(async () => {
     setIsLoading(true);
-    const response = await getInstructorFees(instructorId);
+    const response =
+      access === "admin"
+        ? await getInstructorFees(instructorId!)
+        : await getMyInstructorFees();
     if ("status" in response) {
       setIsLoading(false);
       await errorAlert(response.message);
@@ -134,12 +141,17 @@ export default function InstructorFeeRates({
 
     applyFees(response.fees);
     setIsLoading(false);
-  };
+  }, [access, applyFees, instructorId]);
 
   useEffect(() => {
     let isMounted = true;
 
-    getInstructorFees(instructorId).then(async (response) => {
+    const request =
+      access === "admin"
+        ? getInstructorFees(instructorId!)
+        : getMyInstructorFees();
+
+    request.then(async (response) => {
       if (!isMounted) {
         return;
       }
@@ -157,7 +169,7 @@ export default function InstructorFeeRates({
     return () => {
       isMounted = false;
     };
-  }, [instructorId]);
+  }, [access, applyFees, instructorId]);
 
   const activeFee = fees.find((fee) => fee.effectiveTo === null) ?? fees[0];
   const historicalFees = activeFee
@@ -182,6 +194,10 @@ export default function InstructorFeeRates({
   };
 
   const handleCreateFee = async () => {
+    if (access !== "admin" || instructorId === undefined) {
+      return;
+    }
+
     const trialFee = Number(formState.trialFee);
     const regularFee = Number(formState.regularFee);
     const cancelFee = Number(formState.cancelFee);
@@ -227,7 +243,12 @@ export default function InstructorFeeRates({
   };
 
   const handleDeleteLatest = async () => {
-    if (!activeFee || fees.length < 2) {
+    if (
+      access !== "admin" ||
+      instructorId === undefined ||
+      !activeFee ||
+      fees.length < 2
+    ) {
       return;
     }
 
@@ -263,15 +284,15 @@ export default function InstructorFeeRates({
           ) : activeFee ? (
             <FeeRateCard
               fee={activeFee}
-              isLatest={true}
-              onDelete={handleDeleteLatest}
+              isLatest={access === "admin"}
+              onDelete={access === "admin" ? handleDeleteLatest : undefined}
               isDeleteDisabled={isSubmitting || fees.length < 2}
             />
           ) : (
             <p className={styles.feeMutedText}>No fee rates registered yet.</p>
           )}
 
-          {isFormOpen && (
+          {access === "admin" && isFormOpen && (
             <div className={styles.feeForm}>
               <h4 className={styles.feeFormTitle}>New fee rate</h4>
               <div className={styles.feeFormGrid}>
@@ -356,34 +377,36 @@ export default function InstructorFeeRates({
             </div>
           )}
 
-          <div className={styles.feeActions}>
-            {isFormOpen ? (
-              <>
+          {access === "admin" && (
+            <div className={styles.feeActions}>
+              {isFormOpen ? (
+                <>
+                  <ActionButton
+                    type="button"
+                    onClick={handleCancelForm}
+                    btnText="Cancel"
+                    className="cancelBtn"
+                    disabled={isSubmitting}
+                  />
+                  <ActionButton
+                    type="button"
+                    onClick={handleCreateFee}
+                    btnText={isSubmitting ? "Saving..." : "Save"}
+                    className="saveBtn"
+                    disabled={isSubmitting}
+                  />
+                </>
+              ) : (
                 <ActionButton
                   type="button"
-                  onClick={handleCancelForm}
-                  btnText="Cancel"
-                  className="cancelBtn"
+                  onClick={handleOpenForm}
+                  btnText="Change fee rate"
+                  className="addBtn"
                   disabled={isSubmitting}
                 />
-                <ActionButton
-                  type="button"
-                  onClick={handleCreateFee}
-                  btnText={isSubmitting ? "Saving..." : "Save"}
-                  className="saveBtn"
-                  disabled={isSubmitting}
-                />
-              </>
-            ) : (
-              <ActionButton
-                type="button"
-                onClick={handleOpenForm}
-                btnText="Change fee rate"
-                className="addBtn"
-                disabled={isSubmitting}
-              />
-            )}
-          </div>
+              )}
+            </div>
+          )}
 
           <details className={styles.feeHistory}>
             <summary>Rate history</summary>

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -696,11 +696,16 @@ function InstructorProfile({
               </div>
             )}
 
-            {userSessionType === "admin" &&
-              !isCustomerView &&
-              latestInstructor && (
-                <InstructorFeeRates instructorId={latestInstructor.id} />
-              )}
+            {!isCustomerView &&
+              latestInstructor &&
+              (userSessionType === "admin" ? (
+                <InstructorFeeRates
+                  access="admin"
+                  instructorId={latestInstructor.id}
+                />
+              ) : userSessionType === "instructor" ? (
+                <InstructorFeeRates access="instructor" />
+              ) : null)}
 
             {(latestInstructor.tags?.length || 0) > 0 && (
               <div className={styles.insideContainer}>

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -34,12 +34,18 @@ import type {
   UpdateInstructorTagsRequest,
 } from "@shared/schemas/instructors";
 import { EnglishBackground } from "@/types";
+import type { InstructorFeeRatesResponse } from "@shared/schemas/admins";
 
 const BACKEND_ORIGIN =
   process.env.NEXT_PUBLIC_BACKEND_ORIGIN || "http://localhost:4000";
 const BASE_URL = `${BACKEND_ORIGIN}/instructors`;
 
 type Response<T> = T | { message: string };
+type InstructorFeeApiError = {
+  status: number;
+  code: string;
+  message: string;
+};
 
 export type InstructorSlot = {
   scheduleId: number;
@@ -49,6 +55,47 @@ export type InstructorSlot = {
 
 export type InstructorScheduleWithSlots = InstructorSchedule & {
   slots: InstructorSlot[];
+};
+
+export const getMyInstructorFees = async (): Promise<
+  InstructorFeeRatesResponse | InstructorFeeApiError
+> => {
+  try {
+    const backendEndpoint = "/instructors/fees";
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "backend-endpoint": backendEndpoint,
+          "no-cache": "true",
+        },
+      },
+    );
+    const data = await response.json();
+
+    if (response.status !== 200) {
+      return {
+        status: response.status,
+        code:
+          typeof data?.code === "string" ? data.code : "INSTRUCTOR_FEE_ERROR",
+        message:
+          typeof data?.message === "string"
+            ? data.message
+            : `HTTP error! status: ${response.status}`,
+      };
+    }
+
+    return data as InstructorFeeRatesResponse;
+  } catch (error) {
+    console.error("Failed to fetch authenticated instructor fees:", error);
+    return {
+      status: 500,
+      code: "INSTRUCTOR_FEE_ERROR",
+      message: GENERAL_ERROR_MESSAGE,
+    };
+  }
 };
 
 // GET instructors data


### PR DESCRIPTION
## Summary

- add a parameterless instructor-only fee-history endpoint that derives the instructor ID exclusively from the verified session
- reuse the existing fee-rate component in a read-only instructor mode while preserving admin create/delete controls
- show current and historical fee rates on the signed-in instructor profile page
- add authorization and data-isolation coverage for self access, ignored arbitrary query IDs, customer denial, unauthenticated denial, and customer profile payloads

## Security

`GET /instructors/fees` does not accept an instructor ID in its route contract. It is restricted to instructor sessions and queries fee history using the authenticated JWT identity. Existing customer-facing profile endpoints and schemas remain fee-free, with regression assertions covering both customer-accessible profile responses.

## Validation

- focused backend API tests: 2 files, 13 tests
- backend and frontend `npx tsc --noEmit`
- full all-scope CI-equivalent gate:
  - frontend format check, zero-warning ESLint, unused-code check, and production build
  - backend format, unused-code check, 30 API files / 268 tests, and build/migrate/bootstrap
- `git diff --check`

The frontend build logged existing non-fatal backend `ECONNREFUSED` messages during static generation and completed successfully.

Closes #602