### PR TITLE
Fix instructor image upload size handling

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -44,6 +44,11 @@ const securityHeaders = [
 ];
 
 const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "6mb",
+    },
+  },
   turbopack: {
     resolveAlias: {
       "@": "./src",

--- a/frontend/src/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/components/features/registerForm/RegisterForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useRef, useState } from "react";
+import { useActionState, useState } from "react";
 import styles from "./RegisterForm.module.scss";
 import {
   EnvelopeIcon,
@@ -61,7 +61,6 @@ const RegisterForm = ({
   const { localMessages, clearErrorMessage, resetMessages } =
     useFormMessages(registerResultState);
   const { passwordStrength } = usePasswordStrength(password);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [englishBackground, setEnglishBackground] = useState<EnglishBackground>(
     EnglishBackground.NonNative,
   );
@@ -385,27 +384,7 @@ const RegisterForm = ({
               </div>
 
               {/* Image File */}
-              <input
-                type="file"
-                name="icon"
-                ref={fileInputRef}
-                style={{ display: "none" }}
-              />
-              <Uploader
-                onFileSelect={(file) => {
-                  if (fileInputRef.current && file) {
-                    const dataTransfer = new DataTransfer();
-                    dataTransfer.items.add(file);
-                    fileInputRef.current.files = dataTransfer.files;
-                  }
-                }}
-                clearFileInputRef={() => {
-                  if (fileInputRef.current) {
-                    fileInputRef.current.value = "";
-                  }
-                }}
-                label={"Instructor profile image"}
-              />
+              <Uploader label={"Instructor profile image"} />
             </>
           )}
         </>

--- a/frontend/src/components/features/registerForm/uploadImages/Uploader.tsx
+++ b/frontend/src/components/features/registerForm/uploadImages/Uploader.tsx
@@ -1,36 +1,38 @@
 "use client";
 
-import React, { ChangeEvent, DragEvent, useState } from "react";
+import React, { ChangeEvent, DragEvent, useRef, useState } from "react";
 import styles from "./Uploader.module.scss";
 import { PhotoIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 
 type UploaderProps = {
-  onFileSelect: (file: File | null) => void;
-  clearFileInputRef?: () => void;
   label?: string;
 };
 
-function Uploader({ onFileSelect, clearFileInputRef, label }: UploaderProps) {
+function Uploader({ label }: UploaderProps) {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState<string>("");
   const [isDragging, setIsDragging] = useState<boolean>(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0] as File;
     const url = URL.createObjectURL(e.target.files?.[0] as File);
     setFile(selectedFile);
     setFileName(url);
-    onFileSelect(selectedFile);
   };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const droppedFile = e.dataTransfer.files?.[0] as File;
     const url = URL.createObjectURL(e.dataTransfer.files?.[0] as File);
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(droppedFile);
+    if (fileInputRef.current) {
+      fileInputRef.current.files = dataTransfer.files;
+    }
     setFile(droppedFile);
     setFileName(url);
-    onFileSelect(droppedFile);
     setIsDragging(false);
   };
 
@@ -42,15 +44,13 @@ function Uploader({ onFileSelect, clearFileInputRef, label }: UploaderProps) {
   const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setIsDragging(false);
-    onFileSelect(null);
   };
 
   const handleRemoveFile = () => {
     setFile(null);
     setFileName("");
-    onFileSelect(null);
-    if (typeof clearFileInputRef === "function") {
-      clearFileInputRef();
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
     }
   };
 
@@ -74,6 +74,7 @@ function Uploader({ onFileSelect, clearFileInputRef, label }: UploaderProps) {
               type="file"
               id="icon"
               name="icon"
+              ref={fileInputRef}
               accept=".png,.jpg"
               onChange={handleFileChange}
               hidden

--- a/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
+++ b/frontend/src/components/instructors-dashboard/instructor-profile/InstructorProfile.tsx
@@ -112,7 +112,6 @@ function InstructorProfile({
   const [isEditing, setIsEditing] = useState(false);
   const [userStatus, setUserStatus] = useState<string>("Active");
   const [leavingDate, setLeavingDate] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const { language } = useLanguage();
   const formRef = useRef<HTMLFormElement>(null);
   const englishBackgroundClassNames = ["", "nativeA", "nativeB"] as const;
@@ -246,26 +245,7 @@ function InstructorProfile({
               <>
                 {/* Image Uploader */}
                 <p className={styles.profileImage__text}>Profile Image</p>
-                <input
-                  type="file"
-                  name="icon"
-                  ref={fileInputRef}
-                  style={{ display: "none" }}
-                />
-                <Uploader
-                  onFileSelect={(file) => {
-                    if (fileInputRef.current && file) {
-                      const dataTransfer = new DataTransfer();
-                      dataTransfer.items.add(file);
-                      fileInputRef.current.files = dataTransfer.files;
-                    }
-                  }}
-                  clearFileInputRef={() => {
-                    if (fileInputRef.current) {
-                      fileInputRef.current.value = "";
-                    }
-                  }}
-                />
+                <Uploader />
               </>
             )}
 
@@ -741,11 +721,6 @@ function InstructorProfile({
 
             {/* Hidden input fields */}
             <input type="hidden" name="id" value={latestInstructor.id} />
-            <input
-              type="hidden"
-              name="icon"
-              value={latestInstructor.icon.url}
-            />
 
             {/* Action buttons for only admin */}
             {userSessionType === "admin" &&


### PR DESCRIPTION
## Summary

- submit instructor profile images through a single file input for both registration and profile editing
- preserve browse, drag-and-drop, preview, and removal behavior inside the reusable uploader
- raise the Next.js Server Action body limit to 6 MB to support the existing 5 MiB image validation with multipart overhead

## Root cause

The instructor profile form contained two file inputs named `icon`. Selecting a file left it in the uploader input and copied it into the second hidden input, so a 554 KB image was serialized twice and exceeded Next.js's default 1 MB Server Action request limit. The UI and schema also advertised a 5 MB maximum without configuring a matching Server Action limit.

## Impact

Instructor image uploads below the existing 5 MiB validation limit can reach the server action without duplicate file data or a premature 413 response.

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`

All frontend CI-equivalent checks passed. Backend checks were skipped because backend and shared code are unchanged.