### PR TITLE
Fix absence editor slot loading

### DIFF
--- a/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AdminInstructorCalendar.tsx
+++ b/frontend/src/components/admins-dashboard/instructors-dashboard/instructor-schedule/AdminInstructorCalendar.tsx
@@ -8,8 +8,8 @@ import MessageBoardPanel from "@/components/features/messageBoardPanel/MessageBo
 import Modal from "@/components/elements/modal/Modal";
 import ActionButton from "@/components/elements/buttons/actionButton/ActionButton";
 import {
+  getAdminInstructorAvailableSlots,
   getInstructorAbsences,
-  getInstructorAvailableSlots,
 } from "@/lib/api/instructorsApi";
 import {
   batchUpdateInstructorAbsences,
@@ -83,7 +83,12 @@ export default function AdminInstructorCalendar({
 
       try {
         const [slotsResponse, absencesResponse] = await Promise.all([
-          getInstructorAvailableSlots(instructorId, startStr, endStr, false),
+          getAdminInstructorAvailableSlots(
+            instructorId,
+            startStr,
+            endStr,
+            false,
+          ),
           getInstructorAbsences(instructorId),
         ]);
 

--- a/frontend/src/lib/api/instructorsApi.ts
+++ b/frontend/src/lib/api/instructorsApi.ts
@@ -941,6 +941,40 @@ export const getInstructorAvailableSlots = async (
   }
 };
 
+export const getAdminInstructorAvailableSlots = async (
+  instructorId: number,
+  startDate: string,
+  endDate: string,
+  excludeBookedSlots: boolean,
+) => {
+  const params = new URLSearchParams({
+    start: startDate,
+    end: endDate,
+    timezone: "Asia/Tokyo",
+    excludeBookedSlots: excludeBookedSlots.toString(),
+  } as AvailableSlotsQuery & { excludeBookedSlots: string });
+  const backendEndpoint = `/instructors/${instructorId}/available-slots?${params}`;
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/api/proxy`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "backend-endpoint": backendEndpoint,
+        "no-cache": "no-cache",
+      },
+    },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const result = (await response.json()) as { data: AvailableSlot[] };
+
+  return { data: result.data };
+};
+
 export const getInstructorCalendarSlots = async (
   instructorId: number,
   startDate: string,


### PR DESCRIPTION
## Summary

- add an admin-specific instructor availability request through the authenticated frontend proxy
- use that request when loading slots in the Edit Absences modal
- keep the direct backend request used by customer booking flows unchanged

## Root cause

The shared instructor availability helper was changed to call the backend directly from the browser. The admin absence editor continued using that helper, so its request did not reliably carry the admin authentication available through the frontend proxy. The editor caught the request failure and returned an empty event list, making all slots disappear.

## Impact

Admin users can see available instructor slots again when opening Edit Absences and can select them to register absences.

## Validation

- shared and frontend Prettier checks
- frontend ESLint and unused-code checks
- frontend production build
- backend Prettier and unused-code checks
- backend test suite: 31 files, 272 tests passed
