### PR TITLE
Add repository-local development skills

### DIFF
--- a/.agents/skills/ensure-pipeline/SKILL.md
+++ b/.agents/skills/ensure-pipeline/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: ensure-pipeline
+description: Run AaasoBo's local CI-equivalent checks before committing, pushing, opening a PR, or marking changes complete. Use for pre-commit or pre-push validation, reproducing GitHub Actions failures, or requests to ensure, check, or fix the pipeline.
+---
+
+# Ensure Pipeline
+
+1. Inspect the scope with `git status -sb` and `git diff --stat`.
+2. Run the bundled script with its default `all` scope before publishing changes.
+3. Use a narrower scope only while iterating on a known frontend, backend, or shared failure.
+4. Fix the root cause of failures, rerun the failed check, then rerun the default full gate.
+5. For an existing PR failure, inspect the GitHub Actions logs before reproducing it locally.
+
+Run the full gate:
+
+```bash
+"$(git rev-parse --show-toplevel)/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh"
+```
+
+Use a targeted gate during diagnosis:
+
+```bash
+"$(git rev-parse --show-toplevel)/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh" frontend
+"$(git rev-parse --show-toplevel)/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh" backend
+"$(git rev-parse --show-toplevel)/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh" shared
+```
+
+The `shared` scope also runs frontend and backend checks because both applications consume shared code. The backend gate requires Docker and forces the test suite to use its disposable Testcontainers PostgreSQL instance instead of any developer database configured in local environment files.
+
+Summarize exactly which gates passed, which commands were skipped due to unchanged scope, and any residual external checks that cannot be reproduced locally, such as Vercel deployment status.

--- a/.agents/skills/ensure-pipeline/agents/openai.yaml
+++ b/.agents/skills/ensure-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ensure Pipeline"
+  short_description: "Run repo CI-equivalent checks before pushing."
+  default_prompt: "Use $ensure-pipeline to run the full local CI gate and fix any failures."

--- a/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh
+++ b/.agents/skills/ensure-pipeline/scripts/aaasobo_pipeline.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: aaasobo_pipeline.sh [all|frontend|backend|shared]
+
+Run CI-equivalent local checks for the aaasobo-management-system repo.
+The default scope is all. The shared scope includes both consuming applications.
+EOF
+}
+
+scope="${1:-all}"
+case "$scope" in
+  all|frontend|backend|shared) ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+run_shared=false
+run_frontend=false
+run_backend=false
+
+case "$scope" in
+  all)
+    run_shared=true
+    run_frontend=true
+    run_backend=true
+    ;;
+  frontend)
+    run_frontend=true
+    ;;
+  backend)
+    run_backend=true
+    ;;
+  shared)
+    run_shared=true
+    run_frontend=true
+    run_backend=true
+    ;;
+esac
+
+if [[ "$run_shared" == true ]]; then
+  echo "==> shared: format-check"
+  (cd shared && npm run format-check)
+else
+  echo "==> shared: skipped"
+fi
+
+if [[ "$run_frontend" == true ]]; then
+  echo "==> frontend: format-check"
+  (cd frontend && npm run format-check)
+  echo "==> frontend: lint -- --max-warnings 0"
+  (cd frontend && npm run lint -- --max-warnings 0)
+  echo "==> frontend: lint:unused"
+  (cd frontend && npm run lint:unused)
+  echo "==> frontend: build"
+  (cd frontend && npm run build)
+else
+  echo "==> frontend: skipped"
+fi
+
+if [[ "$run_backend" == true ]]; then
+  echo "==> backend: format-check"
+  (cd backend && npm run format-check)
+  echo "==> backend: lint:unused"
+  (cd backend && npm run lint:unused)
+  echo "==> backend: test (disposable Testcontainers database)"
+  (
+    cd backend
+    npx prisma generate
+    TEST_DATABASE_URL='' POSTGRES_PRISMA_URL='' DATABASE_URL='' \
+      npx vitest run src/test/api
+  )
+else
+  echo "==> backend: skipped"
+fi
+
+echo "Pipeline gate completed."

--- a/.agents/skills/launch-task-worktree/SKILL.md
+++ b/.agents/skills/launch-task-worktree/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: launch-task-worktree
+description: Create an AaasoBo task branch and Git worktree from the latest origin/develop, copy local environment files, and install monorepo dependencies. Use when starting isolated development work or when asked to create, launch, or set up a task worktree.
+---
+
+# Launch Task Worktree
+
+## Inputs
+
+- Required: `branch_name`
+- Optional: `worktree_path`, resolved relative to the repository root (defaults to `../<branch_name>`)
+
+Run:
+
+```bash
+"$(git rev-parse --show-toplevel)/.agents/skills/launch-task-worktree/scripts/launch_task_worktree.sh" <branch_name> [worktree_path]
+```
+
+The script:
+
+1. Validate the branch name and destination.
+2. Fetch and validate `origin/develop`.
+3. Create the branch and worktree directly from `origin/develop`.
+4. Copy these files when present:
+   - `backend/.env`
+   - `frontend/.env`
+   - `shared/.env`
+5. Run `npm install` in:
+   - `shared`
+   - `backend`
+   - `frontend`
+
+Do not overwrite an existing branch or path. If dependency installation fails after worktree creation, report the created worktree and the failed directory rather than deleting the worktree.

--- a/.agents/skills/launch-task-worktree/agents/openai.yaml
+++ b/.agents/skills/launch-task-worktree/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Launch Task Worktree"
+  short_description: "Create task worktree from latest develop"
+  default_prompt: "Use $launch-task-worktree to create a task branch and worktree from the latest origin/develop."

--- a/.agents/skills/launch-task-worktree/scripts/launch_task_worktree.sh
+++ b/.agents/skills/launch-task-worktree/scripts/launch_task_worktree.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  launch_task_worktree.sh <branch-name> [worktree-path]
+
+Examples:
+  launch_task_worktree.sh issue-123-fix-login
+  launch_task_worktree.sh issue-123-fix-login ../aaasobo-issue-123-fix-login
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+branch_name="$1"
+worktree_path="${2:-../${branch_name}}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  echo "Error: this command must run inside a git repository." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+
+if ! git check-ref-format --branch "$branch_name" >/dev/null 2>&1; then
+  echo "Error: invalid branch name: ${branch_name}" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
+  echo "Error: branch '${branch_name}' already exists." >&2
+  exit 1
+fi
+
+if [[ -e "$worktree_path" || -L "$worktree_path" ]]; then
+  echo "Error: worktree path already exists: ${worktree_path}" >&2
+  exit 1
+fi
+
+echo "==> Fetch latest origin/develop"
+git fetch origin develop
+
+if ! git rev-parse --verify --quiet refs/remotes/origin/develop >/dev/null; then
+  echo "Error: origin/develop was not found after fetch." >&2
+  exit 1
+fi
+
+echo "==> Create worktree '${worktree_path}' on branch '${branch_name}' from origin/develop"
+git worktree add -b "$branch_name" "$worktree_path" origin/develop
+
+copy_if_exists() {
+  local rel_path="$1"
+  local src="${repo_root}/${rel_path}"
+  local dst="${worktree_path}/${rel_path}"
+  if [[ -f "$src" ]]; then
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+    echo "==> Copied ${rel_path}"
+  else
+    echo "==> Skipped ${rel_path} (not found)"
+  fi
+}
+
+copy_if_exists "backend/.env"
+copy_if_exists "frontend/.env"
+copy_if_exists "shared/.env"
+
+npm_install_if_exists() {
+  local dir="$1"
+  if [[ -f "${worktree_path}/${dir}/package.json" ]]; then
+    echo "==> npm install in ${dir}"
+    if ! (cd "${worktree_path}/${dir}" && npm install); then
+      echo "Error: npm install failed in ${dir}." >&2
+      echo "Worktree remains available at: ${worktree_path}" >&2
+      echo "Branch remains available as: ${branch_name}" >&2
+      exit 1
+    fi
+  else
+    echo "==> Skipped ${dir} (package.json not found)"
+  fi
+}
+
+npm_install_if_exists "shared"
+npm_install_if_exists "backend"
+npm_install_if_exists "frontend"
+
+echo "==> Done"
+echo "Worktree: ${worktree_path}"
+echo "Branch:   ${branch_name}"


### PR DESCRIPTION
## Summary

- add repository-scoped `ensure-pipeline` and `launch-task-worktree` skills under `.agents/skills`
- align the pipeline helper with the repository's GitHub Actions checks
- make backend validation use a disposable Testcontainers PostgreSQL database
- create task worktrees directly from `origin/develop` without modifying the local `develop` branch

## Why

These workflows are specific to AaasoBo and should be version-controlled and shared with the repository instead of living in one developer's global Codex skill directory.

## Impact

Contributors using Codex from this repository can invoke consistent pre-push validation and task-worktree setup workflows. The helpers avoid machine-specific paths and protect local branches and developer databases from unintended mutation.

## Validation

- official skill validator for both skills
- Bash syntax checks and ShellCheck
- isolated end-to-end worktree creation test
- shared Prettier check
- frontend Prettier, ESLint, Knip, and production build
- backend Prettier and Knip
- backend API tests: 30 files and 268 tests passed