### PR TITLE
Fix instructor schedule weekday mapping

### DIFF
--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleCalendar.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/ScheduleCalendar.tsx
@@ -2,10 +2,8 @@ import styles from "./ScheduleCalendar.module.scss";
 import { InstructorSlot } from "@/lib/api/instructorsApi";
 import {
   BusinessTime,
-  Weekday,
   Weekday_Ja,
   WEEKDAYS_JA,
-  weekdayToDay,
 } from "@/lib/utils/scheduleUtils";
 import {
   TimeColumn,
@@ -26,7 +24,7 @@ interface ScheduleCalendarProps {
 export default function ScheduleCalendar({ slots }: ScheduleCalendarProps) {
   const slotsByDay = slots.reduce(
     (acc, slot) => {
-      const day = weekdayToDay(slot.weekday) as Weekday_Ja;
+      const day = WEEKDAYS_JA[slot.weekday];
       if (!acc[day]) acc[day] = [];
 
       acc[day].push(slot.startTime);


### PR DESCRIPTION
## Summary

- map imported numeric weekdays to the Japanese weekday keys used by the read-only schedule grid
- restore scheduled-cell highlighting on the admin instructor schedule tab

## Root cause

The grid grouped slots under English weekday names but rendered columns using Japanese weekday names, so no imported slot matched a displayed column.

## Validation

- full local pipeline gate passed
- frontend format, lint, unused-code check, and production build passed
- backend API suite passed: 268 tests