### PR TITLE
Fix normalized import ID mapping

### DIFF
--- a/backend/src/services/adminImport/execute.ts
+++ b/backend/src/services/adminImport/execute.ts
@@ -1713,6 +1713,21 @@ function parseTimeAsDate(value: string): Date {
   return new Date(`1970-01-01T${value}:00.000Z`);
 }
 
+export function getCreatedIdsInInputOrder(
+  createdRows: ReadonlyArray<{ id: number }>,
+  expectedCount: number,
+): number[] {
+  if (createdRows.length !== expectedCount) {
+    throw new Error(
+      `Bulk insert returned ${createdRows.length} rows; expected ${expectedCount}`,
+    );
+  }
+
+  // PostgreSQL allocates these sequence-backed IDs in VALUES input order, but
+  // Prisma does not guarantee the order of rows returned by createManyAndReturn.
+  return createdRows.map(({ id }) => id).sort((a, b) => a - b);
+}
+
 async function resetImportTargetData(tx: TxClient) {
   await tx.$executeRawUnsafe(IMPORT_RESET_TRUNCATE_SQL);
 }
@@ -1731,8 +1746,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const planIds = getCreatedIdsInInputOrder(
+    createdPlans,
+    parsed["plans.csv"].length,
+  );
   parsed["plans.csv"].forEach((row, index) => {
-    planIdByRef.set(row.data.plan_ref, createdPlans[index].id);
+    planIdByRef.set(row.data.plan_ref, planIds[index]);
   });
 
   const customerIdByRef = new Map<string, number>();
@@ -1753,8 +1772,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const customerIds = getCreatedIdsInInputOrder(
+    createdCustomers,
+    parsed["customers.csv"].length,
+  );
   parsed["customers.csv"].forEach((row, index) => {
-    customerIdByRef.set(row.data.customer_ref, createdCustomers[index].id);
+    customerIdByRef.set(row.data.customer_ref, customerIds[index]);
   });
 
   const childIdByRef = new Map<string, number>();
@@ -1769,8 +1792,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const childIds = getCreatedIdsInInputOrder(
+    createdChildren,
+    parsed["children.csv"].length,
+  );
   parsed["children.csv"].forEach((row, index) => {
-    childIdByRef.set(row.data.child_ref, createdChildren[index].id);
+    childIdByRef.set(row.data.child_ref, childIds[index]);
   });
 
   const subscriptionIdByRef = new Map<string, number>();
@@ -1786,11 +1813,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const subscriptionIds = getCreatedIdsInInputOrder(
+    createdSubscriptions,
+    parsed["subscriptions.csv"].length,
+  );
   parsed["subscriptions.csv"].forEach((row, index) => {
-    subscriptionIdByRef.set(
-      row.data.subscription_ref,
-      createdSubscriptions[index].id,
-    );
+    subscriptionIdByRef.set(row.data.subscription_ref, subscriptionIds[index]);
   });
 
   const instructorIdByRef = new Map<string, number>();
@@ -1823,11 +1851,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const instructorIds = getCreatedIdsInInputOrder(
+    createdInstructors,
+    parsed["instructors.csv"].length,
+  );
   parsed["instructors.csv"].forEach((row, index) => {
-    instructorIdByRef.set(
-      row.data.instructor_ref,
-      createdInstructors[index].id,
-    );
+    instructorIdByRef.set(row.data.instructor_ref, instructorIds[index]);
   });
 
   if (parsed["instructor_fees.csv"].length > 0) {
@@ -1891,10 +1920,14 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const scheduleIds = getCreatedIdsInInputOrder(
+    createdSchedules,
+    scheduleRows.length,
+  );
 
   const slotRows = scheduleRows.flatMap((group, index) =>
     group.slots.map((slot) => ({
-      scheduleId: createdSchedules[index].id,
+      scheduleId: scheduleIds[index],
       weekday: slot.weekday,
       startTime: slot.startTime,
     })),
@@ -1924,8 +1957,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const eventIds = getCreatedIdsInInputOrder(
+    createdEvents,
+    parsed["events.csv"].length,
+  );
   parsed["events.csv"].forEach((row, index) => {
-    eventIdByRef.set(row.data.event_ref, createdEvents[index].id);
+    eventIdByRef.set(row.data.event_ref, eventIds[index]);
   });
 
   if (parsed["schedules.csv"].length > 0) {
@@ -1959,10 +1996,14 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const recurringClassIds = getCreatedIdsInInputOrder(
+    createdRecurringClasses,
+    parsed["recurring_classes.csv"].length,
+  );
   parsed["recurring_classes.csv"].forEach((row, index) => {
     recurringClassIdByRef.set(
       row.data.recurring_class_ref,
-      createdRecurringClasses[index].id,
+      recurringClassIds[index],
     );
   });
 
@@ -2002,8 +2043,12 @@ async function insertValidatedRows(tx: TxClient, parsed: ParsedNormalizedRows) {
       id: true,
     },
   });
+  const classIds = getCreatedIdsInInputOrder(
+    createdClasses,
+    parsed["classes.csv"].length,
+  );
   parsed["classes.csv"].forEach((row, index) => {
-    classIdByRef.set(row.data.class_ref, createdClasses[index].id);
+    classIdByRef.set(row.data.class_ref, classIds[index]);
   });
 
   if (parsed["class_attendance.csv"].length > 0) {

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -6,6 +6,7 @@ import { server } from "../../../server";
 import { generateNormalizedImportFixture } from "../../../seed/generateNormalizedImportFixture";
 import { validateNormalizedImportFiles } from "../../../services/adminImport";
 import {
+  getCreatedIdsInInputOrder,
   IMPORT_PRESERVED_TABLES,
   IMPORT_RESET_TABLES,
 } from "../../../services/adminImport/execute";
@@ -20,6 +21,20 @@ import { prisma } from "../../setup";
 const RAW_HEADER =
   ",英語村,,2020.10.,name,child name,plan,講師名,date,time,class,お子さま誕生日,兄弟お子さま誕生日,年齢,詳細,備考※月2回の場合は週を記入,favorite,,,";
 const IMPORT_FILE_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
+
+describe("normalized import bulk insert ID mapping", () => {
+  it("restores input order when createManyAndReturn returns rows out of order", () => {
+    expect(
+      getCreatedIdsInInputOrder([{ id: 103 }, { id: 101 }, { id: 102 }], 3),
+    ).toEqual([101, 102, 103]);
+  });
+
+  it("rejects an incomplete bulk insert result", () => {
+    expect(() => getCreatedIdsInInputOrder([{ id: 101 }], 2)).toThrow(
+      "Bulk insert returned 1 rows; expected 2",
+    );
+  });
+});
 
 function rawRow(columns: string[]) {
   return columns.join(",");
@@ -692,6 +707,29 @@ describe("POST /admins/import/execute", () => {
       generated.rows["recurring_class_attendance.csv"].length,
     );
     expect(classAttendance).toBe(generated.rows["class_attendance.csv"].length);
+
+    const [classRelationshipMismatches, attendanceRelationshipMismatches] =
+      await Promise.all([
+        prisma.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*) AS count
+          FROM "Class" c
+          JOIN "Subscription" s ON s.id = c."subscriptionId"
+          JOIN "RecurringClass" rc ON rc.id = c."recurringClassId"
+          WHERE c."customerId" <> s."customerId"
+             OR rc."subscriptionId" <> c."subscriptionId"
+             OR rc."instructorId" <> c."instructorId"
+        `,
+        prisma.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*) AS count
+          FROM "ClassAttendance" ca
+          JOIN "Class" c ON c.id = ca."classId"
+          JOIN "Child" child ON child.id = ca."childrenId"
+          WHERE c."customerId" <> child."customerId"
+        `,
+      ]);
+
+    expect(classRelationshipMismatches[0].count).toBe(0n);
+    expect(attendanceRelationshipMismatches[0].count).toBe(0n);
   }, 120_000);
 
   it("scales the deterministic fixture from the instructor count option", async () => {


### PR DESCRIPTION
## What changed

- normalize `createManyAndReturn` IDs into insertion order before mapping normalized import references
- apply the deterministic mapping to plans, customers, children, subscriptions, instructors, schedules, events, recurring classes, and classes
- fail explicitly if a bulk insert returns an unexpected number of rows
- add regression coverage for out-of-order bulk results and cross-entity relationship integrity

## Why

Prisma does not guarantee the result order of `createManyAndReturn`. The import previously paired returned IDs with CSV rows by array index, so larger imports could attach subscriptions, recurring classes, instructors, children, and classes to the wrong records. Customer dashboards then showed missing classes, blank attendees, and `Unknown Instructor`.

## Impact

Clean normalized imports now preserve the intended CSV relationships. Existing environments with corrupted imported relationships need to run the clean import again after deployment.

## Validation

- focused normalized-import suite: 19/19 passed
- shared format check: passed
- frontend format, lint, unused-code check, and production build: passed
- backend format and unused-code check: passed
- full backend suite: 271/272 passed; the unrelated enrollment-status test is date-expired as of 2026-08-07 (fixture ends 2026-08-05)
