### PR TITLE
Fix instructor list nav line break

### DIFF
--- a/frontend/src/components/layouts/sideNav/SideNav.module.scss
+++ b/frontend/src/components/layouts/sideNav/SideNav.module.scss
@@ -110,6 +110,7 @@
 
 .linkText {
   display: block;
+  white-space: pre-wrap;
 }
 
 .active {

--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -77,7 +77,7 @@ export function getLinks(
       icon: UsersIcon,
     },
     {
-      name: "インストラクター　　リスト",
+      name: "インストラクター\nリスト",
       href: "/admins/instructor-list",
       icon: UsersIcon,
     },


### PR DESCRIPTION
## Summary

- replace the admin instructor-list navigation label's spacing workaround with an explicit line break
- preserve intentional whitespace in side navigation labels so the break renders consistently

## Why

The instructor-list label relied on full-width spaces to wrap, which made its alignment depend on the available width and look inconsistent with the instructor-profile navigation item.

## Impact

The admin navigation now displays `インストラクター` and `リスト` on separate lines consistently.

## Validation

- shared Prettier check
- frontend Prettier check
- frontend ESLint with zero warnings
- frontend unused-code check
- frontend production build
- backend Prettier check
- backend unused-code check
- backend API suite: 30 files, 268 tests passed
