### PR TITLE
Remove duplicate instructor registration scrollbar

### DIFF
--- a/frontend/src/components/admins-dashboard/ListPageRegistrationModal.module.scss
+++ b/frontend/src/components/admins-dashboard/ListPageRegistrationModal.module.scss
@@ -6,8 +6,6 @@
   align-items: flex-start;
   background-color: #fff;
   padding: 40px;
-  max-height: 90vh;
-  overflow-x: hidden;
 
   h2 {
     align-self: center;


### PR DESCRIPTION
## Summary

- remove the registration panel's redundant nested scroll context
- keep vertical scrolling owned by the shared modal container

## Root cause

The registration panel set `overflow-x: hidden` alongside a height limit. CSS computes the other overflow axis as scrollable in that situation, while the shared modal already provides vertical scrolling. This produced two adjacent scrollbars for the long instructor registration form.

## Impact

The admin instructor registration dialog now displays a single vertical scrollbar without changing the form fields or submission behavior.

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`
- `git diff --check`