### PR TITLE
Use local default icons in import fixtures

### DIFF
--- a/backend/src/seed/generateIncrementalImportFixture.ts
+++ b/backend/src/seed/generateIncrementalImportFixture.ts
@@ -52,8 +52,7 @@ const MAX_COUNT = 99_999;
 const DEFAULT_START_ID = 1;
 const MAX_ID = 99_999;
 const FAKER_SEED = 20250301;
-const DEFAULT_DUMMY_INSTRUCTOR_ICON_URL =
-  "http://localhost:3000/images/default-user-icon.jpg";
+const DEFAULT_DUMMY_INSTRUCTOR_ICON = "/images/default-user-icon.jpg";
 const PATTERN_A_SLOTS = buildPatternSlots(
   ["1", "2", "3"],
   ["16:00", "16:30", "17:00", "17:30", "18:00"],
@@ -405,7 +404,7 @@ function instructorRows(
       email: `${lowerRef}@example.com`,
       temp_password: `Temp-${lowerRef}`,
       class_url: `https://class.example.com/${lowerRef}`,
-      icon: `${DEFAULT_DUMMY_INSTRUCTOR_ICON_URL}?id=${lowerRef}`,
+      icon: `${DEFAULT_DUMMY_INSTRUCTOR_ICON}?id=${lowerRef}`,
       nickname,
       meeting_id: `MID${String(index).padStart(4, "0")}`,
       passcode: `PIN${String(index).padStart(4, "0")}`,

--- a/backend/src/seed/generateNormalizedImportFixture.ts
+++ b/backend/src/seed/generateNormalizedImportFixture.ts
@@ -13,6 +13,7 @@ const FAKER_SEED = 20250301;
 
 const DEFAULT_INSTRUCTOR_COUNT = 10;
 const CUSTOMERS_PER_INSTRUCTOR = 10;
+const DEFAULT_DUMMY_INSTRUCTOR_ICON = "/images/default-user-icon.jpg";
 
 const PATTERN_A_SLOTS: SlotDef[] = buildPatternSlots(
   [1, 2, 3],
@@ -468,7 +469,7 @@ function instructorRows(
       email: `${lowerRef}@example.com`,
       temp_password: `Temp-${lowerRef}`,
       class_url: `https://class.example.com/${lowerRef}`,
-      icon: `https://img.example.com/${lowerRef}.png`,
+      icon: `${DEFAULT_DUMMY_INSTRUCTOR_ICON}?id=${lowerRef}`,
       nickname,
       meeting_id: `MID${String(i).padStart(4, "0")}`,
       passcode: `PIN${String(i).padStart(4, "0")}`,

--- a/backend/src/services/adminImport/incremental.ts
+++ b/backend/src/services/adminImport/incremental.ts
@@ -652,12 +652,21 @@ function validateFileData(
           const url = new URL(row.data[column]);
           if (!["http:", "https:"].includes(url.protocol)) throw new Error();
         } catch {
+          if (
+            column === "icon" &&
+            row.data[column].startsWith("/images/") &&
+            !row.data[column].startsWith("//")
+          ) {
+            continue;
+          }
           issue(
             issues,
             "instructors.csv",
             row.rowNumber,
             column,
-            "URL must use http or https",
+            column === "icon"
+              ? "URL must use http or https or a local /images/ path"
+              : "URL must use http or https",
           );
         }
       }

--- a/backend/src/test/api/admins/import-incremental.test.ts
+++ b/backend/src/test/api/admins/import-incremental.test.ts
@@ -136,7 +136,7 @@ describe("incremental admin imports", () => {
       ",in0031@example.com,Temp-in0031,",
     );
     expect(instructorFixture.instructorFiles["instructors.csv"]).toContain(
-      ",http://localhost:3000/images/default-user-icon.jpg?id=in0031,",
+      ",/images/default-user-icon.jpg?id=in0031,",
     );
     expect(instructorFixture.instructorFiles["instructors.csv"]).not.toContain(
       "Incremental Instructor",

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -616,6 +616,9 @@ describe("POST /admins/import/execute", () => {
     expect(validation.issues).toEqual([]);
     expect(validation.isValid).toBe(true);
     expect(generated.rows["instructors.csv"]).toHaveLength(5);
+    expect(generated.files["instructors.csv"]).toContain(
+      ",/images/default-user-icon.jpg?id=in0001,",
+    );
     expect(generated.rows["customers.csv"]).toHaveLength(50);
     expect(generated.rows["children.csv"]).toHaveLength(55);
     expect(generated.rows["subscriptions.csv"]).toHaveLength(50);


### PR DESCRIPTION
## Summary

- use the bundled `/images/default-user-icon.jpg` asset in both normalized and incremental instructor fixtures
- keep instructor icon values unique with deterministic instructor-reference query parameters
- allow incremental instructor imports to accept local `/images/` icon paths while retaining HTTP/HTTPS validation for class URLs
- add regression coverage for both fixture generators

## Why

PR #609 updated the incremental fixture to use the default icon, but it hard-coded the localhost frontend origin while the normalized fixture still generated an external placeholder URL. This made generated icon values environment-specific and inconsistent.

Both generators now emit values such as `/images/default-user-icon.jpg?id=in0001`, which resolve against the active frontend origin in local and deployed environments. The query parameter is required because `Instructor.icon` is unique in the database.

## Validation

- backend formatting
- backend unused-code check
- 30 API test files / 268 tests
- backend build, migration deploy, and bootstrap
- `git diff --check`

Follow-up to #609.