### PR TITLE
Set rebooking deadlines in import fixtures

### DIFF
--- a/backend/src/seed/generateNormalizedImportFixture.ts
+++ b/backend/src/seed/generateNormalizedImportFixture.ts
@@ -745,6 +745,10 @@ function classRowsAndAttendance(
       const classRef = ref("CL", classSeq);
       const dateOnly = formatDateOnly(cursor);
       const status = cursor <= completedDate ? "completed" : "booked";
+      const rebookableUntil =
+        status === "booked"
+          ? formatDateTime(formatDateOnly(addDays(cursor, 180)), item.startTime)
+          : "";
       classes.push({
         class_ref: classRef,
         customer_ref: item.customerRef,
@@ -753,7 +757,7 @@ function classRowsAndAttendance(
         subscription_ref: item.subscriptionRef,
         date_time: formatDateTime(dateOnly, item.startTime),
         status,
-        rebookable_until: "",
+        rebookable_until: rebookableUntil,
         class_code: `c${classSeq}`,
         is_free_trial: "false",
       });

--- a/backend/src/test/api/admins/import-normalize.test.ts
+++ b/backend/src/test/api/admins/import-normalize.test.ts
@@ -17,6 +17,10 @@ import {
   generateAuthCookie,
 } from "../../testUtils";
 import { prisma } from "../../setup";
+import {
+  cancelClassById,
+  getRebookableClasses,
+} from "../../../services/classesService";
 
 const RAW_HEADER =
   ",英語村,,2020.10.,name,child name,plan,講師名,date,time,class,お子さま誕生日,兄弟お子さま誕生日,年齢,詳細,備考※月2回の場合は週を記入,favorite,,,";
@@ -640,9 +644,9 @@ describe("POST /admins/import/execute", () => {
     const admin = await createAdmin();
     const authCookie = await generateAuthCookie(admin.id, "admin");
     const generated = await generateNormalizedImportFixture({
-      from: "2026-01-01",
-      completedUntil: "2026-01-03",
-      to: "2026-01-07",
+      from: "2099-01-01",
+      completedUntil: "2099-01-03",
+      to: "2099-01-07",
     });
 
     const validation = validateNormalizedImportFiles(generated.files);
@@ -707,6 +711,33 @@ describe("POST /admins/import/execute", () => {
       generated.rows["recurring_class_attendance.csv"].length,
     );
     expect(classAttendance).toBe(generated.rows["class_attendance.csv"].length);
+
+    const [completedClasses, bookedClasses] = await Promise.all([
+      prisma.class.findMany({ where: { status: "completed" } }),
+      prisma.class.findMany({ where: { status: "booked" } }),
+    ]);
+    expect(
+      completedClasses.every(({ rebookableUntil }) => !rebookableUntil),
+    ).toBe(true);
+    expect(bookedClasses.length).toBeGreaterThan(0);
+    expect(
+      bookedClasses.every(
+        ({ dateTime, rebookableUntil }) =>
+          dateTime &&
+          rebookableUntil &&
+          rebookableUntil.getTime() - dateTime.getTime() ===
+            180 * 24 * 60 * 60 * 1000,
+      ),
+    ).toBe(true);
+
+    const classToCancel = bookedClasses[0];
+    await cancelClassById(classToCancel.id);
+    const rebookableClasses = await getRebookableClasses(
+      classToCancel.customerId,
+    );
+    expect(rebookableClasses).toContainEqual(
+      expect.objectContaining({ id: classToCancel.id }),
+    );
 
     const [classRelationshipMismatches, attendanceRelationshipMismatches] =
       await Promise.all([

--- a/docs/testing/data-import/normalized-fixture-generator-spec.md
+++ b/docs/testing/data-import/normalized-fixture-generator-spec.md
@@ -160,7 +160,9 @@ Field rules:
 - `status`:
   - `completed` when `class.date <= completed-until`
   - `booked` when `class.date > completed-until`
-- `rebookable_until`: empty
+- `rebookable_until`:
+  - `class.date_time + 180 days` when `status = booked`
+  - empty when `status = completed`
 - `is_free_trial`: `false`
 - `class_code`: short deterministic unique string (stable for same inputs)
 


### PR DESCRIPTION
## Summary

- populate `rebookable_until` for booked classes generated by the deterministic normalized import fixture
- keep completed-class deadlines empty
- document the fixture rule

## Root cause

The fixture generator emitted an empty `rebookable_until` for every class. The import correctly persisted that value as `NULL`, so canceling an imported booked class could not make it available for rebooking.

## Impact

Imported booked classes now receive a rebooking deadline 180 days after their class time, matching classes created through the normal application flow.

## Validation

- imported the generated normalized ZIP through the import API
- verified completed classes retain a null deadline
- verified booked classes persist a deadline exactly 180 days after `dateTime`
- canceled an imported booked class and verified it appears in `getRebookableClasses`
- full local CI-equivalent pipeline passed (shared, frontend, and backend; 272 backend API tests passed)