### PR TITLE
Add default instructor skill prompts

### DIFF
--- a/frontend/src/components/features/registerForm/RegisterForm.module.scss
+++ b/frontend/src/components/features/registerForm/RegisterForm.module.scss
@@ -57,6 +57,10 @@
   white-space: pre-line;
 }
 
+.skillTextarea {
+  height: 12rem;
+}
+
 .radioButtonContainer {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/components/features/registerForm/RegisterForm.tsx
+++ b/frontend/src/components/features/registerForm/RegisterForm.tsx
@@ -35,6 +35,16 @@ import RadioButton from "../../elements/radioButton/RadioButton";
 import TextAreaInput from "../../elements/textAreaInput/TextAreaInput";
 import { ENGLISH_BACKGROUND_LABELS } from "@/lib/data/englishBackground";
 
+const DEFAULT_INSTRUCTOR_SKILL = `Science: [Can you provide a simple experiment?]
+Cooking: [Can you lead a cooking class?]
+Crafting: (Are you good at crafting?)
+Origami: (Are you good at playing Origami?)
+Minecraft: [Account required]
+Roblox: [Account required]
+Pokemon: [Do you know over 10 characters?]
+Disney: [Do you know over 10 characters?]
+Others: [Please specify:]`;
+
 const RegisterForm = ({
   categoryType,
   userType,
@@ -343,7 +353,7 @@ const RegisterForm = ({
                 id="skill"
                 name="skill"
                 label="スキル"
-                defaultValue={persistedValues.skill}
+                defaultValue={persistedValues.skill ?? DEFAULT_INSTRUCTOR_SKILL}
                 placeholder="例: 日本語"
                 maxLength={500}
                 icon={
@@ -352,7 +362,7 @@ const RegisterForm = ({
                 unstyled
                 labelTextClassName={styles.label}
                 inputWrapperClassName={styles.textareaContainer}
-                inputClassName={styles.textarea}
+                inputClassName={`${styles.textarea} ${styles.skillTextarea}`}
               />
 
               {/* English Background Selection (radio button) */}


### PR DESCRIPTION
## Summary

- prefill the instructor skill field with activity-specific prompts
- preserve submitted skill text when registration validation fails
- enlarge only the skill textarea so all nine prompt lines are visible by default

## Why

Admins currently start with an empty, compact skill field when adding an instructor. The default prompts make the expected information explicit and the larger field keeps the complete template visible while it is filled in.

## Validation

- full local pipeline gate
- shared and application formatting checks
- frontend lint and unused-code checks
- frontend production build
- backend unused-code check
- backend API tests: 268 passed across 30 files
