### PR TITLE
Align class calendars to the current three-month range

### DIFF
--- a/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.tsx
+++ b/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.tsx
@@ -2,12 +2,9 @@
 
 import { useCallback, useEffect, useState } from "react";
 import styles from "./InstructorCalendarForAdmin.module.scss";
-import {
-  getCalendarClasses,
-  getInstructorProfile,
-} from "@/lib/api/instructorsApi";
+import { getCalendarClasses } from "@/lib/api/instructorsApi";
 import Loading from "../elements/loading/Loading";
-import { getValidRange } from "@/lib/utils/calendarUtils";
+import { getCurrentMonthValidRange } from "@/lib/utils/calendarUtils";
 import { initialSetup } from "@/lib/utils/initialSetup";
 import InstructorCalendarClient from "../instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient";
 import InstructorSearch from "@/components/admins-dashboard/InstructorSearch";
@@ -40,17 +37,14 @@ function InstructorCalendarForAdmin({
     if (!instructorId) return;
 
     try {
-      const [classes, instructorProfile, schedule, events] = await Promise.all([
+      const [classes, schedule, events] = await Promise.all([
         getCalendarClasses(instructorId),
-        getInstructorProfile(instructorId),
         getAllBusinessSchedules(),
         getAllEvents(),
       ]);
 
       setInstructorCalendarEvents(classes);
-      const instructorCreatedAt = instructorProfile.createdAt;
-      const calendarValidRange = getValidRange(instructorCreatedAt, 3);
-      setCalendarValidRange(calendarValidRange);
+      setCalendarValidRange(getCurrentMonthValidRange(3));
       setSchedule(schedule);
       const colorsForEvents: { event: string; color: string }[] = events
         .map((e: EventColor) => ({

--- a/frontend/src/components/customers-dashboard/classes/ClassCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/ClassCalendar.tsx
@@ -34,7 +34,6 @@ export default async function ClassCalendar({
       getMessageBoardPosts(cookie),
     ]);
 
-  const createdAt = customer.createdAt;
   const hasSeenWelcomeModal = customer.hasSeenWelcome;
   const terminationAt = customer.terminationAt;
 
@@ -68,7 +67,6 @@ export default async function ClassCalendar({
       <CustomerCalendar
         customerId={customerId}
         classes={classes}
-        createdAt={createdAt}
         businessSchedule={schedule.organizedData}
         colorsForEvents={colorsForEvents}
         userSessionType={userSessionType}

--- a/frontend/src/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
@@ -21,7 +21,6 @@ import CalendarLegend from "@/components/features/calendarLegend/CalendarLegend"
 export default function CustomerCalendar({
   customerId,
   classes,
-  createdAt,
   businessSchedule,
   colorsForEvents,
   userSessionType,
@@ -39,7 +38,14 @@ export default function CustomerCalendar({
     setIsClassDetailModalOpen(true);
   };
 
-  const validRange = () => getValidRange(createdAt, 3);
+  const validRange = () => {
+    const now = new Date();
+    const currentMonthStart = `${now.getFullYear()}-${String(
+      now.getMonth() + 1,
+    ).padStart(2, "0")}-01`;
+
+    return getValidRange(currentMonthStart, 3);
+  };
   const renderCustomerEventContent = createRenderEventContent("customer");
 
   const handleModalClose = () => {

--- a/frontend/src/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
+++ b/frontend/src/components/customers-dashboard/classes/customerCalensar/CustomerCalendar.tsx
@@ -13,8 +13,8 @@ import Modal from "@/components/elements/modal/Modal";
 import ClassDetail from "@/components/features/classDetail/ClassDetail";
 import {
   createRenderEventContent,
+  getCurrentMonthValidRange,
   getDayCellColorHandler,
-  getValidRange,
 } from "@/lib/utils/calendarUtils";
 import CalendarLegend from "@/components/features/calendarLegend/CalendarLegend";
 
@@ -38,14 +38,7 @@ export default function CustomerCalendar({
     setIsClassDetailModalOpen(true);
   };
 
-  const validRange = () => {
-    const now = new Date();
-    const currentMonthStart = `${now.getFullYear()}-${String(
-      now.getMonth() + 1,
-    ).padStart(2, "0")}-01`;
-
-    return getValidRange(currentMonthStart, 3);
-  };
+  const validRange = () => getCurrentMonthValidRange(3);
   const renderCustomerEventContent = createRenderEventContent("customer");
 
   const handleModalClose = () => {

--- a/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorSlotScheduleClient.tsx
+++ b/frontend/src/components/instructors-dashboard/class-schedule/instructorCalendar/InstructorSlotScheduleClient.tsx
@@ -2,6 +2,7 @@
 
 import InstructorSlotCalendar from "@/components/features/instructorSlotCalendar/InstructorSlotCalendar";
 import MessageBoardPanel from "@/components/features/messageBoardPanel/MessageBoardPanel";
+import { getCurrentMonthValidRange } from "@/lib/utils/calendarUtils";
 import { MessageTarget } from "@/types";
 import styles from "./InstructorCalendarClient.module.scss";
 
@@ -37,6 +38,7 @@ export default function InstructorSlotScheduleClient({
           slotMaxTime: "24:00:00",
           slotDuration: "00:30:00",
           timeZone: "local",
+          validRange: getCurrentMonthValidRange(3),
         }}
       />
     </div>

--- a/frontend/src/lib/types.d.ts
+++ b/frontend/src/lib/types.d.ts
@@ -356,7 +356,6 @@ type BusinessCalendarClientProps = {
 type CustomerCalendarProps = {
   customerId: number;
   classes: CustomerClass[] | [];
-  createdAt: string;
   businessSchedule: BusinessSchedule[];
   colorsForEvents: { event: string; color: string }[];
   userSessionType?: UserType;

--- a/frontend/src/lib/utils/calendarUtils.tsx
+++ b/frontend/src/lib/utils/calendarUtils.tsx
@@ -117,12 +117,12 @@ export const createRenderEventContent = (userType: UserType) => {
   return RenderEventContent;
 };
 
-export const getValidRange = (createdAt: string, monthsAhead: number) => {
+export const getValidRange = (startDate: string, monthsAhead: number) => {
   const now = new Date();
   const end = new Date(now.getFullYear(), now.getMonth() + monthsAhead, 1);
 
   return {
-    start: createdAt.split("T")[0],
+    start: startDate.split("T")[0],
     end: end.toISOString().split("T")[0],
   };
 };

--- a/frontend/src/lib/utils/calendarUtils.tsx
+++ b/frontend/src/lib/utils/calendarUtils.tsx
@@ -117,13 +117,25 @@ export const createRenderEventContent = (userType: UserType) => {
   return RenderEventContent;
 };
 
-export const getValidRange = (startDate: string, monthsAhead: number) => {
+const getValidRange = (startDate: string, monthsAhead: number) => {
   const now = new Date();
   const end = new Date(now.getFullYear(), now.getMonth() + monthsAhead, 1);
 
   return {
     start: startDate.split("T")[0],
     end: end.toISOString().split("T")[0],
+  };
+};
+
+export const getCurrentMonthValidRange = (monthsAhead: number) => {
+  const now = new Date();
+  const end = new Date(now.getFullYear(), now.getMonth() + monthsAhead, 1);
+  const formatMonthStart = (date: Date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-01`;
+
+  return {
+    start: formatMonthStart(now),
+    end: formatMonthStart(end),
   };
 };
 


### PR DESCRIPTION
## What changed

- Use a shared date range covering the current month, next month, and the following month for customer, admin instructor, and instructor class calendars.
- Start each range on the first day of the current month so earlier classes in the month remain visible.
- Remove the customer account creation date from customer calendar props.
- Remove the unnecessary instructor profile request that was only used to derive the admin calendar's start date.

## Why

The customer and admin instructor calendars previously used account creation dates as their lower boundaries. For migrated or newly imported records, those dates can be later than existing classes, causing past dates in the current month to appear disabled and hiding classes already returned by the API. The instructor's newer slot calendar had no equivalent three-month boundary, so the three class-calendar views behaved inconsistently.

## Impact

Customers, admins, and instructors can see completed or canceled classes from earlier in the current month. Dates before the current month and after the following two months remain outside the class calendar range.

## Validation

- `npm run format`
- Frontend CI-equivalent gate:
  - `npm run format-check`
  - `npm run lint -- --max-warnings 0`
  - `npm run lint:unused`
  - `npm run build`

The full frontend gate was rerun after extending the change to the admin and instructor calendars.