### PR TITLE
Unify class calendar status colors

### DIFF
--- a/backend/src/services/classesService.ts
+++ b/backend/src/services/classesService.ts
@@ -10,9 +10,7 @@ import {
 import {
   CANCELED_CLASS_COLOR,
   COMPLETED_CLASS_COLOR,
-  FREE_TRIAL_CLASS_COLOR,
-  REBOOKED_CLASS_COLOR,
-  REGULAR_CLASS_COLOR,
+  UPCOMING_CLASS_COLOR,
 } from "../utils/colors";
 import { getInstructorAvailableSlots } from "./instructorScheduleService";
 
@@ -676,21 +674,15 @@ export const getCustomerClasses = async (customerId: number) => {
     const end = new Date(new Date(start).getTime() + 25 * 60000).toISOString();
 
     const statusColorMap: Partial<Record<Status, string>> = {
-      booked: REGULAR_CLASS_COLOR,
-      rebooked: REBOOKED_CLASS_COLOR,
+      booked: UPCOMING_CLASS_COLOR,
+      rebooked: UPCOMING_CLASS_COLOR,
       canceledByCustomer: CANCELED_CLASS_COLOR,
       canceledByInstructor: CANCELED_CLASS_COLOR,
       canceledByAdmin: CANCELED_CLASS_COLOR,
       completed: COMPLETED_CLASS_COLOR,
     };
 
-    const isBookedOrRebooked =
-      classItem.status === "booked" || classItem.status === "rebooked";
-
-    const color =
-      classItem.isFreeTrial && isBookedOrRebooked
-        ? FREE_TRIAL_CLASS_COLOR
-        : statusColorMap[classItem.status];
+    const color = statusColorMap[classItem.status];
 
     const childrenNames = classItem.classAttendance
       .map((attendance) => attendance.children.name)
@@ -752,20 +744,14 @@ export const getCalendarClasses = async (instructorId: number) => {
     const end = new Date(new Date(start).getTime() + 25 * 60000).toISOString();
 
     const statusColorMap: Partial<Record<Status, string>> = {
-      booked: REGULAR_CLASS_COLOR,
-      rebooked: REBOOKED_CLASS_COLOR,
+      booked: UPCOMING_CLASS_COLOR,
+      rebooked: UPCOMING_CLASS_COLOR,
       canceledByInstructor: CANCELED_CLASS_COLOR,
       canceledByAdmin: CANCELED_CLASS_COLOR,
       completed: COMPLETED_CLASS_COLOR,
     };
 
-    const isBookedOrRebooked =
-      classItem.status === "booked" || classItem.status === "rebooked";
-
-    const color =
-      classItem.isFreeTrial && isBookedOrRebooked
-        ? FREE_TRIAL_CLASS_COLOR
-        : statusColorMap[classItem.status];
+    const color = statusColorMap[classItem.status];
 
     const childrenNames = classItem.classAttendance
       .map((attendance) => attendance.children.name)

--- a/backend/src/services/instructorScheduleService.ts
+++ b/backend/src/services/instructorScheduleService.ts
@@ -5,9 +5,7 @@ import { EnglishBackground } from "../types";
 import {
   CANCELED_CLASS_COLOR,
   COMPLETED_CLASS_COLOR,
-  FREE_TRIAL_CLASS_COLOR,
-  REBOOKED_CLASS_COLOR,
-  REGULAR_CLASS_COLOR,
+  UPCOMING_CLASS_COLOR,
 } from "../utils/colors";
 import {
   NO_CLASS_EVENT_NAME,
@@ -520,17 +518,14 @@ export const getInstructorCalendarSlots = async (
       Extract<Status, "booked" | "rebooked" | "completed">,
       string
     > = {
-      booked: REGULAR_CLASS_COLOR,
-      rebooked: REBOOKED_CLASS_COLOR,
+      booked: UPCOMING_CLASS_COLOR,
+      rebooked: UPCOMING_CLASS_COLOR,
       completed: COMPLETED_CLASS_COLOR,
     };
 
     const classSlots = classes
       .filter((classItem) => classItem.dateTime !== null)
       .map((classItem) => {
-        const isBookedOrRebooked =
-          classItem.status === "booked" || classItem.status === "rebooked";
-
         return {
           start: classItem.dateTime!.toISOString(),
           end: new Date(
@@ -541,9 +536,7 @@ export const getInstructorCalendarSlots = async (
               .map((attendance) => attendance.children.name)
               .join(", ") || "Class",
           color:
-            classItem.isFreeTrial && isBookedOrRebooked
-              ? FREE_TRIAL_CLASS_COLOR
-              : statusColorMap[classItem.status as keyof typeof statusColorMap],
+            statusColorMap[classItem.status as keyof typeof statusColorMap],
           slotType: classItem.status as "booked" | "rebooked" | "completed",
           classId: classItem.id,
         };

--- a/backend/src/utils/colors.ts
+++ b/backend/src/utils/colors.ts
@@ -1,14 +1,8 @@
-// Regular (booked) class
-export const REGULAR_CLASS_COLOR = "#FFEBEF"; // Cherry Blossom
-
-// Rebooked class
-export const REBOOKED_CLASS_COLOR = "#FFFACD"; // Gentle, light yellow
+// Upcoming class (regular, rebooked, or free trial)
+export const UPCOMING_CLASS_COLOR = "#E3E4FF"; // Light purple
 
 // Canceled class (by customer or instructor)
-export const CANCELED_CLASS_COLOR = "#FFEBE0"; // Light orange
+export const CANCELED_CLASS_COLOR = "#D9D9D9"; // Light gray
 
 // Completed class
-export const COMPLETED_CLASS_COLOR = "#B5C4AB"; // Olive green
-
-// Free trial class (when booked or rebooked)
-export const FREE_TRIAL_CLASS_COLOR = "#E7FBD9"; // Light green
+export const COMPLETED_CLASS_COLOR = "#E7FBD9"; // Light green

--- a/frontend/src/components/features/calendarView/CalendarView.module.scss
+++ b/frontend/src/components/features/calendarView/CalendarView.module.scss
@@ -92,11 +92,9 @@
   border: 1.5px solid #7f8c6b;
   margin-right: 5px;
 
-  &.booked {
-    border: 1.5px solid #415a77;
-  }
+  &.booked,
   &.rebooked {
-    border: 1.5px solid #2c6e01;
+    border: 1.5px solid $blue-primary;
   }
 }
 
@@ -106,12 +104,12 @@
   margin-right: 5px;
 
   &__completed {
-    color: #7f8c6b;
+    color: $completed-text-color;
     width: 17px;
   }
 
   &__canceled {
-    color: #d7590f;
+    color: $canceled-text-color;
     width: 18px;
   }
 }
@@ -120,17 +118,15 @@
   color: white;
   display: flex;
   align-items: center;
-  &.booked {
-    color: #415a77;
-  }
+  &.booked,
   &.rebooked {
-    color: #2c6e01;
+    color: $blue-primary;
   }
   &.completed {
-    color: #7f8c6b;
+    color: $completed-text-color;
   }
   &.canceled {
-    color: #d7590f;
+    color: $canceled-text-color;
     text-decoration: line-through;
   }
 }

--- a/frontend/src/styles/variables.module.scss
+++ b/frontend/src/styles/variables.module.scss
@@ -11,9 +11,10 @@ $yellow-selected: #ffffde;
 
 $booked-background-color: #e7fbd9;
 $booked-text-color: #2c6e01;
-$canceled-background-color: #ffebe0;
-$canceled-text-color: #d7590f;
-$completed-background-color: #b5c4ab; // 60% something
+$canceled-background-color: #d9d9d9;
+$canceled-text-color: #666;
+$completed-background-color: #e7fbd9;
+$completed-text-color: #2c6e01;
 
 $active-sidenav-menu: #5a5c99;
 $gray-background: #d9d9d9;


### PR DESCRIPTION
## Summary

- use one light-purple upcoming-class color for regular, rebooked, and free-trial bookings
- use the existing success-green palette for completed classes
- use a neutral gray palette for canceled classes
- align calendar text, status icons, and instructor-avatar borders with the shared status colors
- replace separate booked/rebooked/free-trial backend constants with one `UPCOMING_CLASS_COLOR`

## Why

Booked classes were visually similar to pink business-calendar events such as “No Class,” while rebooked and free-trial bookings used separate colors despite sharing the same active/upcoming state. This simplifies the calendar’s visual language and keeps class statuses distinct from business-event colors.

## User impact

Customers see a clearer lifecycle in the class calendar:

- upcoming bookings: purple
- completed classes: green
- canceled classes: gray

Regular, rebooked, and free-trial bookings now look consistent while their detailed labels remain available elsewhere in the interface.

## Validation

- frontend format check passed
- frontend lint passed with zero warnings
- frontend unused-code check passed
- frontend production build passed
- backend format and unused-code checks passed
- one complete backend run passed all 268 API tests and the production build after the upcoming-class unification
- the final repeat run passed the affected class, customer, free-trial rebooking, and instructor-calendar groups before it was stopped to avoid another lengthy full-suite run
- `git diff --check` passed