### PR TITLE
Add Japanese translations to regular class schedule dialog

### DIFF
--- a/frontend/src/components/customers-dashboard/regular-classes/EditRegularClassModal.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/EditRegularClassModal.tsx
@@ -11,6 +11,7 @@ import {
   UserGroupIcon,
   AcademicCapIcon,
 } from "@heroicons/react/24/solid";
+import { EDIT_REGULAR_CLASS_MESSAGES } from "@/lib/messages/customerDashboard";
 import styles from "./EditRegularClassModal.module.scss";
 
 interface EditRegularClassModalProps {
@@ -23,6 +24,7 @@ interface EditRegularClassModalProps {
   adminId?: number;
   onSuccess?: () => void;
   plan?: Plan;
+  language: LanguageType;
 }
 
 export default function EditRegularClassModal({
@@ -35,7 +37,10 @@ export default function EditRegularClassModal({
   adminId,
   onSuccess,
   plan,
+  language,
 }: EditRegularClassModalProps) {
+  const messages = EDIT_REGULAR_CLASS_MESSAGES[language];
+
   // Form state
   const [startDate, setStartDate] = useState("");
   const [minDate, setMinDate] = useState("");
@@ -147,7 +152,7 @@ export default function EditRegularClassModal({
 
   const handleSubmit = async () => {
     if (!startDate) {
-      setError("Please select a start date");
+      setError(messages.selectStartDate);
       return;
     }
 
@@ -183,7 +188,7 @@ export default function EditRegularClassModal({
     }
 
     if (finalWeekday === null || !finalStartTime) {
-      setError("Unable to determine schedule. Please select a time slot.");
+      setError(messages.scheduleRequired);
       return;
     }
 
@@ -193,7 +198,7 @@ export default function EditRegularClassModal({
         : recurringClass.recurringClassAttendance.map((att) => att.children.id);
 
     if (finalChildrenIds.length === 0) {
-      setError("At least one child must be selected for the class");
+      setError(messages.childRequired);
       return;
     }
 
@@ -216,7 +221,7 @@ export default function EditRegularClassModal({
       onClose();
     } catch (error: any) {
       console.error("Failed to update regular class:", error);
-      setError(error.message || "Failed to update regular class");
+      setError(messages.updateFailed);
     } finally {
       setLoading(false);
     }
@@ -236,7 +241,7 @@ export default function EditRegularClassModal({
     <Modal isOpen={isOpen} onClose={resetAndClose} overlayClosable={true}>
       <div className={styles.progressiveFlow}>
         <div className={styles.modalHeader}>
-          <h2>Edit Regular Class Schedule</h2>
+          <h2>{messages.title}</h2>
         </div>
 
         <div className={styles.sectionsContainer}>
@@ -246,7 +251,7 @@ export default function EditRegularClassModal({
           <div className={styles.section}>
             <div className={styles.sectionHeader}>
               <CalendarIcon className={styles.sectionIcon} />
-              <h3>Start New Schedule On</h3>
+              <h3>{messages.startNewScheduleOn}</h3>
             </div>
             <div className={styles.sectionContent}>
               <input
@@ -264,31 +269,20 @@ export default function EditRegularClassModal({
           <div className={styles.section}>
             <div className={styles.sectionHeader}>
               <AcademicCapIcon className={styles.sectionIcon} />
-              <h3>Instructor & Schedule</h3>
+              <h3>{messages.instructorAndSchedule}</h3>
               {selectedInstructor &&
                 selectedWeekday !== null &&
                 selectedStartTime && (
                   <>
                     <span className={styles.selectedValue}>
                       {selectedInstructor.nickname} -{" "}
-                      {
-                        [
-                          "Sunday",
-                          "Monday",
-                          "Tuesday",
-                          "Wednesday",
-                          "Thursday",
-                          "Friday",
-                          "Saturday",
-                        ][selectedWeekday]
-                      }{" "}
-                      {selectedStartTime}
+                      {messages.weekdays[selectedWeekday]} {selectedStartTime}
                     </span>
                     <button
                       onClick={handleEditInstructor}
                       className={styles.changeButton}
                     >
-                      Change
+                      {messages.change}
                     </button>
                   </>
                 )}
@@ -301,7 +295,7 @@ export default function EditRegularClassModal({
                   <InstructorSelection
                     onInstructorSelect={handleInstructorSelect}
                     plan={plan}
-                    language="en"
+                    language={language}
                     adminId={adminId}
                     customerId={customerId}
                   />
@@ -315,6 +309,7 @@ export default function EditRegularClassModal({
                       onSlotSelect={handleScheduleSlotSelect}
                       selectedWeekday={selectedWeekday}
                       selectedStartTime={selectedStartTime}
+                      language={language}
                     />
                   )}
               </div>
@@ -325,26 +320,30 @@ export default function EditRegularClassModal({
           <div className={styles.section}>
             <div className={styles.sectionHeader}>
               <UserGroupIcon className={styles.sectionIcon} />
-              <h3>Children</h3>
+              <h3>{messages.children}</h3>
               <span className={styles.selectedValue}>
                 {selectedChildrenIds.length > 0
                   ? `${allChildren
                       .filter((child) => selectedChildrenIds.includes(child.id))
                       .map((child) => child.name)
-                      .join(
-                        ", ",
-                      )} (${selectedChildrenIds.length} child${selectedChildrenIds.length !== 1 ? "ren" : ""})`
+                      .join(", ")} (${
+                      language === "ja"
+                        ? `${selectedChildrenIds.length}人`
+                        : `${selectedChildrenIds.length} child${selectedChildrenIds.length !== 1 ? "ren" : ""}`
+                    })`
                   : `${recurringClass.recurringClassAttendance
                       .map((att) => att.children.name)
-                      .join(
-                        ", ",
-                      )} (${recurringClass.recurringClassAttendance.length} child${recurringClass.recurringClassAttendance.length !== 1 ? "ren" : ""})`}
+                      .join(", ")} (${
+                      language === "ja"
+                        ? `${recurringClass.recurringClassAttendance.length}人`
+                        : `${recurringClass.recurringClassAttendance.length} child${recurringClass.recurringClassAttendance.length !== 1 ? "ren" : ""}`
+                    })`}
               </span>
               <button
                 onClick={() => setEditingChildren(!editingChildren)}
                 className={styles.changeButton}
               >
-                Change
+                {messages.change}
               </button>
             </div>
             {editingChildren && (
@@ -366,14 +365,14 @@ export default function EditRegularClassModal({
                     onClick={() => setEditingChildren(false)}
                     className={styles.cancelButton}
                   >
-                    Cancel
+                    {messages.cancel}
                   </button>
                   <button
                     onClick={handleConfirmChildrenSelection}
                     className={styles.confirmButton}
                     disabled={selectedChildrenIds.length === 0}
                   >
-                    Confirm
+                    {messages.confirm}
                   </button>
                 </div>
               </div>
@@ -383,14 +382,14 @@ export default function EditRegularClassModal({
           {/* Action Buttons */}
           <div className={styles.confirmationActions}>
             <button onClick={resetAndClose} className={styles.cancelButton}>
-              Cancel
+              {messages.cancel}
             </button>
             <button
               onClick={handleSubmit}
               className={styles.confirmButton}
               disabled={loading || selectedChildrenIds.length === 0}
             >
-              {loading ? "Applying..." : "Apply Changes"}
+              {loading ? messages.applying : messages.applyChanges}
             </button>
           </div>
         </div>

--- a/frontend/src/components/customers-dashboard/regular-classes/InstructorSchedule.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/InstructorSchedule.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/api/instructorsApi";
 import { getTodayInJapanISODate } from "@/lib/utils/dateUtils";
 import { WEEKDAYS } from "@/lib/utils/scheduleUtils";
+import { EDIT_REGULAR_CLASS_MESSAGES } from "@/lib/messages/customerDashboard";
 import styles from "./InstructorSchedule.module.scss";
 
 interface InstructorScheduleProps {
@@ -15,6 +16,7 @@ interface InstructorScheduleProps {
   onSlotSelect: (weekday: number, startTime: string) => void;
   selectedWeekday: number | null;
   selectedStartTime: string;
+  language: LanguageType;
 }
 
 export default function InstructorSchedule({
@@ -23,7 +25,9 @@ export default function InstructorSchedule({
   onSlotSelect,
   selectedWeekday,
   selectedStartTime,
+  language,
 }: InstructorScheduleProps) {
+  const messages = EDIT_REGULAR_CLASS_MESSAGES[language];
   const [slots, setSlots] = useState<InstructorSlot[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
@@ -44,7 +48,7 @@ export default function InstructorSchedule({
         setSlots(response.schedule?.slots || []);
       } catch (error) {
         console.error("Failed to fetch instructor schedule:", error);
-        setError("Failed to load instructor schedule");
+        setError(messages.scheduleLoadFailed);
       } finally {
         setLoading(false);
       }
@@ -53,7 +57,7 @@ export default function InstructorSchedule({
     if (instructorId) {
       fetchSchedule();
     }
-  }, [instructorId, effectiveDate]);
+  }, [instructorId, effectiveDate, messages.scheduleLoadFailed]);
 
   // Group JST slots by weekday
   const slotsByWeekday = (slots || []).reduce(
@@ -92,7 +96,7 @@ export default function InstructorSchedule({
     return (
       <div className={styles.loadingContainer}>
         <div className={styles.spinner}></div>
-        <span>Loading instructor schedule...</span>
+        <span>{messages.loadingSchedule}</span>
       </div>
     );
   }
@@ -108,10 +112,7 @@ export default function InstructorSchedule({
   if (!slots || slots.length === 0) {
     return (
       <div className={styles.emptyContainer}>
-        <span>
-          No available time slots found for this instructor on the selected
-          date.
-        </span>
+        <span>{messages.noAvailableSlots}</span>
       </div>
     );
   }
@@ -123,7 +124,7 @@ export default function InstructorSchedule({
         <div className={styles.header}>
           {WEEKDAYS.map((day, index) => (
             <div key={day} className={styles.dayHeader}>
-              {day}
+              {messages.weekdays[index]}
             </div>
           ))}
         </div>
@@ -151,7 +152,7 @@ export default function InstructorSchedule({
                 >
                   {slotInfo.displayTime}
                 </button>
-              )) || <div className={styles.noSlots}>No slots</div>}
+              )) || <div className={styles.noSlots}>{messages.noSlots}</div>}
             </div>
           ))}
         </div>

--- a/frontend/src/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
+++ b/frontend/src/components/customers-dashboard/regular-classes/RegularClassesTable.tsx
@@ -220,6 +220,7 @@ function RegularClassesTable({
           adminId={adminId}
           onSuccess={handleEditSuccess}
           plan={plan}
+          language={language}
         />
       )}
     </div>

--- a/frontend/src/lib/messages/customerDashboard.ts
+++ b/frontend/src/lib/messages/customerDashboard.ts
@@ -386,3 +386,66 @@ export const EDIT_CLASS_ARIA_LABEL = {
   ja: "クラスを編集",
   en: "Edit class",
 };
+
+export const EDIT_REGULAR_CLASS_MESSAGES = {
+  ja: {
+    title: "レギュラークラスのスケジュールを編集",
+    startNewScheduleOn: "新しいスケジュールの開始日",
+    instructorAndSchedule: "講師とスケジュール",
+    change: "変更",
+    children: "お子さま",
+    cancel: "キャンセル",
+    confirm: "確定",
+    applying: "適用中...",
+    applyChanges: "変更を適用",
+    selectStartDate: "開始日を選択してください。",
+    scheduleRequired:
+      "スケジュールを特定できません。時間枠を選択してください。",
+    childRequired: "クラスに参加するお子さまを1人以上選択してください。",
+    updateFailed: "レギュラークラスの更新に失敗しました。",
+    loadingSchedule: "講師のスケジュールを読み込んでいます...",
+    scheduleLoadFailed: "講師のスケジュールの読み込みに失敗しました。",
+    noAvailableSlots:
+      "選択した日付に、この講師の予約可能な時間枠はありません。",
+    noSlots: "空きなし",
+    weekdays: [
+      "日曜日",
+      "月曜日",
+      "火曜日",
+      "水曜日",
+      "木曜日",
+      "金曜日",
+      "土曜日",
+    ],
+  },
+  en: {
+    title: "Edit Regular Class Schedule",
+    startNewScheduleOn: "Start New Schedule On",
+    instructorAndSchedule: "Instructor & Schedule",
+    change: "Change",
+    children: "Children",
+    cancel: "Cancel",
+    confirm: "Confirm",
+    applying: "Applying...",
+    applyChanges: "Apply Changes",
+    selectStartDate: "Please select a start date.",
+    scheduleRequired:
+      "Unable to determine schedule. Please select a time slot.",
+    childRequired: "At least one child must be selected for the class.",
+    updateFailed: "Failed to update regular class.",
+    loadingSchedule: "Loading instructor schedule...",
+    scheduleLoadFailed: "Failed to load instructor schedule.",
+    noAvailableSlots:
+      "No available time slots found for this instructor on the selected date.",
+    noSlots: "No slots",
+    weekdays: [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ],
+  },
+} as const;


### PR DESCRIPTION
## What changed

- Localized the customer “Edit Regular Class Schedule” dialog in Japanese.
- Passed the active language through to the instructor picker and schedule view.
- Added Japanese weekdays, child counts, validation messages, loading/error/empty states, and action labels.

## Why

The dialog and its nested schedule controls were hard-coded in English, so switching the customer interface to Japanese did not translate this workflow.

## Impact

Customers using Japanese now see the complete regular-class editing flow in Japanese. English behavior remains available through the existing language switcher.

## Validation

- `npm run format-check`
- `npm run lint -- --max-warnings 0`
- `npm run lint:unused`
- `npm run build`
- `npx tsc --noEmit`