### PR TITLE
Add admin enrollment list

### DIFF
--- a/backend/src/controllers/adminsController.ts
+++ b/backend/src/controllers/adminsController.ts
@@ -90,6 +90,7 @@ import type {
 } from "../../../shared/schemas/admins";
 import { ENGLISH_BACKGROUND_LABELS } from "../constants/englishBackground";
 import { EnglishBackground } from "../types";
+import { getEnrollmentStatus } from "../services/enrollmentStatusService";
 
 // Register Admin
 export const registerAdminController = async (
@@ -300,6 +301,18 @@ export const getAllCustomersController = async (_: Request, res: Response) => {
 
     res.json({ data });
   } catch (error) {
+    res.status(500).json({ error });
+  }
+};
+
+export const getEnrollmentStatusController = async (
+  _: Request,
+  res: Response,
+) => {
+  try {
+    res.json({ data: await getEnrollmentStatus() });
+  } catch (error) {
+    console.error("Failed to get enrollment status:", error);
     res.status(500).json({ error });
   }
 };

--- a/backend/src/routes/adminsRouter.ts
+++ b/backend/src/routes/adminsRouter.ts
@@ -20,6 +20,7 @@ import {
   deleteLatestInstructorFeeController,
   getAllPastInstructorsController,
   getAllCustomersController,
+  getEnrollmentStatusController,
   getAllPastCustomersController,
   getAllChildrenController,
   getAllPlansController,
@@ -72,6 +73,7 @@ import {
   InstructorsListResponse,
   PastInstructorsListResponse,
   CustomersListResponse,
+  EnrollmentStatusResponse,
   PastCustomersListResponse,
   ChildrenListResponse,
   PlansListResponse,
@@ -561,6 +563,23 @@ const getAllPastCustomersConfig = {
         description: "Internal server error",
         schema: ErrorResponse,
       },
+    },
+  },
+} as const;
+
+const getEnrollmentStatusConfig = {
+  method: "get" as const,
+  middleware: [verifyAuthentication(AUTH_ROLES.A)] as RequestHandler[],
+  handler: getEnrollmentStatusController,
+  openapi: {
+    summary: "Get active enrollment status",
+    description: "Get active subscriptions and recurring classes by customer",
+    responses: {
+      200: {
+        description: "Enrollment status retrieved successfully",
+        schema: EnrollmentStatusResponse,
+      },
+      500: { description: "Internal server error", schema: ErrorResponse },
     },
   },
 } as const;
@@ -1144,6 +1163,7 @@ const validatedRouteConfigs = {
   "/customer-list": [getAllCustomersConfig],
   "/customer-list/past": [getAllPastCustomersConfig],
   "/customer-list/deactivate/:id": [deactivateCustomerConfig],
+  "/enrollment-status": [getEnrollmentStatusConfig],
   "/event-list": [getAllEventsConfig],
   "/event-list/delete/:id": [deleteEventConfig],
   "/event-list/register": [registerEventConfig],

--- a/backend/src/services/enrollmentStatusService.ts
+++ b/backend/src/services/enrollmentStatusService.ts
@@ -1,0 +1,118 @@
+import { prisma } from "../../prisma/prismaClient";
+import type { EnrollmentStatusCustomer } from "../../../shared/schemas/admins";
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function jstDateKey(date: Date): string {
+  return new Date(date.getTime() + JST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+function formatJstTime(date: Date): string {
+  return new Date(date.getTime() + JST_OFFSET_MS).toISOString().slice(11, 16);
+}
+
+function displayRecurringEndAt(endAt: Date): Date {
+  return new Date(endAt.getTime() - DAY_MS);
+}
+
+function isActivePeriod(
+  today: string,
+  startAt: Date | null,
+  endAt: Date | null,
+  exclusiveEnd: boolean,
+): boolean {
+  if (!startAt || jstDateKey(startAt) > today) return false;
+  if (!endAt) return true;
+  const displayedEnd = exclusiveEnd ? displayRecurringEndAt(endAt) : endAt;
+  return today <= jstDateKey(displayedEnd);
+}
+
+export async function getEnrollmentStatus(
+  now: Date = new Date(),
+): Promise<EnrollmentStatusCustomer[]> {
+  const today = jstDateKey(now);
+  const customers = await prisma.customer.findMany({
+    where: { terminationAt: null },
+    orderBy: { id: "asc" },
+    select: {
+      id: true,
+      name: true,
+      subscription: {
+        orderBy: [{ startAt: "asc" }, { id: "asc" }],
+        select: {
+          id: true,
+          startAt: true,
+          endAt: true,
+          plan: { select: { name: true } },
+          recurringClass: {
+            select: {
+              id: true,
+              startAt: true,
+              endAt: true,
+              instructor: { select: { nickname: true } },
+              recurringClassAttendance: {
+                orderBy: { childrenId: "asc" },
+                select: { children: { select: { name: true } } },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return customers.map((customer) => ({
+    id: customer.id,
+    name: customer.name,
+    subscriptions: customer.subscription
+      .filter((subscription) =>
+        isActivePeriod(today, subscription.startAt, subscription.endAt, false),
+      )
+      .map((subscription) => ({
+        id: subscription.id,
+        planName: subscription.plan.name,
+        recurringClasses: subscription.recurringClass
+          .filter((recurringClass) =>
+            isActivePeriod(
+              today,
+              recurringClass.startAt,
+              recurringClass.endAt,
+              true,
+            ),
+          )
+          .sort((a, b) => {
+            const aStart = a.startAt?.getTime() ?? 0;
+            const bStart = b.startAt?.getTime() ?? 0;
+            const aJst = new Date(aStart + JST_OFFSET_MS);
+            const bJst = new Date(bStart + JST_OFFSET_MS);
+            return (
+              aJst.getUTCDay() - bJst.getUTCDay() ||
+              aJst.getUTCHours() * 60 +
+                aJst.getUTCMinutes() -
+                (bJst.getUTCHours() * 60 + bJst.getUTCMinutes()) ||
+              a.id - b.id
+            );
+          })
+          .map((recurringClass) => {
+            const startAt = recurringClass.startAt!;
+            const endTime = new Date(startAt.getTime() + 25 * 60 * 1000);
+            const jstStart = new Date(startAt.getTime() + JST_OFFSET_MS);
+            return {
+              id: recurringClass.id,
+              children: recurringClass.recurringClassAttendance.map(
+                (attendance) => attendance.children.name,
+              ),
+              instructor: recurringClass.instructor?.nickname ?? "未割当",
+              weekday: WEEKDAYS[jstStart.getUTCDay()],
+              time: `${formatJstTime(startAt)}–${formatJstTime(endTime)}`,
+              startDate: jstDateKey(startAt),
+              endDate: recurringClass.endAt
+                ? jstDateKey(displayRecurringEndAt(recurringClass.endAt))
+                : "継続中",
+            };
+          }),
+      })),
+  }));
+}

--- a/backend/src/test/api/admins/enrollment-status.test.ts
+++ b/backend/src/test/api/admins/enrollment-status.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { server } from "../../../server";
+import { prisma } from "../../setup";
+import {
+  createAdmin,
+  createChild,
+  createCustomer,
+  createInstructor,
+  createPlan,
+  createSubscription,
+  generateAuthCookie,
+} from "../../testUtils";
+
+describe("GET /admins/enrollment-status", () => {
+  it("requires administrator authentication", async () => {
+    await request(server).get("/admins/enrollment-status").expect(401);
+  });
+
+  it("returns active enrollment groups with JST formatting and stable ordering", async () => {
+    const admin = await createAdmin();
+    const cookie = await generateAuthCookie(admin.id, "admin");
+    const customer = await createCustomer({
+      email: "active@example.com",
+      password: "password",
+      name: "Active Customer",
+      prefecture: "Tokyo",
+      emailVerified: new Date(),
+    });
+    const emptyCustomer = await createCustomer({
+      email: "empty@example.com",
+      password: "password",
+      name: "Empty Customer",
+      prefecture: "Tokyo",
+      emailVerified: new Date(),
+    });
+    const child2 = await createChild(customer.id, { name: "Second Child" });
+    const child1 = await createChild(customer.id, { name: "First Child" });
+    const instructor = await createInstructor();
+    const plan = await createPlan({
+      name: "Weekly Plan",
+      description: "",
+      weeklyClassTimes: 2,
+      englishBackground: 0,
+    });
+    const now = new Date();
+    const activeSubscription = await createSubscription(plan.id, customer.id, {
+      selectType: "active-enrollment-test",
+      startAt: new Date(now.getTime() - 20 * 86_400_000),
+      endAt: null,
+    });
+    await createSubscription(plan.id, customer.id, {
+      selectType: "future-enrollment-test",
+      startAt: new Date(now.getTime() + 20 * 86_400_000),
+      endAt: null,
+    });
+
+    const startAt = new Date("2026-07-27T23:30:00.000Z");
+    const recurringClass = await prisma.recurringClass.create({
+      data: {
+        subscriptionId: activeSubscription.id,
+        instructorId: instructor.id,
+        startAt,
+        endAt: new Date("2026-08-05T15:00:00.000Z"),
+      },
+    });
+    await prisma.recurringClassAttendance.createMany({
+      data: [
+        { recurringClassId: recurringClass.id, childrenId: child2.id },
+        { recurringClassId: recurringClass.id, childrenId: child1.id },
+      ],
+    });
+    await prisma.recurringClass.create({
+      data: {
+        subscriptionId: activeSubscription.id,
+        startAt: new Date("2026-07-26T22:00:00.000Z"),
+        endAt: null,
+      },
+    });
+    await prisma.recurringClass.create({
+      data: {
+        subscriptionId: activeSubscription.id,
+        startAt: new Date(now.getTime() + 10 * 86_400_000),
+        endAt: null,
+      },
+    });
+
+    const response = await request(server)
+      .get("/admins/enrollment-status")
+      .set("Cookie", cookie)
+      .expect(200);
+
+    expect(response.body.data.map(({ id }: { id: number }) => id)).toEqual([
+      customer.id,
+      emptyCustomer.id,
+    ]);
+    expect(response.body.data[1].subscriptions).toEqual([]);
+    expect(response.body.data[0].subscriptions).toHaveLength(1);
+    expect(response.body.data[0].subscriptions[0]).toMatchObject({
+      id: activeSubscription.id,
+      planName: "Weekly Plan",
+      recurringClasses: [
+        {
+          children: [],
+          instructor: "未割当",
+          weekday: "月",
+          time: "07:00–07:25",
+          startDate: "2026-07-27",
+          endDate: "継続中",
+        },
+        {
+          children: ["Second Child", "First Child"],
+          instructor: instructor.nickname,
+          weekday: "火",
+          time: "08:30–08:55",
+          startDate: "2026-07-28",
+          endDate: "2026-08-05",
+        },
+      ],
+    });
+  });
+});

--- a/frontend/src/app/admins/(protected)/enrollment-status/page.tsx
+++ b/frontend/src/app/admins/(protected)/enrollment-status/page.tsx
@@ -1,0 +1,10 @@
+import EnrollmentStatusList from "@/components/admins-dashboard/enrollment-status/EnrollmentStatusList";
+import { getEnrollmentStatus } from "@/lib/api/adminsApi";
+import { authenticateUserSession } from "@/lib/auth/sessionUtils";
+import { getCookie } from "@/proxy";
+
+export default async function Page() {
+  await authenticateUserSession("admin");
+  const data = await getEnrollmentStatus(await getCookie());
+  return <EnrollmentStatusList customers={data} />;
+}

--- a/frontend/src/components/admins-dashboard/enrollment-status/EnrollmentStatusList.module.scss
+++ b/frontend/src/components/admins-dashboard/enrollment-status/EnrollmentStatusList.module.scss
@@ -1,0 +1,152 @@
+@use "@/styles/variables.module.scss" as *;
+
+.container {
+  background: $white-background;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  width: 100%;
+}
+.container h1 {
+  color: $text-dark;
+  font-size: 1.5rem;
+  margin: 0;
+}
+.description {
+  color: #5f6368;
+  font-size: 0.875rem;
+  margin: 0.25rem 0 1rem;
+}
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+.controls input {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  padding: 0.5rem 0.65rem;
+  width: min(100%, 360px);
+}
+.controlButtons {
+  display: flex;
+  gap: 0.5rem;
+}
+.controls button,
+.pagination button {
+  background: white;
+  border: 1px solid $blue_primary;
+  border-radius: 0.4rem;
+  color: $blue_primary;
+  cursor: pointer;
+  font-size: 0.825rem;
+  padding: 0.45rem 0.7rem;
+}
+.tableScroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+.enrollmentTable {
+  border: 1px solid #d9dee5;
+  border-collapse: collapse;
+  font-size: 0.825rem;
+  min-width: 980px;
+  width: 100%;
+}
+.enrollmentTable th {
+  background: $blue_primary;
+  color: white;
+  font-weight: 500;
+  text-align: left;
+}
+.enrollmentTable th,
+.enrollmentTable td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.45rem 0.6rem;
+  white-space: nowrap;
+}
+.customerRow td {
+  background: #eef4fb;
+  border-top: 1px solid #cbd8e7;
+  padding: 0.4rem 0.55rem;
+}
+.customerRow button {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  margin-right: 0.35rem;
+  padding: 0;
+  vertical-align: middle;
+}
+.customerRow svg {
+  color: $blue_primary;
+  height: 1rem;
+  width: 1rem;
+}
+.customerRow a {
+  color: $blue_primary;
+  font-weight: 600;
+}
+.classRow td:first-child,
+.noClassesRow td:first-child {
+  background: #fafbfc;
+  width: 1.5rem;
+}
+.classRow:hover td {
+  background: #f8fafc;
+}
+.planCell {
+  color: $text-dark;
+  font-weight: 600;
+  vertical-align: top;
+}
+.noClassesRow td:last-child {
+  color: #6b7280;
+  font-style: italic;
+}
+.empty {
+  color: #6b7280;
+  margin: 0;
+}
+.empty {
+  border: 1px dashed #d1d5db;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+}
+.pagination {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.825rem;
+  margin-top: 0.75rem;
+}
+.pagination .activePage {
+  background: $blue_primary;
+  color: white;
+}
+.pagination label {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin-left: 0.5rem;
+}
+.pagination select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.4rem;
+  padding: 0.4rem;
+}
+@media (max-width: 600px) {
+  .container {
+    padding: 1rem;
+  }
+  .controls {
+    display: block;
+  }
+  .controlButtons {
+    margin-top: 0.75rem;
+  }
+}

--- a/frontend/src/components/admins-dashboard/enrollment-status/EnrollmentStatusList.tsx
+++ b/frontend/src/components/admins-dashboard/enrollment-status/EnrollmentStatusList.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
+import type { EnrollmentStatusCustomer } from "@shared/schemas/admins";
+import styles from "./EnrollmentStatusList.module.scss";
+
+const PAGE_SIZES = [30, 50, 100];
+
+const japanesePlanName = (planName: string) =>
+  planName.split(" / ", 1)[0].trim();
+
+export default function EnrollmentStatusList({
+  customers,
+}: {
+  customers: EnrollmentStatusCustomer[];
+}) {
+  const [query, setQuery] = useState("");
+  const [pageSize, setPageSizeState] = useState(30);
+  const [page, setPageState] = useState(0);
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(
+    () => new Set(customers.slice(0, 30).map(({ id }) => id)),
+  );
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLocaleLowerCase();
+    if (!term) return customers;
+    return customers.filter(
+      (customer) =>
+        customer.name.toLocaleLowerCase().includes(term) ||
+        customer.subscriptions.some(({ recurringClasses }) =>
+          recurringClasses.some(
+            (recurringClass) =>
+              recurringClass.instructor.toLocaleLowerCase().includes(term) ||
+              recurringClass.children.some((child) =>
+                child.toLocaleLowerCase().includes(term),
+              ),
+          ),
+        ),
+    );
+  }, [customers, query]);
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const visible = filtered.slice(page * pageSize, (page + 1) * pageSize);
+
+  const resetToFirstPage = (nextPageSize = pageSize, nextQuery = query) => {
+    setPageState(0);
+    const normalized = nextQuery.trim().toLocaleLowerCase();
+    const nextFiltered = normalized
+      ? customers.filter(
+          (customer) =>
+            customer.name.toLocaleLowerCase().includes(normalized) ||
+            customer.subscriptions.some(({ recurringClasses }) =>
+              recurringClasses.some(
+                (item) =>
+                  item.instructor.toLocaleLowerCase().includes(normalized) ||
+                  item.children.some((child) =>
+                    child.toLocaleLowerCase().includes(normalized),
+                  ),
+              ),
+            ),
+        )
+      : customers;
+    setExpandedIds(
+      new Set(nextFiltered.slice(0, nextPageSize).map(({ id }) => id)),
+    );
+  };
+
+  const changePage = (nextPage: number) => {
+    setPageState(nextPage);
+    setExpandedIds(
+      new Set(
+        filtered
+          .slice(nextPage * pageSize, (nextPage + 1) * pageSize)
+          .map(({ id }) => id),
+      ),
+    );
+  };
+
+  return (
+    <main className={styles.container}>
+      <h1>受講リスト</h1>
+      <p className={styles.description}>
+        お客さまごとの契約プランと、現在有効な定期クラスの割当状況を表示します。
+      </p>
+      <div className={styles.controls}>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            resetToFirstPage(pageSize, event.target.value);
+          }}
+          placeholder="お客さま・お子さま・講師を検索"
+          aria-label="受講状況を検索"
+        />
+        <div className={styles.controlButtons}>
+          <button
+            type="button"
+            onClick={() => setExpandedIds(new Set(visible.map(({ id }) => id)))}
+          >
+            すべて開く
+          </button>
+          <button type="button" onClick={() => setExpandedIds(new Set())}>
+            すべて閉じる
+          </button>
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <p className={styles.empty}>該当するお客さまが見つかりません</p>
+      ) : (
+        <div className={styles.tableScroll}>
+          <table className={styles.enrollmentTable}>
+            <thead>
+              <tr>
+                <th>お客さま</th>
+                <th>プラン</th>
+                <th>お子さま</th>
+                <th>講師</th>
+                <th>曜日</th>
+                <th>時間</th>
+                <th>期間</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((customer) => {
+                const expanded = expandedIds.has(customer.id);
+                const subscriptions = customer.subscriptions.filter(
+                  ({ recurringClasses }) => recurringClasses.length,
+                );
+                return (
+                  <Fragment key={customer.id}>
+                    <tr className={styles.customerRow}>
+                      <td colSpan={7}>
+                        <button
+                          type="button"
+                          aria-label={`${customer.name}の詳細を${expanded ? "閉じる" : "開く"}`}
+                          aria-expanded={expanded}
+                          onClick={() =>
+                            setExpandedIds((current) => {
+                              const next = new Set(current);
+                              expanded
+                                ? next.delete(customer.id)
+                                : next.add(customer.id);
+                              return next;
+                            })
+                          }
+                        >
+                          {expanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                        </button>
+                        <Link href={`/admins/customer-list/${customer.id}`}>
+                          {customer.name}
+                        </Link>
+                      </td>
+                    </tr>
+                    {expanded && subscriptions.length === 0 && (
+                      <tr className={styles.noClassesRow}>
+                        <td></td>
+                        <td colSpan={6}>現在受講中のクラスはありません</td>
+                      </tr>
+                    )}
+                    {expanded &&
+                      subscriptions.map((subscription) =>
+                        subscription.recurringClasses.map((item, index) => (
+                          <tr className={styles.classRow} key={item.id}>
+                            <td></td>
+                            {index === 0 && (
+                              <td
+                                className={styles.planCell}
+                                rowSpan={subscription.recurringClasses.length}
+                              >
+                                {japanesePlanName(subscription.planName)}
+                              </td>
+                            )}
+                            <td>{item.children.join(", ") || "—"}</td>
+                            <td>{item.instructor}</td>
+                            <td>{item.weekday}</td>
+                            <td>{item.time}</td>
+                            <td>
+                              {item.startDate}〜{item.endDate}
+                            </td>
+                          </tr>
+                        )),
+                      )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {filtered.length > 0 && (
+        <nav className={styles.pagination} aria-label="ページネーション">
+          {Array.from({ length: pageCount }, (_, index) => (
+            <button
+              type="button"
+              key={index}
+              className={page === index ? styles.activePage : undefined}
+              onClick={() => changePage(index)}
+              aria-current={page === index ? "page" : undefined}
+            >
+              {index + 1}
+            </button>
+          ))}
+          <label>
+            表示件数
+            <select
+              value={pageSize}
+              onChange={(event) => {
+                const size = Number(event.target.value);
+                setPageSizeState(size);
+                resetToFirstPage(size);
+              }}
+            >
+              {PAGE_SIZES.map((size) => (
+                <option key={size} value={size}>
+                  {size}件
+                </option>
+              ))}
+            </select>
+          </label>
+        </nav>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/lib/api/adminsApi.ts
+++ b/frontend/src/lib/api/adminsApi.ts
@@ -17,6 +17,7 @@ import {
   type InstructorsListResponse,
   type PastInstructorsListResponse,
   type CustomersListResponse,
+  type EnrollmentStatusResponse,
   type PastCustomersListResponse,
   type ChildrenListResponse,
   type PlansListResponse,
@@ -270,6 +271,32 @@ export const getAllCustomers = async (
     console.error("Failed to fetch customers:", error);
     throw error;
   }
+};
+
+export const getEnrollmentStatus = async (
+  cookie?: string,
+): Promise<EnrollmentStatusResponse["data"]> => {
+  const method = "GET";
+  const response = cookie
+    ? await fetch(`${BASE_URL}/enrollment-status`, {
+        method,
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        cache: "no-store",
+      })
+    : await fetch(`${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "backend-endpoint": "/admins/enrollment-status",
+          "no-cache": "no-cache",
+        },
+      });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const result: EnrollmentStatusResponse = await response.json();
+  return result.data;
 };
 
 // GET all past customers data

--- a/frontend/src/lib/data/navLinks.ts
+++ b/frontend/src/lib/data/navLinks.ts
@@ -77,6 +77,11 @@ export function getLinks(
       icon: UsersIcon,
     },
     {
+      name: "受講リスト",
+      href: "/admins/enrollment-status",
+      icon: ClipboardDocumentCheckIcon,
+    },
+    {
       name: "インストラクター\nリスト",
       href: "/admins/instructor-list",
       icon: UsersIcon,

--- a/shared/schemas/admins.ts
+++ b/shared/schemas/admins.ts
@@ -355,6 +355,35 @@ export const CustomersListResponse = z.object({
   data: z.array(CustomerListItem),
 });
 
+export const EnrollmentStatusRecurringClass = z.object({
+  id: z.number().int().positive(),
+  children: z.array(z.string()),
+  instructor: z.string(),
+  weekday: z.string(),
+  time: z.string(),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.union([
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    z.literal("継続中"),
+  ]),
+});
+
+export const EnrollmentStatusSubscription = z.object({
+  id: z.number().int().positive(),
+  planName: z.string(),
+  recurringClasses: z.array(EnrollmentStatusRecurringClass),
+});
+
+export const EnrollmentStatusCustomer = z.object({
+  id: z.number().int().positive(),
+  name: z.string(),
+  subscriptions: z.array(EnrollmentStatusSubscription),
+});
+
+export const EnrollmentStatusResponse = z.object({
+  data: z.array(EnrollmentStatusCustomer),
+});
+
 // Past customer list item for table display
 export const PastCustomerListItem = z.object({
   No: z.number(),
@@ -673,6 +702,14 @@ export type PastInstructorsListResponse = z.infer<
   typeof PastInstructorsListResponse
 >;
 export type CustomersListResponse = z.infer<typeof CustomersListResponse>;
+export type EnrollmentStatusRecurringClass = z.infer<
+  typeof EnrollmentStatusRecurringClass
+>;
+export type EnrollmentStatusSubscription = z.infer<
+  typeof EnrollmentStatusSubscription
+>;
+export type EnrollmentStatusCustomer = z.infer<typeof EnrollmentStatusCustomer>;
+export type EnrollmentStatusResponse = z.infer<typeof EnrollmentStatusResponse>;
 export type PastCustomersListResponse = z.infer<
   typeof PastCustomersListResponse
 >;


### PR DESCRIPTION
## Summary

- add an admin-only enrollment list at `/admins/enrollment-status`
- group active subscriptions and recurring classes by customer
- show a compact, expandable table with customer, plan, child, instructor, weekday, time, and enrollment period
- add customer/child/instructor search and customer-based pagination
- add the new `受講リスト` entry directly below the customer list in admin navigation

## Details

The backend determines active subscriptions and recurring classes using the current JST date. Recurring class `endAt` remains an exclusive boundary, so the displayed and evaluated end date is adjusted by one day. The response also provides stable ordering and Japanese-formatted display values for weekdays, times, dates, ongoing enrollment, and unassigned records.

The frontend keeps customer groups expandable while presenting their plans and classes in a dense, horizontally scrollable table. Plan names are displayed using their Japanese portion to keep the list compact.

## Validation

- shared format check
- frontend format check
- frontend lint
- frontend unused-code check
- frontend production build
- backend format check
- backend unused-code check
- backend API suite: 31 files, 270 tests passed
- `git diff --check`
