### PR TITLE
Localize payroll by audience

### DIFF
--- a/frontend/src/app/instructors/(protected)/payroll/page.tsx
+++ b/frontend/src/app/instructors/(protected)/payroll/page.tsx
@@ -4,5 +4,5 @@ import { getAuthenticatedUserId } from "@/lib/auth/sessionUtils";
 export default async function Page() {
   const instructorId = await getAuthenticatedUserId("instructor");
 
-  return <InstructorPayroll instructorId={instructorId} />;
+  return <InstructorPayroll instructorId={instructorId} locale="en" />;
 }

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorDashboardClient.tsx
@@ -103,7 +103,7 @@ export default function InstructorTabs({
     },
     {
       label: "給与管理",
-      content: <InstructorPayroll instructorId={instructorId} />,
+      content: <InstructorPayroll instructorId={instructorId} locale="ja" />,
     },
     {
       label: "タグ設定",

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -14,6 +14,57 @@ import type {
   InstructorPayrollResponse,
 } from "@shared/schemas/admins";
 
+type PayrollLocale = "en" | "ja";
+
+const labels = {
+  en: {
+    unknown: "Unknown",
+    from: "to",
+    current: "Present",
+    noPayableClasses: "There are no payable classes in this period.",
+    date: "Date",
+    trial: "Trial",
+    regular: "Regular",
+    cancel: "Cancellation",
+    cancellationCount: "cancellations",
+    cancelWithoutNotice: "Cancellation without notice",
+    dailyTotal: "Daily total",
+    monthlyCancellationCount: "Monthly cancellation count",
+    dailyBreakdown: "Daily breakdown",
+    lastUpdated: "Last updated",
+    applicablePeriods: "Applicable periods",
+    noApplicablePeriods: "There are no applicable periods.",
+    trialClass: "Trial class",
+    regularClass: "Regular class",
+    monthlyCancellationFormula: "Monthly cancellation count / 10",
+    monthInput: "Select payroll month",
+    loading: "Loading payroll information…",
+  },
+  ja: {
+    unknown: "不明",
+    from: "から",
+    current: "現在",
+    noPayableClasses: "この期間には給与支払い対象のクラスがありません。",
+    date: "日付",
+    trial: "体験",
+    regular: "通常",
+    cancel: "キャンセル",
+    cancellationCount: "キャンセル",
+    cancelWithoutNotice: "通知なしキャンセル",
+    dailyTotal: "日計",
+    monthlyCancellationCount: "月次の合計キャンセル数",
+    dailyBreakdown: "日次内訳",
+    lastUpdated: "最終更新日時",
+    applicablePeriods: "適用期間",
+    noApplicablePeriods: "対象期間がありません。",
+    trialClass: "トライアルクラス",
+    regularClass: "レギュラークラス",
+    monthlyCancellationFormula: "月次の合計キャンセル数 / 10",
+    monthInput: "給与計算対象月を選択",
+    loading: "給与情報を取得中…",
+  },
+} as const;
+
 const getCurrentJstMonth = () => {
   const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone: "Asia/Tokyo",
@@ -60,12 +111,15 @@ const formatMoneyWithCurrencyCode = (
   return `${formattedAmount} (${currency})`;
 };
 
-const formatLastUpdatedLabel = (value: string | null) => {
+const formatLastUpdatedLabel = (
+  value: string | null,
+  locale: PayrollLocale,
+) => {
   if (!value) {
-    return "不明";
+    return labels[locale].unknown;
   }
 
-  return new Intl.DateTimeFormat("ja-JP", {
+  return new Intl.DateTimeFormat(locale === "ja" ? "ja-JP" : "en-US", {
     timeZone: "Asia/Tokyo",
     year: "numeric",
     month: "short",
@@ -76,8 +130,8 @@ const formatLastUpdatedLabel = (value: string | null) => {
   }).format(new Date(value));
 };
 
-const formatDayLabel = (date: string) =>
-  new Intl.DateTimeFormat("ja-JP", {
+const formatDayLabel = (date: string, locale: PayrollLocale) =>
+  new Intl.DateTimeFormat(locale === "ja" ? "ja-JP" : "en-US", {
     timeZone: "Asia/Tokyo",
     day: "2-digit",
     weekday: "short",
@@ -96,13 +150,13 @@ const formatDayLabel = (date: string) =>
       { day: "", weekday: "" },
     );
 
-const formatPeriodLabel = (from: string, to: string) => {
-  return `${from} から ${to}`;
+const formatPeriodLabel = (from: string, to: string, locale: PayrollLocale) => {
+  return `${from} ${labels[locale].from} ${to}`;
 };
 
-const formatFeeCoverageEnd = (value: string | null) => {
+const formatFeeCoverageEnd = (value: string | null, locale: PayrollLocale) => {
   if (!value) {
-    return "現在";
+    return labels[locale].current;
   }
 
   const date = new Date(`${value}T00:00:00.000Z`);
@@ -116,15 +170,15 @@ const isSecondHalfPeriod = (period: InstructorPayrollPeriod) =>
 function DailyBreakdownTable({
   rows,
   currency,
+  locale,
 }: {
   rows: InstructorPayrollDailyBreakdown[];
   currency: string | null;
+  locale: PayrollLocale;
 }) {
   if (rows.length === 0) {
     return (
-      <p className={styles.emptyMessage}>
-        この期間には給与支払い対象のクラスがありません。
-      </p>
+      <p className={styles.emptyMessage}>{labels[locale].noPayableClasses}</p>
     );
   }
 
@@ -159,17 +213,17 @@ function DailyBreakdownTable({
         </colgroup>
         <thead>
           <tr>
-            <th>日付</th>
-            <th>体験</th>
-            <th>通常</th>
-            <th>キャンセル</th>
-            <th>通知なしキャンセル</th>
-            <th>日計</th>
+            <th>{labels[locale].date}</th>
+            <th>{labels[locale].trial}</th>
+            <th>{labels[locale].regular}</th>
+            <th>{labels[locale].cancel}</th>
+            <th>{labels[locale].cancelWithoutNotice}</th>
+            <th>{labels[locale].dailyTotal}</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => {
-            const dayLabel = formatDayLabel(row.date);
+            const dayLabel = formatDayLabel(row.date, locale);
 
             return (
               <tr key={row.date}>
@@ -203,17 +257,19 @@ function DailyBreakdownTable({
 function MonthlyCancelAdjustment({
   currency,
   monthlyCancelFee,
+  locale,
 }: {
   currency: string | null;
   monthlyCancelFee: InstructorPayrollPeriod["monthlyCancelFee"];
+  locale: PayrollLocale;
 }) {
   return (
     <div className={styles.monthlyCancelAdjustment}>
       <div className={styles.monthlyCancelLabel}>
-        <h5>月次の合計キャンセル数</h5>
+        <h5>{labels[locale].monthlyCancellationCount}</h5>
       </div>
       <p className={styles.monthlyCancelFormula}>
-        {monthlyCancelFee.cancelCount} 合計キャンセル数 /{" "}
+        {monthlyCancelFee.cancelCount} {labels[locale].cancellationCount} /{" "}
         {monthlyCancelFee.threshold} = {monthlyCancelFee.timesApplied} x{" "}
         {formatMoney(monthlyCancelFee.unitFee, currency)}
       </p>
@@ -225,14 +281,20 @@ function MonthlyCancelAdjustment({
   );
 }
 
-function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
+function PeriodCard({
+  period,
+  locale,
+}: {
+  period: InstructorPayrollPeriod;
+  locale: PayrollLocale;
+}) {
   const showMonthlyCancelAdjustment = isSecondHalfPeriod(period);
 
   return (
     <section className={styles.periodCard}>
       <div className={styles.periodSummary}>
         <div>
-          <h3>{formatPeriodLabel(period.from, period.to)}</h3>
+          <h3>{formatPeriodLabel(period.from, period.to, locale)}</h3>
         </div>
         <div className={styles.summaryStats}>
           <strong>
@@ -243,25 +305,29 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
 
       <div className={styles.breakdownSection}>
         <h4>
-          日次内訳 (最終更新日時{" "}
-          {formatLastUpdatedLabel(period.sourceLastUpdatedAt)})
+          {labels[locale].dailyBreakdown} ({labels[locale].lastUpdated}{" "}
+          {formatLastUpdatedLabel(period.sourceLastUpdatedAt, locale)})
         </h4>
         <DailyBreakdownTable
           rows={period.dailyBreakdown}
           currency={period.currency}
+          locale={locale}
         />
         {showMonthlyCancelAdjustment && (
           <MonthlyCancelAdjustment
             currency={period.currency}
             monthlyCancelFee={period.monthlyCancelFee}
+            locale={locale}
           />
         )}
       </div>
 
       <div className={styles.feePeriodsSection}>
-        <h4>適用期間</h4>
+        <h4>{labels[locale].applicablePeriods}</h4>
         {period.appliedFeePeriods.length === 0 ? (
-          <p className={styles.emptyMessage}>対象期間がありません。</p>
+          <p className={styles.emptyMessage}>
+            {labels[locale].noApplicablePeriods}
+          </p>
         ) : (
           <div className={styles.feePeriodsList}>
             {period.appliedFeePeriods.map((fee) => (
@@ -271,31 +337,31 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
               >
                 <div className={styles.feeCardHeader}>
                   <strong>
-                    {fee.effectiveFrom} から{" "}
-                    {formatFeeCoverageEnd(fee.effectiveTo)}
+                    {fee.effectiveFrom} {labels[locale].from}{" "}
+                    {formatFeeCoverageEnd(fee.effectiveTo, locale)}
                   </strong>
                 </div>
                 <dl className={styles.feeGrid}>
                   <div>
-                    <dt>トライアルクラス</dt>
+                    <dt>{labels[locale].trialClass}</dt>
                     <dd>{formatMoney(fee.trialFee, fee.currency)}</dd>
                   </div>
                   <div>
-                    <dt>レギュラークラス</dt>
+                    <dt>{labels[locale].regularClass}</dt>
                     <dd>{formatMoney(fee.regularFee, fee.currency)}</dd>
                   </div>
                   <div>
-                    <dt>キャンセル</dt>
+                    <dt>{labels[locale].cancel}</dt>
                     <dd>{formatMoney(fee.cancelFee, fee.currency)}</dd>
                   </div>
                   <div>
-                    <dt>通知なしキャンセル</dt>
+                    <dt>{labels[locale].cancelWithoutNotice}</dt>
                     <dd>
                       {formatMoney(fee.cancelWithoutNoticeFee, fee.currency)}
                     </dd>
                   </div>
                   <div>
-                    <dt>月次の合計キャンセル数 / 10</dt>
+                    <dt>{labels[locale].monthlyCancellationFormula}</dt>
                     <dd>{formatMoney(fee.monthlyCancelFee, fee.currency)}</dd>
                   </div>
                 </dl>
@@ -310,8 +376,10 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
 
 export default function InstructorPayroll({
   instructorId,
+  locale,
 }: {
   instructorId: number;
+  locale: PayrollLocale;
 }) {
   const [selectedMonth, setSelectedMonth] = useState(() =>
     getCurrentJstMonth(),
@@ -374,11 +442,13 @@ export default function InstructorPayroll({
           value={selectedMonth}
           onChange={handleMonthChange}
           className={styles.monthInput}
-          aria-label="給与計算対象月を選択"
+          aria-label={labels[locale].monthInput}
         />
       </header>
 
-      {isPending && <p className={styles.pendingMessage}>給与情報を取得中…</p>}
+      {isPending && (
+        <p className={styles.pendingMessage}>{labels[locale].loading}</p>
+      )}
 
       {error ? (
         <div className={styles.errorBox}>
@@ -388,7 +458,11 @@ export default function InstructorPayroll({
       ) : payroll ? (
         <div className={styles.periodGrid}>
           {payroll.periods.map((period) => (
-            <PeriodCard key={`${period.from}-${period.to}`} period={period} />
+            <PeriodCard
+              key={`${period.from}-${period.to}`}
+              period={period}
+              locale={locale}
+            />
           ))}
         </div>
       ) : null}

--- a/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/InstructorPayroll.tsx
@@ -271,7 +271,7 @@ function PeriodCard({ period }: { period: InstructorPayrollPeriod }) {
               >
                 <div className={styles.feeCardHeader}>
                   <strong>
-                    {fee.effectiveFrom} to{" "}
+                    {fee.effectiveFrom} から{" "}
                     {formatFeeCoverageEnd(fee.effectiveTo)}
                   </strong>
                 </div>


### PR DESCRIPTION
## Summary

- add explicit English and Japanese presentation modes to the shared payroll component
- render the admin instructor payroll tab in Japanese
- render /instructors/payroll in English
- localize headings, date formatting, table labels, fee periods, empty/loading states, and accessibility labels

## Impact

Admins continue to see labels such as 2026-06-01 から 現在, while instructors see 2026-06-01 to Present and an otherwise English payroll page.

## Validation

- frontend ESLint passed with zero warnings
- TypeScript no-emit check passed
- Prettier and diff whitespace checks passed
- verified both admin and instructor payroll views in the local browser with no console errors
- full pipeline intentionally left to GitHub Actions as requested