### PR TITLE
Fix admin calendar instructor selection

### DIFF
--- a/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.module.scss
+++ b/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.module.scss
@@ -2,3 +2,7 @@
   font-size: 1.2rem;
   font-weight: 500;
 }
+
+.emptyState {
+  color: #4b5563;
+}

--- a/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.tsx
+++ b/frontend/src/components/admins-dashboard/InstructorCalendarForAdmin.tsx
@@ -9,6 +9,7 @@ import { initialSetup } from "@/lib/utils/initialSetup";
 import InstructorCalendarClient from "../instructors-dashboard/class-schedule/instructorCalendar/InstructorCalendarClient";
 import InstructorSearch from "@/components/admins-dashboard/InstructorSearch";
 import { getAllBusinessSchedules, getAllEvents } from "@/lib/api/adminsApi";
+import type { SchedulesListResponse } from "@shared/schemas/admins";
 
 function InstructorCalendarForAdmin({
   adminId,
@@ -26,16 +27,18 @@ function InstructorCalendarForAdmin({
     start: string;
     end: string;
   } | null>(null);
-  const [schedule, setSchedule] = useState<any>([]);
+  const [schedule, setSchedule] = useState<SchedulesListResponse | null>(null);
   const [colorsForEvents, setColorsForEvents] = useState<
     { event: string; color: string }[]
   >([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!instructorId) return;
+    if (instructorId === null) return;
 
+    setIsLoading(true);
+    setError(null);
     try {
       const [classes, schedule, events] = await Promise.all([
         getCalendarClasses(instructorId),
@@ -69,46 +72,46 @@ function InstructorCalendarForAdmin({
     initialSetup("admin");
   }, []);
 
-  const handleSendInstructor = async (id: number, name: string) => {
-    localStorage.setItem("activeInstructor", [String(id), name].join(","));
+  const handleSendInstructor = useCallback((id: number, name: string) => {
+    localStorage.setItem("activeInstructor", String(id));
+    setIsLoading(true);
+    setError(null);
     setInstructorId(id);
-    setInstructorName(name);
-  };
-
-  useEffect(() => {
-    const activeInstructor = localStorage.getItem("activeInstructor");
-    const [id, name] = activeInstructor?.split(",") || ["1", ""];
-    setInstructorId(parseInt(id));
     setInstructorName(name);
   }, []);
 
-  if (error) {
-    return <div>{error}</div>;
-  }
-
   return (
     <div className={styles.calendarContainer}>
+      <InstructorSearch handleSendInstructor={handleSendInstructor} />
       {isLoading && <Loading />}
       {error && <div>{error}</div>}
-      {!isLoading && !error && (
-        <>
-          <InstructorSearch handleSendInstructor={handleSendInstructor} />
-          {userSessionType === "admin" && instructorName ? (
-            <span className={styles.instructorName}>
-              Instructor: &nbsp;{instructorName}
-            </span>
-          ) : null}
-          <InstructorCalendarClient
-            adminId={adminId}
-            instructorId={instructorId}
-            instructorCalendarEvents={instructorCalendarEvents}
-            validRange={calendarValidRange!}
-            userSessionType={userSessionType}
-            businessSchedule={schedule.organizedData}
-            colorsForEvents={colorsForEvents}
-          />
-        </>
+      {!isLoading && !error && instructorId === null && (
+        <p className={styles.emptyState}>
+          Select an instructor to display their calendar.
+        </p>
       )}
+      {!isLoading &&
+        !error &&
+        instructorId !== null &&
+        schedule !== null &&
+        calendarValidRange !== null && (
+          <>
+            {userSessionType === "admin" && instructorName ? (
+              <span className={styles.instructorName}>
+                Instructor: &nbsp;{instructorName}
+              </span>
+            ) : null}
+            <InstructorCalendarClient
+              adminId={adminId}
+              instructorId={instructorId}
+              instructorCalendarEvents={instructorCalendarEvents}
+              validRange={calendarValidRange}
+              userSessionType={userSessionType}
+              businessSchedule={schedule.organizedData}
+              colorsForEvents={colorsForEvents}
+            />
+          </>
+        )}
     </div>
   );
 }

--- a/frontend/src/components/admins-dashboard/InstructorSearch.tsx
+++ b/frontend/src/components/admins-dashboard/InstructorSearch.tsx
@@ -13,12 +13,15 @@ function InstructorSearch({
   const [searchTerm, setSearchTerm] = useState("");
   const [suggestions, setSuggestions] = useState<Instructor[]>([]);
   const [instructors, setInstructors] = useState<Instructor[]>([]);
-  const [selectedInstructorId, setSelectedInstructorId] = useState<number>(0);
+  const [selectedInstructorId, setSelectedInstructorId] = useState<
+    number | null
+  >(null);
 
   // Show the autocomplete list when the user types in the search bar.
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value;
     setSearchTerm(input);
+    setSelectedInstructorId(null);
 
     if (input.length === 0) {
       setSuggestions([]);
@@ -31,22 +34,17 @@ function InstructorSearch({
   };
 
   // Store a selected instructor's ID and name.
-  const handleAutocompleteClick = (value: string) => {
-    const selectedInstructor = instructors.filter((instructor) =>
-      instructor.name.includes(value),
-    );
-
-    if (!selectedInstructor) {
-      return;
-    }
-
-    setSelectedInstructorId(selectedInstructor[0].id);
-    setSearchTerm(selectedInstructor[0].name);
+  const handleAutocompleteClick = (instructor: Instructor) => {
+    setSelectedInstructorId(instructor.id);
+    setSearchTerm(instructor.name);
     setSuggestions([]);
   };
 
   const handleUpdateCalendar = () => {
+    if (selectedInstructorId === null) return;
+
     handleSendInstructor(selectedInstructorId, searchTerm);
+    setSelectedInstructorId(null);
     setSearchTerm("");
   };
 
@@ -58,8 +56,22 @@ function InstructorSearch({
         throw new Error("No instructors found.");
       }
       setInstructors(instructors);
+
+      const storedInstructorId = Number.parseInt(
+        localStorage.getItem("activeInstructor")?.split(",")[0] ?? "",
+        10,
+      );
+      const activeInstructor = instructors.find(
+        (instructor: Instructor) => instructor.id === storedInstructorId,
+      );
+
+      if (activeInstructor) {
+        handleSendInstructor(activeInstructor.id, activeInstructor.name);
+      } else {
+        localStorage.removeItem("activeInstructor");
+      }
     })();
-  }, []);
+  }, [handleSendInstructor]);
 
   return (
     <>
@@ -72,10 +84,10 @@ function InstructorSearch({
         />
         {suggestions.length > 0 && (
           <ul>
-            {suggestions.map((instructor, index) => (
+            {suggestions.map((instructor) => (
               <li
-                key={index}
-                onClick={() => handleAutocompleteClick(instructor.name)}
+                key={instructor.id}
+                onClick={() => handleAutocompleteClick(instructor)}
               >
                 {instructor.name}
               </li>
@@ -86,6 +98,7 @@ function InstructorSearch({
           onClick={() => handleUpdateCalendar()}
           btnText="Display Calendar"
           className="bookBtn"
+          disabled={selectedInstructorId === null}
         />
       </div>
     </>

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -587,9 +587,17 @@ export const getAllBusinessSchedules = async (
     if (response.status !== 200) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const data: SchedulesListResponse = await response.json();
+    const data: unknown = await response.json();
+    if (
+      typeof data !== "object" ||
+      data === null ||
+      !("organizedData" in data) ||
+      !Array.isArray(data.organizedData)
+    ) {
+      throw new Error("Invalid business schedule response");
+    }
 
-    return data;
+    return data as SchedulesListResponse;
   } catch (error) {
     console.error("Failed to fetch schedules:", error);
     throw error;


### PR DESCRIPTION
## Summary

- require admins to select a valid instructor before displaying a calendar
- preserve and validate the last selected instructor ID across visits
- prevent the calendar from rendering before its business schedule is ready
- validate the business schedule response before using it

## Root cause

The page silently defaulted to instructor ID 1 and allowed the display action without a valid autocomplete selection. That could persist ID 0, causing the data loader to return without clearing its loading state. After switching to a selection-first flow, React could also briefly render the calendar before the business schedule effect completed, passing `undefined` to the day-color mapping logic.

## Impact

First-time admins now see a clear selection prompt. The display button remains disabled until they select an autocomplete result. A valid previous instructor is restored, while malformed, stale, or deleted IDs are cleared safely. Calendar loading no longer hangs or crashes during selection.

## Validation

- Playwright verified first-time selection, valid ID restoration, invalid ID cleanup, and successful calendar rendering with no console errors
- shared and frontend formatting checks
- frontend ESLint and unused-code checks
- frontend production build and TypeScript validation
- backend formatting and unused-code checks
- backend API suite: 30 files and 268 tests passed
